### PR TITLE
persist logs after running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ aries-agent-test-harness.code-workspace
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Agent log files
+.logs

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -514,8 +514,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
     def _process(self, args, env, loop):
         proc = subprocess.Popen(
             args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             env=env,
             encoding="utf-8",
         )

--- a/manage
+++ b/manage
@@ -256,6 +256,13 @@ runTests() {
   ${terminalEmu} docker run -it --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
   rm ${BEHAVE_INI_TMP}
 
+  # Export agent logs
+  mkdir -p .logs
+  docker logs acme_agent > .logs/acme_agent.log
+  docker logs bob_agent > .logs/bob_agent.log
+  docker logs faber_agent > .logs/faber_agent.log
+  docker logs mallory_agent > .logs/mallory_agent.log
+
   echo
   echo "Cleanup:"
   echo "  - Shutting down all the agents ..."


### PR DESCRIPTION
This PR makes the CUTs a bit easier to debug. After running the logs of the docker containers will be persisted to the `.logs` folder. This folder is ignored, so it is only for local testing.

I also made a small change to the acapy backchannel to also print the logs of aca-py itself. Now only the backchannel logs were printed.

Signed-off-by: Timo Glastra <timo@animo.id>