### PR TITLE
Convert url mapping to include the topic + operation in the url …

### DIFF
--- a/aries-test-harness/agent_backchannel_client.py
+++ b/aries-test-harness/agent_backchannel_client.py
@@ -54,7 +54,7 @@ async def make_agent_backchannel_request(
         return (resp_status, resp_text)
 
 
-def agent_backchannel_GET(url, topic, operation=None, id=None, data=None) -> (int, str):
+def agent_backchannel_GET(url, topic, id=None, data=None) -> (int, str):
     agent_url = url + topic + "/"
     if id:
         agent_url = agent_url + id
@@ -68,7 +68,7 @@ def agent_backchannel_POST(url, topic, operation=None, id=None, data=None) -> (i
     if data:
         payload["data"] = data
     if operation:
-        payload["operation"] = operation
+        agent_url = agent_url + operation + "/"
     if id:
         if topic == 'credential':
             payload["cred_ex_id"] = id


### PR DESCRIPTION
... rather than payload, for aca-py backend.  (Should also work for VCX and Pico but not tested.)

Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Also added support for url with & without the trailing slash for all url mappings

Note - kept the csv file (for now) that defines the allowable topic/operation combinations.  We can revisit this when we build in the swagger functionality.

