### PR TITLE
webhook calls for proof removed and into Aca-py backchannel

### DIFF
--- a/aries-backchannels/backchannel_operations.csv
+++ b/aries-backchannels/backchannel_operations.csv
@@ -72,3 +72,5 @@ rfc,command,response,topic,method,operation,id,data,description,id_details,data_
 0037 Present Proof,X,,proof,POST,send-request,Y,Y,Send a proof request in reference to a proposal,pres_exchange_id,proof_request,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-presentation,Y,Y,Send a proof presentation,pres_exchange_id,proof_presentation,pres_exchange_id
 0037 Present Proof,X,,proof,POST,verify-presentation,Y,,Verify a received proof presentation,pres_exchange_id,,status
+0037 Present Proof,X,,proof,GET,,Y,,Get a stored presentation from the wallet ,presentation_id,,presentation
+0036 Present Proof,X,,proof,GET,,Y,,Fetch a specific credential by ID ,presentation_exchange_id,,presentation_exchange_id

--- a/aries-backchannels/data/backchannel_operations.csv
+++ b/aries-backchannels/data/backchannel_operations.csv
@@ -72,3 +72,4 @@ rfc,command,response,topic,method,operation,id,data,description,id_details,data_
 0037 Present Proof,X,,proof,POST,send-request,Y,Y,Send a proof request in reference to a proposal,pres_exchange_id,proof_request,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-presentation,Y,Y,Send a proof presentation,pres_exchange_id,proof_presentation,pres_exchange_id
 0037 Present Proof,X,,proof,POST,verify-presentation,Y,,Verify a received proof presentation,pres_exchange_id,,status
+0037 Present Proof,X,,proof,GET,,Y,,Get a stored presentation from the holders wallet ,presentation_id,,presentation

--- a/aries-test-harness/agent_backchannel_client.py
+++ b/aries-test-harness/agent_backchannel_client.py
@@ -78,47 +78,13 @@ def agent_backchannel_POST(url, topic, operation=None, id=None, data=None) -> (i
     return (resp_status, resp_text)
 
 
-def connection_status(agent_url, connection_id, status_txt):
+def expected_agent_state(agent_url, protocol_txt, thread_id, status_txt):
     sleep(0.2)
     state = "None"
     if type(status_txt) != list:
         status_txt = [status_txt]
     for i in range(5):
-        (resp_status, resp_text) = agent_backchannel_GET(agent_url + "/agent/command/", "connection", id=connection_id)
-        if resp_status == 200:
-            resp_json = json.loads(resp_text)
-            state = resp_json["state"]
-            if state in status_txt:
-                return True
-        sleep(0.2)
-    # TODO only loop if the status is 200. Are we expectin the state to change in the loop? 
-    print("From", agent_url, "Expected state", status_txt, "but received", state, ", with a response status of", resp_status)
-    return False
-
-def issue_credential_status(agent_url, thread_id, status_txt):
-    sleep(0.2)
-    state = "None"
-    if type(status_txt) != list:
-        status_txt = [status_txt]
-    for i in range(5):
-        (resp_status, resp_text) = agent_backchannel_GET(agent_url + "/agent/command/", "issue-credential", id=thread_id)
-        if resp_status == 200:
-            resp_json = json.loads(resp_text)
-            state = resp_json["state"]
-            if state in status_txt:
-                return True
-        sleep(0.2)
-
-    print("From", agent_url, "Expected state", status_txt, "but received", state, ", with a response status of", resp_status)
-    return False
-
-def present_proof_status(agent_url, pred_ex_id, status_txt):
-    sleep(0.2)
-    state = "None"
-    if type(status_txt) != list:
-        status_txt = [status_txt]
-    for i in range(5):
-        (resp_status, resp_text) = agent_backchannel_GET(agent_url + "/agent/command/", "proof", id=pred_ex_id)
+        (resp_status, resp_text) = agent_backchannel_GET(agent_url + "/agent/command/", protocol_txt, id=thread_id)
         if resp_status == 200:
             resp_json = json.loads(resp_text)
             state = resp_json["state"]

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -1,6 +1,6 @@
 from behave import *
 import json
-from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST, issue_credential_status
+from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST, expected_agent_state
 from time import sleep
 
 # This step is defined in another feature file
@@ -217,7 +217,7 @@ def step_impl(context, issuer):
     assert resp_json["state"] == "offer-sent"
 
     # Check the state of the holder after issuers call of send-offer
-    assert issue_credential_status(context.holder_url, context.cred_thread_id, "offer-received")
+    assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
 
     
 @when('"{holder}" requests the credential')
@@ -240,7 +240,7 @@ def step_impl(context, holder):
     assert resp_json["state"] == "request-sent"
 
     # Verify issuer status
-    assert issue_credential_status(context.issuer_url, context.cred_thread_id, "request-received")
+    assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "request-received")
 
 
 @when('"{issuer}" issues the credential')
@@ -268,7 +268,7 @@ def step_impl(context, issuer):
     assert resp_json["state"] == "credential-issued"
 
     # Verify holder status
-    assert issue_credential_status(context.holder_url, context.cred_thread_id, "credential-received")
+    assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "credential-received")
 
 
 @when('"{holder}" acknowledges the credential issue')
@@ -291,7 +291,7 @@ def step_impl(context, holder):
 
     # Verify issuer status
     # This is returning none instead of Done. Should this be the case. Needs investigation.
-    #assert issue_credential_status(context.issuer_url, context.cred_thread_id, "done")
+    #assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "done")
 
 @then('"{holder}" has the credential issued')
 def step_impl(context, holder):


### PR DESCRIPTION
Webhook calls for proof are now removed and into Aca-py backchannel. Some related code cleanup and streamlining was done as well.

fyi @TimoGlastra  