### PR TITLE
 dotnet: get operation from url instead of payload

### DIFF
--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using DotNet.Backchannel.Models;
+using Newtonsoft.Json.Linq;
 
 using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Features.TrustPing;
@@ -95,7 +96,7 @@ namespace DotNet.Backchannel.Controllers
             return Ok(new { connection_id = connection.Id, invitation });
         }
 
-        private async Task<IActionResult> ReceiveInvitationAsync(object invitation)
+        private async Task<IActionResult> ReceiveInvitationAsync(JObject invitationObject)
         {
             throw new NotImplementedException();
         }
@@ -109,14 +110,14 @@ namespace DotNet.Backchannel.Controllers
         {
             throw new NotImplementedException();
         }
-        private async Task<IActionResult> SendPingAsync(string connectionId, dynamic data)
+        private async Task<IActionResult> SendPingAsync(string connectionId, JObject data)
         {
             var context = await _agentContextProvider.GetContextAsync();
             var connection = await _connectionService.GetAsync(context, connectionId);
             var message = new TrustPingMessage
             {
                 ResponseRequested = true,
-                Comment = data.comment
+                Comment = (string)data["comment"]
             };
 
             await _messageService.SendAsync(context.Wallet, message, connection);

--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -67,27 +67,8 @@ namespace DotNet.Backchannel.Controllers
             });
         }
 
-        [HttpPost]
-        public async Task<IActionResult> ConnectionOperationAsync(OperationBody body)
-        {
-            switch (body.Operation)
-            {
-                case "create-invitation":
-                    return await this.CreateInvitationAsync();
-                case "receive-invitation":
-                    return await this.ReceiveInvitationAsync(body.Data);
-                case "accept-invitation":
-                    return await this.AcceptInvitationAsync(body.Id);
-                case "accept-request":
-                    return await this.AcceptRequestAsync(body.Id);
-                case "send-ping":
-                    return await this.SendPingAsync(body.Id, body.Data);
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        private async Task<IActionResult> CreateInvitationAsync()
+        [HttpPost("create-invitation")]
+        public async Task<IActionResult> CreateInvitationAsync()
         {
             var context = await _agentContextProvider.GetContextAsync();
 
@@ -96,22 +77,33 @@ namespace DotNet.Backchannel.Controllers
             return Ok(new { connection_id = connection.Id, invitation });
         }
 
-        private async Task<IActionResult> ReceiveInvitationAsync(JObject invitationObject)
+        [HttpPost("receive-invitation")]
+        public async Task<IActionResult> ReceiveInvitationAsync(OperationBody body)
         {
+            var invitationBody = body.Data;
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> AcceptInvitationAsync(string connectionId)
+        [HttpPost("accept-invitation")]
+        public async Task<IActionResult> AcceptInvitationAsync(OperationBody body)
         {
+            var connectionId = body.Id;
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> AcceptRequestAsync(string connectionId)
+        [HttpPost("accept-request")]
+        public async Task<IActionResult> AcceptRequestAsync(OperationBody body)
         {
+            var connectionId = body.Id;
             throw new NotImplementedException();
         }
-        private async Task<IActionResult> SendPingAsync(string connectionId, JObject data)
+
+        [HttpPost("send-ping")]
+        public async Task<IActionResult> SendPingAsync(OperationBody body)
         {
+            var connectionId = body.Id;
+            var data = body.Data;
+
             var context = await _agentContextProvider.GetContextAsync();
             var connection = await _connectionService.GetAsync(context, connectionId);
             var message = new TrustPingMessage

--- a/aries-backchannels/dotnet/server/Controllers/CredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialController.cs
@@ -8,7 +8,7 @@ namespace DotNet.Backchannel.Controllers
     [ApiController]
     public class CredentialController : ControllerBase
     {
-        [HttpGet("{id}")]
+        [HttpGet("{credentialId}")]
         public async Task<IActionResult> GetCredentialById([FromRoute] string credentialId)
         {
             throw new NotImplementedException();

--- a/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
@@ -1,14 +1,13 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using DotNet.Backchannel.Models;
+using System.Net.Mime;
+using Newtonsoft.Json.Linq;
 
 using Hyperledger.Aries.Features.IssueCredential;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
-using System.Net.Mime;
 using Hyperledger.Indy;
-using System.Text.Json;
-using Newtonsoft.Json.Linq;
 
 namespace DotNet.Backchannel.Controllers
 {
@@ -50,18 +49,18 @@ namespace DotNet.Backchannel.Controllers
             return await this.CreateCredentialDefinitionAsync(body.Data);
         }
 
-        private async Task<IActionResult> CreateCredentialDefinitionAsync(JsonElement credentialDefinition)
+        private async Task<IActionResult> CreateCredentialDefinitionAsync(JObject credentialDefinition)
         {
             var context = await _agentContextProvider.GetContextAsync();
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
 
-            var schemaId = credentialDefinition.GetProperty("schema_id").GetString();
-            var tag = credentialDefinition.GetProperty("tag").GetString();
-            var supportRevocation = credentialDefinition.GetProperty("support_revocation").GetBoolean();
+            var schemaId = (string)credentialDefinition["schema_id"];
+            var tag = (string)credentialDefinition["tag"];
+            var supportRevocation = (bool)credentialDefinition["support_revocation"];
 
             // Needed to construct credential definition id
             var schema = JObject.Parse(await _schemaService.LookupSchemaAsync(context, schemaId));
-            var schemaSeqNo = schema["seqNo"].ToString();
+            var schemaSeqNo = (string)schema["seqNo"];
             var signatureType = "CL"; // TODO: can we make this variable?
 
             // The test client sends multiple create credential definition requests with

--- a/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
@@ -43,17 +43,13 @@ namespace DotNet.Backchannel.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> CredentialDefinitionOperationAsync(OperationBody body)
+        public async Task<IActionResult> CreateCredentialDefinitionAsync(OperationBody body)
         {
-            // Credential Defintion only has one operation
-            return await this.CreateCredentialDefinitionAsync(body.Data);
-        }
 
-        private async Task<IActionResult> CreateCredentialDefinitionAsync(JObject credentialDefinition)
-        {
             var context = await _agentContextProvider.GetContextAsync();
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
 
+            var credentialDefinition = body.Data;
             var schemaId = (string)credentialDefinition["schema_id"];
             var tag = (string)credentialDefinition["tag"];
             var supportRevocation = (bool)credentialDefinition["support_revocation"];

--- a/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
@@ -15,57 +15,57 @@ namespace DotNet.Backchannel.Controllers
             throw new NotImplementedException();
         }
 
-        [HttpPost]
-        public async Task<IActionResult> IssueCredentialOperationAsync(OperationBody body)
+        [HttpPost("send-proposal")]
+        public async Task<IActionResult> SendCredentialProposalAsync(OperationBody body)
         {
-            switch (body.Operation)
-            {
-                case "send-proposal":
-                    return await this.SendCredentialProposalAsync(body.Id, body.Data);
-                case "send":
-                    return await this.SendCredentialAsync(body.Id, body.Data);
-                case "send-offer":
-                    // TODO: ID can be both cred_exchange_id OR connection_id
-                    // Find out how this works exactly. Probably as different key
-                    return await this.SendCredentialOfferAsync(body.Id, body.Data);
-                case "send-request":
-                    return await this.SendCredentialRequestAsync(body.Id);
-                case "issue":
-                    return await this.IssueCredentialAsync(body.Id, body.Data);
-                case "store":
-                    return await this.StoreCredentialAsync(body.Id, body.Data);
-                default:
-                    throw new NotSupportedException();
-            }
-        }
+            var connectionId = body.Id;
+            var proposal = body.Data;
 
-        private async Task<IActionResult> SendCredentialProposalAsync(string connectionId, dynamic proposal)
-        {
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendCredentialAsync(string connectionId, dynamic credentialOffer)
+        [HttpPost("send")]
+        public async Task<IActionResult> SendCredentialAsync(OperationBody body)
         {
+            var connectionId = body.Id;
+            var credentialOffer = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendCredentialOfferAsync(string connectionId, dynamic credentialOffer)
+        [HttpPost("send-offer")]
+        public async Task<IActionResult> SendCredentialOfferAsync(OperationBody body)
         {
+            // TODO: ID can be both cred_exchange_id OR connection_id
+            // Find out how this works exactly. Probably as different key
+            var connectionId = body.Id;
+            var credentialOffer = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendCredentialRequestAsync(string credentialRecordId)
+        [HttpPost("send-request")]
+        public async Task<IActionResult> SendCredentialRequestAsync(OperationBody body)
         {
+            var credentialRecordId = body.Id;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> IssueCredentialAsync(string credentialRecordId, dynamic credentialOffer = null)
+        [HttpPost("issue")]
+        public async Task<IActionResult> IssueCredentialAsync(OperationBody body)
         {
+            var credentialRecordId = body.Id;
+            var credentialPreview = body.Data; // Can be undefined!
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> StoreCredentialAsync(string credentialRecordId, dynamic credentialOffer = null)
+        [HttpPost("store")]
+        public async Task<IActionResult> StoreCredentialAsync(OperationBody body)
         {
+            var credentialRecordId = body.Id;
+
             throw new NotImplementedException();
         }
     }

--- a/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
@@ -15,43 +15,40 @@ namespace DotNet.Backchannel.Controllers
             throw new NotImplementedException();
         }
 
-        [HttpPost]
-        public async Task<IActionResult> PresentProofOperationAsync(OperationBody body)
+        [HttpPost("send-proposal")]
+        public async Task<IActionResult> SendPresentationProposalAsync(OperationBody body)
         {
-            switch (body.Operation)
-            {
-                case "send-proposal":
-                    return await this.SendPresentationProposalAsync(body.Id, body.Data);
-                case "send-request":
-                    // TODO: ID can be both pres_exchange_id OR connection_id
-                    // Find out how this works exactly. Probably as different key
-                    return await this.SendPresentationRequestAsync(body.Id, body.Data);
-                case "send-presentation":
-                    return await this.SendProofPresentationOfferAsync(body.Id, body.Data);
-                case "verify-presentation":
-                    return await this.VerifyPresentation(body.Id);
-                default:
-                    throw new NotSupportedException();
-            }
-        }
+            var connectionId = body.Id;
+            var proposal = body.Data;
 
-        private async Task<IActionResult> SendPresentationProposalAsync(string connectionId, dynamic proposal)
-        {
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendPresentationRequestAsync(string proofRecordId, dynamic proofRequest)
+        [HttpPost("send-request")]
+        public async Task<IActionResult> SendPresentationRequestAsync(OperationBody body)
         {
+            // TODO: ID can be both pres_exchange_id OR connection_id
+            // Find out how this works exactly. Probably as different key
+            var proofRecordId = body.Id;
+            var proofRequest = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendProofPresentationOfferAsync(string proofRecordId, dynamic proofPresentation)
+        [HttpPost("send-presentation")]
+        public async Task<IActionResult> SendProofPresentationOfferAsync(OperationBody body)
         {
+            var proofRecordId = body.Id;
+            var proofPresentation = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> VerifyPresentation(string proofRecordId)
+        [HttpPost("verify-presentation")]
+        public async Task<IActionResult> VerifyPresentation(OperationBody body)
         {
+            var proofRecordId = body.Id;
+
             throw new NotImplementedException();
         }
     }

--- a/aries-backchannels/dotnet/server/Controllers/SchemaController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/SchemaController.cs
@@ -43,17 +43,12 @@ namespace DotNet.Backchannel.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> SchemaOperationAsync(OperationBody body)
-        {
-            // Schema only has one operation
-            return await this.CreateSchemaAsync(body.Data);
-        }
-
-        private async Task<IActionResult> CreateSchemaAsync(JObject schema)
+        public async Task<IActionResult> CreateSchemaAsync(OperationBody body)
         {
             var context = await _agentContextProvider.GetContextAsync();
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
 
+            var schema = body.Data;
             var schemaName = (string)schema["schema_name"];
             var schemaVersion = (string)schema["schema_version"];
             var schemaAttributes = schema["attributes"].ToObject<string[]>();

--- a/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
+++ b/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Hyperledger.Aries" Version="1.2.14" />
     <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.2.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/aries-backchannels/dotnet/server/Models/OperationBody.cs
+++ b/aries-backchannels/dotnet/server/Models/OperationBody.cs
@@ -1,6 +1,5 @@
-
-using System.Text.Json;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DotNet.Backchannel.Models
 {
@@ -13,6 +12,6 @@ namespace DotNet.Backchannel.Models
         public string Id { get; set; }
 
         [JsonProperty(PropertyName = "data")]
-        public JsonElement Data { get; set; }
+        public JObject Data { get; set; }
     }
 }

--- a/aries-backchannels/dotnet/server/Startup.cs
+++ b/aries-backchannels/dotnet/server/Startup.cs
@@ -21,7 +21,9 @@ namespace DotNet.Backchannel
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers();
+            services.AddControllers()
+            // Aries Framework .NET uses Newtonsoft JSON library
+            .AddNewtonsoftJson();
 
             services.AddLogging();
 


### PR DESCRIPTION
This PR updates the dotnet backchannel to retrieve the operation from the URL instead of the body.

It also switches the JSON library used to the same Aries Framework .NET uses to be more consistent.