### PR TITLE
dotnet: add connection topic operations

### DIFF
--- a/aries-backchannels/dotnet/Dockerfile.dotnet
+++ b/aries-backchannels/dotnet/Dockerfile.dotnet
@@ -3,9 +3,11 @@ FROM streetcred/dotnet-indy:1.15.0 AS build
 RUN mkdir -p /app/src
 WORKDIR /app/src
 
-COPY dotnet/server .
-
+# Only copy dependency file to benefit from Docker layer caching
+COPY dotnet/server/DotNet.Backchannel.csproj ./DotNet.Backchannel.csproj
 RUN dotnet restore "DotNet.Backchannel.csproj"
+
+COPY dotnet/server .
 RUN dotnet publish "DotNet.Backchannel.csproj" -c Release -o /app/build
 
 # Run

--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -1,12 +1,15 @@
-using System;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using DotNet.Backchannel.Models;
-using Newtonsoft.Json.Linq;
 
 using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Features.TrustPing;
 using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Models.Events;
+using Microsoft.Extensions.Caching.Memory;
+using Hyperledger.Aries.Contracts;
+using System.Reactive.Linq;
+using System;
 
 namespace DotNet.Backchannel.Controllers
 {
@@ -14,19 +17,24 @@ namespace DotNet.Backchannel.Controllers
     [ApiController]
     public class ConnectionController : ControllerBase
     {
+        private readonly IEventAggregator _eventAggregator;
         private readonly IConnectionService _connectionService;
         private readonly IAgentProvider _agentContextProvider;
         private readonly IMessageService _messageService;
+        private IMemoryCache _connectionCache;
 
         public ConnectionController(
+            IEventAggregator eventAggregator,
             IConnectionService connectionService,
             IAgentProvider agentContextProvider,
-            IMessageService messageService)
+            IMessageService messageService,
+            IMemoryCache memoryCache)
         {
+            _eventAggregator = eventAggregator;
             _connectionService = connectionService;
             _agentContextProvider = agentContextProvider;
             _messageService = messageService;
-
+            _connectionCache = memoryCache;
         }
 
         [HttpGet]
@@ -35,35 +43,34 @@ namespace DotNet.Backchannel.Controllers
             var context = await _agentContextProvider.GetContextAsync();
             var connections = await _connectionService.ListAsync(context);
 
+            // TODO: Should we also return the invitation connections from the cache?
             return Ok(connections.ConvertAll(connection =>
             {
-                // TODO: states do not match states from RFC
-                var state = connection.State == ConnectionState.Invited ? "invitation" : "TODO";
+
+                var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connection.Id);
+                if (testHarnessConnection != null) return MapConnection(testHarnessConnection);
 
                 return new
                 {
                     connection_id = connection.Id,
-                    state,
-                    connection = connection
+                    state = connection.State
                 };
-            }
-
-                ));
+            }));
         }
 
         [HttpGet("{connectionId}")]
         public async Task<IActionResult> GetConnectionByIdAsync([FromRoute] string connectionId)
         {
             var context = await _agentContextProvider.GetContextAsync();
-            var connection = await _connectionService.GetAsync(context, connectionId);
-            // TODO: states do not match states from RFC
-            var state = connection.State == ConnectionState.Invited ? "invitation" : "TODO";
 
+            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (testHarnessConnection != null) return Ok(MapConnection(testHarnessConnection));
+
+            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
             return Ok(new
             {
                 connection_id = connection.Id,
-                state,
-                connection
+                state = connection.State
             });
         }
 
@@ -72,30 +79,100 @@ namespace DotNet.Backchannel.Controllers
         {
             var context = await _agentContextProvider.GetContextAsync();
 
-            var (invitation, connection) = await _connectionService.CreateInvitationAsync(context, new InviteConfiguration());
+            var (invitation, connection) = await _connectionService.CreateInvitationAsync(context, new InviteConfiguration
+            {
+                MyAlias = new ConnectionAlias { Name = "dotnet" }
+            });
 
-            return Ok(new { connection_id = connection.Id, invitation });
+            var testHarnessConnection = new TestHarnessConnection
+            {
+                ConnectionId = connection.Id,
+                // State is 'Invited', should be 'invitation'
+                State = TestHarnessConnectionState.Invitation
+            };
+
+            _connectionCache.Set(connection.Id, testHarnessConnection);
+
+            // Listen for connection request to update the state
+            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Request, _ => _.MessageType == MessageTypes.ConnectionRequest && _.RecordId == connection.Id);
+
+            return Ok(new { connection_id = testHarnessConnection.ConnectionId, state = testHarnessConnection.State, invitation });
         }
 
         [HttpPost("receive-invitation")]
         public async Task<IActionResult> ReceiveInvitationAsync(OperationBody body)
         {
-            var invitationBody = body.Data;
-            throw new NotImplementedException();
+
+            var invitation = body.Data.ToObject<ConnectionInvitationMessage>();
+            var context = await _agentContextProvider.GetContextAsync();
+
+            var (request, record) = await _connectionService.CreateRequestAsync(context, invitation);
+
+            var THConnection = new TestHarnessConnection
+            {
+                ConnectionId = record.Id,
+                // State is 'Negotiation', should be 'invitation'
+                State = TestHarnessConnectionState.Invitation,
+                Request = request
+            };
+
+            // Cache is needed because the test harness separates
+            // Receiving and accepting of invitations but .NET does not support that
+            // We generate the ConnectionRequestMessage and store it in the cache.
+            // It will be send in the accept-invitation operation.
+            _connectionCache.Set(record.Id, THConnection);
+
+            return Ok(MapConnection(THConnection));
         }
 
         [HttpPost("accept-invitation")]
         public async Task<IActionResult> AcceptInvitationAsync(OperationBody body)
         {
             var connectionId = body.Id;
-            throw new NotImplementedException();
+
+            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (testHarnessConnection == null) return NotFound(); // Return early if not found
+
+            var context = await _agentContextProvider.GetContextAsync();
+            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
+
+            // Listen for connection response and trust ping message to update the state
+            // TODO: TrustPingMessage event doesn't include the connection(id) so we can't verify whether the
+            // received trust ping comes from the connection we send the connection response to.
+            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Response, _ => _.MessageType == MessageTypes.ConnectionResponse && _.RecordId == connection.Id);
+            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Active, _ => _.MessageType == MessageTypes.TrustPingMessageType && testHarnessConnection.State == TestHarnessConnectionState.Response);
+
+            await _messageService.SendAsync(context.Wallet, testHarnessConnection.Request, connection);
+
+            // State is 'Negotiation', should be 'request'
+            testHarnessConnection.State = TestHarnessConnectionState.Request;
+
+            return Ok();
+
         }
 
         [HttpPost("accept-request")]
         public async Task<IActionResult> AcceptRequestAsync(OperationBody body)
         {
             var connectionId = body.Id;
-            throw new NotImplementedException();
+
+            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (testHarnessConnection == null) return NotFound(); // Return early if not found
+
+            var context = await _agentContextProvider.GetContextAsync();
+
+            // Listen for trusting ping to update the state to 'active'
+            // TODO: TrustPingMessage event doesn't include the connection(id) so we can't verify whether the
+            // received trust ping comes from the connection we send the connection response to.
+            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Active, _ => _.MessageType == MessageTypes.TrustPingMessageType);
+
+            var (response, connection) = await _connectionService.CreateResponseAsync(context, connectionId);
+            await _messageService.SendAsync(context.Wallet, response, connection);
+
+            // State is 'Connected', should be 'response'
+            testHarnessConnection.State = TestHarnessConnectionState.Response;
+
+            return Ok();
         }
 
         [HttpPost("send-ping")]
@@ -104,17 +181,35 @@ namespace DotNet.Backchannel.Controllers
             var connectionId = body.Id;
             var data = body.Data;
 
+            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (testHarnessConnection == null) return NotFound(); // Return early if not found
+
             var context = await _agentContextProvider.GetContextAsync();
-            var connection = await _connectionService.GetAsync(context, connectionId);
+            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
             var message = new TrustPingMessage
             {
-                ResponseRequested = true,
                 Comment = (string)data["comment"]
             };
-
             await _messageService.SendAsync(context.Wallet, message, connection);
 
+            // State is 'Connected', should be 'active'
+            testHarnessConnection.State = TestHarnessConnectionState.Active;
+
             return Ok();
+        }
+
+        private object MapConnection(TestHarnessConnection THConnection) => new
+        {
+            connection_id = THConnection.ConnectionId,
+            state = THConnection.State
+        };
+
+        private void UpdateStateOnMessage(TestHarnessConnection testHarnessConnection, TestHarnessConnectionState nextState, Func<ServiceMessageProcessingEvent, bool> predicate)
+        {
+            _eventAggregator.GetEventByType<ServiceMessageProcessingEvent>()
+            .Where(predicate)
+            .Take(1)
+            .Subscribe(_ => { testHarnessConnection.State = nextState; });
         }
     }
 }

--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using DotNet.Backchannel.Models;
+using Newtonsoft.Json.Linq;
 
 using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Features.TrustPing;
@@ -95,7 +96,7 @@ namespace DotNet.Backchannel.Controllers
             return Ok(new { connection_id = connection.Id, invitation });
         }
 
-        private async Task<IActionResult> ReceiveInvitationAsync(object invitation)
+        private async Task<IActionResult> ReceiveInvitationAsync(JObject invitationObject)
         {
             throw new NotImplementedException();
         }
@@ -109,14 +110,14 @@ namespace DotNet.Backchannel.Controllers
         {
             throw new NotImplementedException();
         }
-        private async Task<IActionResult> SendPingAsync(string connectionId, dynamic data)
+        private async Task<IActionResult> SendPingAsync(string connectionId, JObject data)
         {
             var context = await _agentContextProvider.GetContextAsync();
             var connection = await _connectionService.GetAsync(context, connectionId);
             var message = new TrustPingMessage
             {
                 ResponseRequested = true,
-                Comment = data.comment
+                Comment = (string)data["comment"]
             };
 
             await _messageService.SendAsync(context.Wallet, message, connection);

--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -67,27 +67,8 @@ namespace DotNet.Backchannel.Controllers
             });
         }
 
-        [HttpPost]
-        public async Task<IActionResult> ConnectionOperationAsync(OperationBody body)
-        {
-            switch (body.Operation)
-            {
-                case "create-invitation":
-                    return await this.CreateInvitationAsync();
-                case "receive-invitation":
-                    return await this.ReceiveInvitationAsync(body.Data);
-                case "accept-invitation":
-                    return await this.AcceptInvitationAsync(body.Id);
-                case "accept-request":
-                    return await this.AcceptRequestAsync(body.Id);
-                case "send-ping":
-                    return await this.SendPingAsync(body.Id, body.Data);
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        private async Task<IActionResult> CreateInvitationAsync()
+        [HttpPost("create-invitation")]
+        public async Task<IActionResult> CreateInvitationAsync()
         {
             var context = await _agentContextProvider.GetContextAsync();
 
@@ -96,22 +77,33 @@ namespace DotNet.Backchannel.Controllers
             return Ok(new { connection_id = connection.Id, invitation });
         }
 
-        private async Task<IActionResult> ReceiveInvitationAsync(JObject invitationObject)
+        [HttpPost("receive-invitation")]
+        public async Task<IActionResult> ReceiveInvitationAsync(OperationBody body)
         {
+            var invitationBody = body.Data;
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> AcceptInvitationAsync(string connectionId)
+        [HttpPost("accept-invitation")]
+        public async Task<IActionResult> AcceptInvitationAsync(OperationBody body)
         {
+            var connectionId = body.Id;
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> AcceptRequestAsync(string connectionId)
+        [HttpPost("accept-request")]
+        public async Task<IActionResult> AcceptRequestAsync(OperationBody body)
         {
+            var connectionId = body.Id;
             throw new NotImplementedException();
         }
-        private async Task<IActionResult> SendPingAsync(string connectionId, JObject data)
+
+        [HttpPost("send-ping")]
+        public async Task<IActionResult> SendPingAsync(OperationBody body)
         {
+            var connectionId = body.Id;
+            var data = body.Data;
+
             var context = await _agentContextProvider.GetContextAsync();
             var connection = await _connectionService.GetAsync(context, connectionId);
             var message = new TrustPingMessage

--- a/aries-backchannels/dotnet/server/Controllers/CredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialController.cs
@@ -8,7 +8,7 @@ namespace DotNet.Backchannel.Controllers
     [ApiController]
     public class CredentialController : ControllerBase
     {
-        [HttpGet("{id}")]
+        [HttpGet("{credentialId}")]
         public async Task<IActionResult> GetCredentialById([FromRoute] string credentialId)
         {
             throw new NotImplementedException();

--- a/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
@@ -1,14 +1,13 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using DotNet.Backchannel.Models;
+using System.Net.Mime;
+using Newtonsoft.Json.Linq;
 
 using Hyperledger.Aries.Features.IssueCredential;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
-using System.Net.Mime;
 using Hyperledger.Indy;
-using System.Text.Json;
-using Newtonsoft.Json.Linq;
 
 namespace DotNet.Backchannel.Controllers
 {
@@ -50,18 +49,18 @@ namespace DotNet.Backchannel.Controllers
             return await this.CreateCredentialDefinitionAsync(body.Data);
         }
 
-        private async Task<IActionResult> CreateCredentialDefinitionAsync(JsonElement credentialDefinition)
+        private async Task<IActionResult> CreateCredentialDefinitionAsync(JObject credentialDefinition)
         {
             var context = await _agentContextProvider.GetContextAsync();
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
 
-            var schemaId = credentialDefinition.GetProperty("schema_id").GetString();
-            var tag = credentialDefinition.GetProperty("tag").GetString();
-            var supportRevocation = credentialDefinition.GetProperty("support_revocation").GetBoolean();
+            var schemaId = (string)credentialDefinition["schema_id"];
+            var tag = (string)credentialDefinition["tag"];
+            var supportRevocation = (bool)credentialDefinition["support_revocation"];
 
             // Needed to construct credential definition id
             var schema = JObject.Parse(await _schemaService.LookupSchemaAsync(context, schemaId));
-            var schemaSeqNo = schema["seqNo"].ToString();
+            var schemaSeqNo = (string)schema["seqNo"];
             var signatureType = "CL"; // TODO: can we make this variable?
 
             // The test client sends multiple create credential definition requests with

--- a/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
@@ -43,17 +43,13 @@ namespace DotNet.Backchannel.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> CredentialDefinitionOperationAsync(OperationBody body)
+        public async Task<IActionResult> CreateCredentialDefinitionAsync(OperationBody body)
         {
-            // Credential Defintion only has one operation
-            return await this.CreateCredentialDefinitionAsync(body.Data);
-        }
 
-        private async Task<IActionResult> CreateCredentialDefinitionAsync(JObject credentialDefinition)
-        {
             var context = await _agentContextProvider.GetContextAsync();
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
 
+            var credentialDefinition = body.Data;
             var schemaId = (string)credentialDefinition["schema_id"];
             var tag = (string)credentialDefinition["tag"];
             var supportRevocation = (bool)credentialDefinition["support_revocation"];

--- a/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
@@ -15,57 +15,57 @@ namespace DotNet.Backchannel.Controllers
             throw new NotImplementedException();
         }
 
-        [HttpPost]
-        public async Task<IActionResult> IssueCredentialOperationAsync(OperationBody body)
+        [HttpPost("send-proposal")]
+        public async Task<IActionResult> SendCredentialProposalAsync(OperationBody body)
         {
-            switch (body.Operation)
-            {
-                case "send-proposal":
-                    return await this.SendCredentialProposalAsync(body.Id, body.Data);
-                case "send":
-                    return await this.SendCredentialAsync(body.Id, body.Data);
-                case "send-offer":
-                    // TODO: ID can be both cred_exchange_id OR connection_id
-                    // Find out how this works exactly. Probably as different key
-                    return await this.SendCredentialOfferAsync(body.Id, body.Data);
-                case "send-request":
-                    return await this.SendCredentialRequestAsync(body.Id);
-                case "issue":
-                    return await this.IssueCredentialAsync(body.Id, body.Data);
-                case "store":
-                    return await this.StoreCredentialAsync(body.Id, body.Data);
-                default:
-                    throw new NotSupportedException();
-            }
-        }
+            var connectionId = body.Id;
+            var proposal = body.Data;
 
-        private async Task<IActionResult> SendCredentialProposalAsync(string connectionId, dynamic proposal)
-        {
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendCredentialAsync(string connectionId, dynamic credentialOffer)
+        [HttpPost("send")]
+        public async Task<IActionResult> SendCredentialAsync(OperationBody body)
         {
+            var connectionId = body.Id;
+            var credentialOffer = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendCredentialOfferAsync(string connectionId, dynamic credentialOffer)
+        [HttpPost("send-offer")]
+        public async Task<IActionResult> SendCredentialOfferAsync(OperationBody body)
         {
+            // TODO: ID can be both cred_exchange_id OR connection_id
+            // Find out how this works exactly. Probably as different key
+            var connectionId = body.Id;
+            var credentialOffer = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendCredentialRequestAsync(string credentialRecordId)
+        [HttpPost("send-request")]
+        public async Task<IActionResult> SendCredentialRequestAsync(OperationBody body)
         {
+            var credentialRecordId = body.Id;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> IssueCredentialAsync(string credentialRecordId, dynamic credentialOffer = null)
+        [HttpPost("issue")]
+        public async Task<IActionResult> IssueCredentialAsync(OperationBody body)
         {
+            var credentialRecordId = body.Id;
+            var credentialPreview = body.Data; // Can be undefined!
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> StoreCredentialAsync(string credentialRecordId, dynamic credentialOffer = null)
+        [HttpPost("store")]
+        public async Task<IActionResult> StoreCredentialAsync(OperationBody body)
         {
+            var credentialRecordId = body.Id;
+
             throw new NotImplementedException();
         }
     }

--- a/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
@@ -15,43 +15,40 @@ namespace DotNet.Backchannel.Controllers
             throw new NotImplementedException();
         }
 
-        [HttpPost]
-        public async Task<IActionResult> PresentProofOperationAsync(OperationBody body)
+        [HttpPost("send-proposal")]
+        public async Task<IActionResult> SendPresentationProposalAsync(OperationBody body)
         {
-            switch (body.Operation)
-            {
-                case "send-proposal":
-                    return await this.SendPresentationProposalAsync(body.Id, body.Data);
-                case "send-request":
-                    // TODO: ID can be both pres_exchange_id OR connection_id
-                    // Find out how this works exactly. Probably as different key
-                    return await this.SendPresentationRequestAsync(body.Id, body.Data);
-                case "send-presentation":
-                    return await this.SendProofPresentationOfferAsync(body.Id, body.Data);
-                case "verify-presentation":
-                    return await this.VerifyPresentation(body.Id);
-                default:
-                    throw new NotSupportedException();
-            }
-        }
+            var connectionId = body.Id;
+            var proposal = body.Data;
 
-        private async Task<IActionResult> SendPresentationProposalAsync(string connectionId, dynamic proposal)
-        {
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendPresentationRequestAsync(string proofRecordId, dynamic proofRequest)
+        [HttpPost("send-request")]
+        public async Task<IActionResult> SendPresentationRequestAsync(OperationBody body)
         {
+            // TODO: ID can be both pres_exchange_id OR connection_id
+            // Find out how this works exactly. Probably as different key
+            var proofRecordId = body.Id;
+            var proofRequest = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> SendProofPresentationOfferAsync(string proofRecordId, dynamic proofPresentation)
+        [HttpPost("send-presentation")]
+        public async Task<IActionResult> SendProofPresentationOfferAsync(OperationBody body)
         {
+            var proofRecordId = body.Id;
+            var proofPresentation = body.Data;
+
             throw new NotImplementedException();
         }
 
-        private async Task<IActionResult> VerifyPresentation(string proofRecordId)
+        [HttpPost("verify-presentation")]
+        public async Task<IActionResult> VerifyPresentation(OperationBody body)
         {
+            var proofRecordId = body.Id;
+
             throw new NotImplementedException();
         }
     }

--- a/aries-backchannels/dotnet/server/Controllers/SchemaController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/SchemaController.cs
@@ -43,17 +43,12 @@ namespace DotNet.Backchannel.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> SchemaOperationAsync(OperationBody body)
-        {
-            // Schema only has one operation
-            return await this.CreateSchemaAsync(body.Data);
-        }
-
-        private async Task<IActionResult> CreateSchemaAsync(JObject schema)
+        public async Task<IActionResult> CreateSchemaAsync(OperationBody body)
         {
             var context = await _agentContextProvider.GetContextAsync();
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
 
+            var schema = body.Data;
             var schemaName = (string)schema["schema_name"];
             var schemaVersion = (string)schema["schema_version"];
             var schemaAttributes = schema["attributes"].ToObject<string[]>();

--- a/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
+++ b/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Hyperledger.Aries" Version="1.2.14" />
     <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.2.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/aries-backchannels/dotnet/server/Models/OperationBody.cs
+++ b/aries-backchannels/dotnet/server/Models/OperationBody.cs
@@ -1,6 +1,5 @@
-
-using System.Text.Json;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DotNet.Backchannel.Models
 {
@@ -13,6 +12,6 @@ namespace DotNet.Backchannel.Models
         public string Id { get; set; }
 
         [JsonProperty(PropertyName = "data")]
-        public JsonElement Data { get; set; }
+        public JObject Data { get; set; }
     }
 }

--- a/aries-backchannels/dotnet/server/Models/TestHarnessConnection.cs
+++ b/aries-backchannels/dotnet/server/Models/TestHarnessConnection.cs
@@ -1,0 +1,32 @@
+using System.Runtime.Serialization;
+using Hyperledger.Aries.Features.DidExchange;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace DotNet.Backchannel.Models
+{
+    public enum TestHarnessConnectionState
+    {
+        [EnumMember(Value = "invitation")]
+        Invitation,
+
+        [EnumMember(Value = "request")]
+        Request,
+
+        [EnumMember(Value = "response")]
+        Response,
+
+        [EnumMember(Value = "active")]
+        Active,
+    }
+
+    public class TestHarnessConnection
+    {
+
+        public string ConnectionId;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TestHarnessConnectionState State;
+        public ConnectionRequestMessage Request;
+    }
+}

--- a/aries-backchannels/dotnet/server/Startup.cs
+++ b/aries-backchannels/dotnet/server/Startup.cs
@@ -1,11 +1,11 @@
 using System;
-using System.IO;
 using Hyperledger.Aries.Storage;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json.Converters;
 
 namespace DotNet.Backchannel
 {
@@ -23,9 +23,16 @@ namespace DotNet.Backchannel
         {
             services.AddControllers()
             // Aries Framework .NET uses Newtonsoft JSON library
-            .AddNewtonsoftJson();
+            .AddNewtonsoftJson(options =>
+            {
+                // Convert Enum values to string values
+                options.SerializerSettings.Converters.Add(new StringEnumConverter());
+            });
 
             services.AddLogging();
+
+            // Add in memory cache to store invitations
+            services.AddMemoryCache();
 
             services.AddAriesFramework(builder =>
             {

--- a/aries-backchannels/dotnet/server/Startup.cs
+++ b/aries-backchannels/dotnet/server/Startup.cs
@@ -21,7 +21,9 @@ namespace DotNet.Backchannel
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers();
+            services.AddControllers()
+            // Aries Framework .NET uses Newtonsoft JSON library
+            .AddNewtonsoftJson();
 
             services.AddLogging();
 

--- a/aries-backchannels/dotnet/server/TestAgent.cs
+++ b/aries-backchannels/dotnet/server/TestAgent.cs
@@ -18,6 +18,7 @@ namespace DotNet.Backchannel
             AddBasicMessageHandler();
             AddCredentialHandler();
             AddProofHandler();
+            AddForwardHandler();
         }
     }
 }


### PR DESCRIPTION
This PR adds all operations related to the connection topic. It almost works 100%...

It works when all agents are dotnet agents. It also works when dotnet initiates the connection protocol (dotnet is inviter, acapy is invitee). It however does not work when acapy initiates the connection (acapy is inviter, dotnet is invitee).

acapy creates an invitation and send it OOB to dotnet. When dotnet then sends a connection request to acapy, acapy never changes the status from `invitation` to `request`. I'm not sure whether the fault is in acapy or dotnet. As the message gets send without errors on the dotnet side, but I can't see the logs on acapy side to check if it ever receives it. Communication the other way around works, so they definitely can communicate with each other over DIDComm. 

I'll like to merge anyway as I now first started to work on the debugging inside of the docker container to get better insight on the problems.

Just to be sure: acapy and dotnet are interoperable with each other right?



---
One of the errors. Alice (`9020`) is acapy in this test, Bob is dotnet.
```
@T002-API10-RFC0160 @P1 @AcceptanceTest
  Scenario Outline: Connection established between two agents but inviter sends next message to establish full connection state -- @1.1   # features/0160-connection.feature:65
    Given we have "2" agents                                                                                                              # features/steps/0160-connection.py:15 0.001s
      | name | role    |
      | Acme | inviter |
      | Bob  | invitee |
    When "Acme" generates a connection invitation                                                                                         # features/steps/0160-connection.py:57 0.264s
    And "Bob" receives the connection invitation                                                                                          # features/steps/0160-connection.py:89 0.225s
    And "Bob" sends a connection request to "Acme"                                                                                        # features/steps/0160-connection.py:149 0.658s
    And "Acme" receives the connection request                                                                                            # features/steps/0160-connection.py:170 1.330s
      Traceback (most recent call last):
        File "/usr/local/lib/python3.7/site-packages/behave/model.py", line 1329, in run
          match.run(runner.context)
        File "/usr/local/lib/python3.7/site-packages/behave/matchers.py", line 98, in run
          self.func(context, *args, **kwargs)
        File "features/steps/0160-connection.py", line 177, in step_impl
          assert connection_status(inviter_url, inviter_connection_id, "request")
      AssertionError
      
      Captured stdout:
      From http://0.0.0.0:9020 Expected state ['request'] but received invitation , with a response status of 200
```