### PR TITLE
Update the Quick Start Guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -16,15 +16,14 @@ cd von-network
 ./manage start --logs
 ```
 
-### Determine the Ledger Browser IP to use in the URL for the Aca-py Agent in the next section
+### Determine the DockerHost IP address to use for the Aca-py Agent in the next section
 in another shell...
-Make sure there is a von_von network
+Find and record the DockerHost. For example in this guide it is 192.168.65.3
 ```
-docker network ls
-```
-Find the Gateway IP and record it. For example in this guide it is 172.18.0.1
-```
-docker network inspect von_von | grep Gateway
+cd von-network
+./manage dockerhost
+
+DockerHost: 192.168.65.3
 ```
 
 ## Run an ACA-PY Agent and Backchannel (one container per agent)
@@ -33,20 +32,20 @@ In another shell...
 git clone https://github.com/bcgov/aries-agent-test-harness.git
 cd aries-agent-test-harness/aries-backchannels
 docker build -t acapy-agent-backchannel .
-docker run -it --name alice_agent --expose 8020-8023 -p 8020-8023:8020-8023 -e “LEDGER_URL=http://172.18.0.1:9000” acapy-agent-backchannel -p 8020
+docker run -it --rm --name alice_agent --expose 8020-8023 -p 8020-8023:8020-8023 -e "DOCKERHOST=192.168.65.3" -e “LEDGER_URL=http://192.168.65.3:9000” acapy-agent-backchannel -p 8020
 ```
 To run another ACA-PY Agent in another container, open another shell...
 ```
-docker run -it --name bob_agent --expose 8030-8033 -p 8030-8033:8030-8033 -e “LEDGER_URL=http://172.18.0.1:9000” acapy-agent-backchannel -p 8030
+docker run -it --rm --name bob_agent --expose 8030-8033 -p 8030-8033:8030-8033 -e "DOCKERHOST=192.168.65.3" -e “LEDGER_URL=http://192.168.65.3:9000” acapy-agent-backchannel -p 8030
 ```
 Run another ACA-PY Agent in another container, open another shell...
 ```
-docker run -it --name mallory_agent --expose 8040-8043 -p 8040-8043:8040-8043 -e “LEDGER_URL=http://172.18.0.1:9000” acapy-agent-backchannel -p 8040
+docker run -it --rm --name mallory_agent --expose 8040-8043 -p 8040-8043:8040-8043 -e "DOCKERHOST=192.168.65.3" -e “LEDGER_URL=http://192.168.65.3:9000” acapy-agent-backchannel -p 8040
 ```
 
 More agents can be started by making sure the posts are exposed and assigned to the agent properly in the command. The next Agent in this sequence should get a port of 8050, the Agent Startup routine will have the agent listening for the backshannel on port 8050, listening to web_hooks on 8023, and have the agent admin on port 8052. The startup command would look like this:
 ```
-docker run -it --name frank_agent --expose 8050-8053 -p 8050-8053:8050-8053 -e “LEDGER_URL=http://172.18.0.1:9000” acapy-agent-backchannel -p 8050
+docker run -it --rm --name frank_agent --expose 8050-8053 -p 8050-8053:8050-8053 -e "DOCKERHOST=192.168.65.3" -e “LEDGER_URL=http://192.168.65.3:9000” acapy-agent-backchannel -p 8050
 ```
 
 ## Run the Aries Agent Tests
@@ -62,19 +61,19 @@ Read Test Tags Below for in use and proposed test sceanrio tags
 
 Using tags, one can just run Acceptance Tests...
 ```
-docker run -it --network="host" aries-agent-tests -k --tags=AcceptanceTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
+docker run -it --rm --network="host" aries-agent-tests -k --tags=AcceptanceTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
 ```
 or all Priority 1 Acceptance Tests...
 ```
-docker run -it --network="host" aries-agent-tests -k --tags=@P1 --tags=@AcceptanceTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
+docker run -it --rm --network="host" aries-agent-tests -k --tags=@P1 --tags=@AcceptanceTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
 ```
 Or derived functional tests
 ```
-docker run -it --network="host" aries-agent-tests -k --tags=DerivedFunctionalTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
+docker run -it --rm --network="host" aries-agent-tests -k --tags=DerivedFunctionalTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
 ```
 Or all the ExceptionTests...
 ```
-docker run -it --network="host" aries-agent-tests -k --tags=ExceptionTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
+docker run -it --rm --network="host" aries-agent-tests -k --tags=ExceptionTest -D Alice=http://0.0.0.0:8020 -D Bob=http://0.0.0.0:8030 -D Mallory=http://0.0.0.0:8040
 ```
 
 To read more on how one can control the execution of test sets based on tags see https://behave.readthedocs.io/en/latest/tutorial.html#controlling-things-with-tags


### PR DESCRIPTION
- Document how to use `von-network`s `manage` script to determine the DockerHost IP address.
- Add `--rm` to the containers so they are automatically removed when shutdown.
- Add the `DOCKERHOST` environment variable so the agents register their endpoints with it.
  - Agents were registering their endpoints using `host.docker.internal`, which does not work on Linux implementations of Docker, it's only available in Windows and Mac implementations.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>