### PR TITLE
dotnet: issue credential operations

### DIFF
--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -43,19 +43,7 @@ namespace DotNet.Backchannel.Controllers
             var context = await _agentContextProvider.GetContextAsync();
             var connections = await _connectionService.ListAsync(context);
 
-            // TODO: Should we also return the invitation connections from the cache?
-            return Ok(connections.ConvertAll(connection =>
-            {
-
-                var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connection.Id);
-                if (testHarnessConnection != null) return MapConnection(testHarnessConnection);
-
-                return new
-                {
-                    connection_id = connection.Id,
-                    state = connection.State
-                };
-            }));
+            return Ok(connections.ConvertAll(connection => _connectionCache.Get<TestHarnessConnection>(connection.Id)));
         }
 
         [HttpGet("{connectionId}")]
@@ -63,15 +51,21 @@ namespace DotNet.Backchannel.Controllers
         {
             var context = await _agentContextProvider.GetContextAsync();
 
-            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
-            if (testHarnessConnection != null) return Ok(MapConnection(testHarnessConnection));
-
-            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
-            return Ok(new
+            try
             {
-                connection_id = connection.Id,
-                state = connection.State
-            });
+                var THConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+                var connection = await _connectionService.GetAsync(context, connectionId);
+                if (THConnection == null) return NotFound();
+
+                return Ok(THConnection);
+            }
+            catch
+            {
+                // Connection record not found
+                return NotFound();
+            }
+
+
         }
 
         [HttpPost("create-invitation")]
@@ -84,7 +78,6 @@ namespace DotNet.Backchannel.Controllers
             var testHarnessConnection = new TestHarnessConnection
             {
                 ConnectionId = connection.Id,
-                // State is 'Invited', should be 'invitation'
                 State = TestHarnessConnectionState.Invited
             };
 
@@ -108,59 +101,55 @@ namespace DotNet.Backchannel.Controllers
             var THConnection = new TestHarnessConnection
             {
                 ConnectionId = record.Id,
-                // State is 'Negotiation', should be 'invitation'
                 State = TestHarnessConnectionState.Invited,
                 Request = request
             };
 
-            // Cache is needed because the test harness separates
-            // Receiving and accepting of invitations but .NET does not support that
-            // We generate the ConnectionRequestMessage and store it in the cache.
-            // It will be send in the accept-invitation operation.
             _connectionCache.Set(record.Id, THConnection);
 
-            return Ok(MapConnection(THConnection));
+            return Ok(THConnection);
         }
 
         [HttpPost("accept-invitation")]
         public async Task<IActionResult> AcceptInvitationAsync(OperationBody body)
         {
             var connectionId = body.Id;
-
-            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
-            if (testHarnessConnection == null) return NotFound(); // Return early if not found
-
             var context = await _agentContextProvider.GetContextAsync();
-            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
+
+            var THConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (THConnection == null) return NotFound(); // Return early if not found
+
+            ConnectionRecord connection;
+            try { connection = await _connectionService.GetAsync(context, connectionId); }
+            catch { return NotFound(); }
 
             // Listen for connection response to update the state
-            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Responded, _ => _.MessageType == MessageTypes.ConnectionResponse && _.RecordId == connection.Id);
+            UpdateStateOnMessage(THConnection, TestHarnessConnectionState.Responded, _ => _.MessageType == MessageTypes.ConnectionResponse && _.RecordId == connection.Id);
 
-            await _messageService.SendAsync(context.Wallet, testHarnessConnection.Request, connection);
+            await _messageService.SendAsync(context.Wallet, THConnection.Request, connection);
 
-            // State is 'Negotiation', should be 'request'
-            testHarnessConnection.State = TestHarnessConnectionState.Requested;
+            THConnection.State = TestHarnessConnectionState.Requested;
 
-            return Ok();
+            return Ok(THConnection);
+
+
         }
 
         [HttpPost("accept-request")]
         public async Task<IActionResult> AcceptRequestAsync(OperationBody body)
         {
             var connectionId = body.Id;
-
-            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
-            if (testHarnessConnection == null) return NotFound(); // Return early if not found
-
             var context = await _agentContextProvider.GetContextAsync();
+
+            var THConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (THConnection == null) return NotFound(); // Return early if not found
 
             var (response, connection) = await _connectionService.CreateResponseAsync(context, connectionId);
             await _messageService.SendAsync(context.Wallet, response, connection);
 
-            // State is 'Connected', should be 'response'
-            testHarnessConnection.State = TestHarnessConnectionState.Responded;
+            THConnection.State = TestHarnessConnectionState.Responded;
 
-            return Ok();
+            return Ok(THConnection);
         }
 
         [HttpPost("send-ping")]
@@ -168,36 +157,32 @@ namespace DotNet.Backchannel.Controllers
         {
             var connectionId = body.Id;
             var data = body.Data;
-
-            var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
-            if (testHarnessConnection == null) return NotFound(); // Return early if not found
-
             var context = await _agentContextProvider.GetContextAsync();
-            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
+
+            var THConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
+            if (THConnection == null) return NotFound(); // Return early if not found
+
+            ConnectionRecord connection;
+            try { connection = await _connectionService.GetAsync(context, connectionId); }
+            catch { return NotFound(); }
+
             var message = new TrustPingMessage
             {
                 Comment = (string)data["comment"]
             };
             await _messageService.SendAsync(context.Wallet, message, connection);
 
-            // State is 'Connected', should be 'active'
-            testHarnessConnection.State = TestHarnessConnectionState.Complete;
+            THConnection.State = TestHarnessConnectionState.Complete;
 
-            return Ok();
+            return Ok(THConnection);
         }
 
-        private object MapConnection(TestHarnessConnection THConnection) => new
-        {
-            connection_id = THConnection.ConnectionId,
-            state = THConnection.State
-        };
-
-        private void UpdateStateOnMessage(TestHarnessConnection testHarnessConnection, TestHarnessConnectionState nextState, Func<ServiceMessageProcessingEvent, bool> predicate)
+        private void UpdateStateOnMessage(TestHarnessConnection THConnection, TestHarnessConnectionState nextState, Func<ServiceMessageProcessingEvent, bool> predicate)
         {
             _eventAggregator.GetEventByType<ServiceMessageProcessingEvent>()
             .Where(predicate)
             .Take(1)
-            .Subscribe(_ => { testHarnessConnection.State = nextState; });
+            .Subscribe(_ => { THConnection.State = nextState; });
         }
     }
 }

--- a/aries-backchannels/dotnet/server/Controllers/CredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialController.cs
@@ -1,17 +1,56 @@
-using System;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Utils;
 
 namespace DotNet.Backchannel.Controllers
 {
+
     [Route("agent/command/credential")]
     [ApiController]
     public class CredentialController : ControllerBase
     {
+        private readonly ICredentialService _credentialService;
+        private readonly IAgentProvider _agentContextProvider;
+
+        public CredentialController(
+            ICredentialService credentialService,
+            IAgentProvider agentContextProvider
+        )
+        {
+            _credentialService = credentialService;
+            _agentContextProvider = agentContextProvider;
+        }
+
         [HttpGet("{credentialId}")]
         public async Task<IActionResult> GetCredentialById([FromRoute] string credentialId)
         {
-            throw new NotImplementedException();
+            var context = await _agentContextProvider.GetContextAsync();
+
+            try
+            {
+                var credentialRecord = await _credentialService.GetAsync(context, credentialId);
+
+                if (credentialRecord.GetTag(TagConstants.Role) != TagConstants.Holder)
+                {
+                    // We should only return the credential if we are the holder
+                    return NotFound();
+                }
+
+                // TODO: should we return extra data?
+                return Ok(new
+                {
+                    referent = credentialRecord.Id,
+                    schema_id = credentialRecord.SchemaId,
+                    cred_def_id = credentialRecord.CredentialDefinitionId
+                });
+            }
+            catch
+            {
+                // Unable to retrieve credential record.
+                return NotFound();
+            }
         }
     }
 }

--- a/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
@@ -2,6 +2,26 @@ using System;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using DotNet.Backchannel.Models;
+using Microsoft.Extensions.Caching.Memory;
+using DotNet.Backchannel.Messages;
+
+using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries.Storage;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Utils;
+using Hyperledger.Aries.Features.DidExchange;
+using Hyperledger.Aries.Models.Events;
+using Hyperledger.Aries.Contracts;
+
+using System.Reactive.Linq;
+using Hyperledger.Aries.Configuration;
+using Hyperledger.Indy.AnonCredsApi;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using Hyperledger.Aries.Decorators.Attachments;
+using Hyperledger.Aries.Extensions;
+using Hyperledger.Aries.Decorators.Threading;
+using Newtonsoft.Json;
 
 namespace DotNet.Backchannel.Controllers
 {
@@ -9,64 +29,282 @@ namespace DotNet.Backchannel.Controllers
     [ApiController]
     public class IssueCredentialController : ControllerBase
     {
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetCredentialRecordByIdAsync([FromRoute] string credentialRecordId)
+        private readonly ICredentialService _credentialService;
+        private readonly IWalletRecordService _recordService;
+        private readonly IEventAggregator _eventAggregator;
+        private readonly IProvisioningService _provisionService;
+        private readonly IConnectionService _connectionService;
+        private readonly IAgentProvider _agentContextProvider;
+        private readonly IMessageService _messageService;
+        private IMemoryCache _credentialCache;
+
+        public IssueCredentialController(
+            ICredentialService credentialService,
+            IWalletRecordService recordService,
+            IEventAggregator eventAggregator,
+            IProvisioningService provisionService,
+            IConnectionService connectionService,
+            IAgentProvider agentContextProvider,
+            IMessageService messageService,
+            IMemoryCache memoryCache
+            )
         {
-            throw new NotImplementedException();
+            _credentialService = credentialService;
+            _recordService = recordService;
+            _eventAggregator = eventAggregator;
+            _provisionService = provisionService;
+            _connectionService = connectionService;
+            _agentContextProvider = agentContextProvider;
+            _messageService = messageService;
+            _credentialCache = memoryCache;
+        }
+
+        [HttpGet("{threadId}")]
+        public async Task<IActionResult> GetCredentialRecordByThreadIdAsync([FromRoute] string threadId)
+        {
+            var context = await _agentContextProvider.GetContextAsync();
+
+            var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
+            if (THCredentialExchange != null) return Ok(THCredentialExchange);
+
+            return NotFound();
+            // TODO
+            // var credentialRecord = await _credentialService.GetByThreadIdAsync(context, threadId); // TODO: Handle AriesFrameworkException if credential record not found
+            // return Ok(new
+            // {
+            //     connection_id = connection.Id,
+            //     state = connection.State
+            // });
         }
 
         [HttpPost("send-proposal")]
         public async Task<IActionResult> SendCredentialProposalAsync(OperationBody body)
         {
-            var connectionId = body.Id;
+            var context = await _agentContextProvider.GetContextAsync();
             var proposal = body.Data;
+            var connectionId = (string)proposal["connection_id"];
+            var credentialPreview = proposal["credential_proposal"].ToObject<CustomCredentialPreviewMessage>();
+            var credentialDefinitionId = (string)proposal["cred_def_id"];
+            var schemaId = (string)proposal["schema_id"];
+            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
 
-            throw new NotImplementedException();
-        }
+            var threadId = Guid.NewGuid().ToString();
 
-        [HttpPost("send")]
-        public async Task<IActionResult> SendCredentialAsync(OperationBody body)
-        {
-            var connectionId = body.Id;
-            var credentialOffer = body.Data;
+            credentialPreview.Attributes = CleanCredentialPreviewAttributes(credentialPreview.Attributes);
 
-            throw new NotImplementedException();
+            // TODO: add support for v1.1 wich includes 'schema_issuer_did', 'schema_name', 'schema_version', 'issuer_did'
+            // TODO: should we support in response to previous message? Not possible with AATH atm I think.
+            var credentialProposeMessage = new CustomCredentialProposeMessage
+            {
+                Id = threadId,
+                Comment = (string)proposal["comment"] ?? "hello", // ACA-Py requires comment
+                CredentialProposal = credentialPreview,
+                CredentialDefinitionId = credentialDefinitionId,
+                SchemaId = schemaId
+            };
+
+            var credentialRecord = new CredentialRecord
+            {
+                Id = Guid.NewGuid().ToString(),
+                ConnectionId = connectionId,
+                CredentialAttributesValues = credentialPreview.Attributes,
+                CredentialDefinitionId = credentialDefinitionId,
+                SchemaId = schemaId,
+                // State should be proposal-received
+                State = CredentialState.Offered
+            };
+            credentialRecord.SetTag(TagConstants.Role, TagConstants.Holder);
+            credentialRecord.SetTag(TagConstants.LastThreadId, threadId);
+
+            await _recordService.AddAsync(context.Wallet, credentialRecord);
+
+            var THCredentialExchange = new TestHarnessCredentialExchange
+            {
+                RecordId = credentialRecord.Id,
+                ThreadId = threadId,
+                State = TestHarnessCredentialExchangeState.ProposalSent,
+            };
+
+            _credentialCache.Set(THCredentialExchange.ThreadId, THCredentialExchange);
+
+            // Listen for credential offer to update the state
+            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.OfferReceived, _ => _.MessageType == MessageTypes.IssueCredentialNames.OfferCredential && _.ThreadId == THCredentialExchange.ThreadId);
+
+            await _messageService.SendAsync(context.Wallet, credentialProposeMessage, connection);
+
+            return Ok(THCredentialExchange);
         }
 
         [HttpPost("send-offer")]
         public async Task<IActionResult> SendCredentialOfferAsync(OperationBody body)
         {
-            // TODO: ID can be both cred_exchange_id OR connection_id
-            // Find out how this works exactly. Probably as different key
-            var connectionId = body.Id;
-            var credentialOffer = body.Data;
+            var context = await _agentContextProvider.GetContextAsync();
+            var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
+            var threadId = body.Id;
 
-            throw new NotImplementedException();
+            await Task.Delay(5000);
+
+            string connectionId;
+            TestHarnessCredentialExchange THCredentialExchange;
+            CredentialOfferMessage credentialOffer;
+            CredentialRecord credentialRecord;
+
+            // Send offer in response to proposal
+            if (threadId != null)
+            {
+                THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
+
+                credentialRecord = await _credentialService.GetAsync(context, THCredentialExchange.RecordId);
+                connectionId = credentialRecord.ConnectionId;
+
+                var offerJson = await AnonCreds.IssuerCreateCredentialOfferAsync(context.Wallet, credentialRecord.CredentialDefinitionId);
+                var offerJobj = JObject.Parse(offerJson);
+                var schemaId = offerJobj["schema_id"].ToObject<string>();
+
+                // Update credential record
+                credentialRecord.SchemaId = schemaId;
+                credentialRecord.OfferJson = offerJson;
+                credentialRecord.State = CredentialState.Offered;
+                credentialRecord.SetTag(TagConstants.IssuerDid, issuer.IssuerDid);
+                await _recordService.UpdateAsync(context.Wallet, credentialRecord);
+
+                credentialOffer = new CredentialOfferMessage
+                {
+                    CredentialPreview = new CredentialPreviewMessage
+                    {
+                        Attributes = CleanCredentialPreviewAttributes(credentialRecord.CredentialAttributesValues.ToArray())
+                    },
+                    Comment = "credential-offer", // ACA-Py requires comment
+                    Offers = new Attachment[]
+                    {
+                        new Attachment
+                        {
+                            Id = "libindy-cred-offer-0",
+                            MimeType = CredentialMimeTypes.ApplicationJsonMimeType,
+                            Data = new AttachmentContent
+                            {
+                                Base64 = offerJson.GetUTF8Bytes().ToBase64String()
+                            }
+                        }
+                    }
+                };
+
+                credentialOffer.ThreadFrom(threadId);
+
+                THCredentialExchange.State = TestHarnessCredentialExchangeState.OfferSent;
+            }
+            // Send Offer to start credential issuance flow
+            else
+            {
+                var offer = body.Data;
+                connectionId = (string)offer["connection_id"];
+                var credentialPreview = offer["credential_preview"].ToObject<CustomCredentialPreviewMessage>();
+                var credentialDefinitionId = (string)offer["cred_def_id"];
+
+                credentialPreview.Attributes = CleanCredentialPreviewAttributes(credentialPreview.Attributes);
+
+                (credentialOffer, credentialRecord) = await _credentialService.CreateOfferAsync(context, new OfferConfiguration
+                {
+                    CredentialAttributeValues = credentialPreview.Attributes,
+                    CredentialDefinitionId = credentialDefinitionId,
+                    IssuerDid = issuer.IssuerDid
+                }, connectionId);
+
+                THCredentialExchange = new TestHarnessCredentialExchange
+                {
+                    RecordId = credentialRecord.Id,
+                    ThreadId = credentialRecord.GetTag(TagConstants.LastThreadId),
+                    State = TestHarnessCredentialExchangeState.OfferSent
+                };
+                _credentialCache.Set(THCredentialExchange.ThreadId, THCredentialExchange);
+            }
+
+            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
+
+            // TODO: find better way to listen for changes. As the state can move to other statest than just RequestReceived
+            // Listen for credential request to update the state
+            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.RequestReceived, _ => _.MessageType == MessageTypes.IssueCredentialNames.RequestCredential && _.ThreadId == THCredentialExchange.ThreadId);
+
+            await _messageService.SendAsync(context.Wallet, credentialOffer, connection);
+
+            return Ok(THCredentialExchange);
         }
 
         [HttpPost("send-request")]
         public async Task<IActionResult> SendCredentialRequestAsync(OperationBody body)
         {
-            var credentialRecordId = body.Id;
+            // Indy does not support startign from a credential-request. So the id is always the thread id
+            var threadId = body.Id;
+            var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
+            var context = await _agentContextProvider.GetContextAsync();
 
-            throw new NotImplementedException();
+            var (credentialRequest, credentialRecord) = await _credentialService.CreateRequestAsync(context, THCredentialExchange.RecordId);
+            THCredentialExchange.State = TestHarnessCredentialExchangeState.RequestSent;
+
+            // TODO: find better way to listen for changes. As the state can move to other statest than just CredentialReceived
+            // Listen for issue credential to update the state
+            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.CredentialReceived, _ => _.MessageType == MessageTypes.IssueCredentialNames.IssueCredential && _.ThreadId == THCredentialExchange.ThreadId);
+
+            var connection = await _connectionService.GetAsync(context, credentialRecord.ConnectionId); // TODO: Handle AriesFrameworkException if connection not found
+            await _messageService.SendAsync(context.Wallet, credentialRequest, connection);
+
+            return Ok(THCredentialExchange);
         }
 
         [HttpPost("issue")]
         public async Task<IActionResult> IssueCredentialAsync(OperationBody body)
         {
-            var credentialRecordId = body.Id;
-            var credentialPreview = body.Data; // Can be undefined!
+            await Task.Delay(5000);
 
-            throw new NotImplementedException();
+            var threadId = body.Id;
+            var context = await _agentContextProvider.GetContextAsync();
+            var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
+
+            // TODO: should we use body.Data? This can contain an optional comment.
+            var (credentialIssueMessage, credentialRecord) = await _credentialService.CreateCredentialAsync(context, THCredentialExchange.RecordId);
+            var connection = await _connectionService.GetAsync(context, credentialRecord.ConnectionId);
+
+            await _messageService.SendAsync(context.Wallet, credentialIssueMessage, connection);
+
+            THCredentialExchange.State = TestHarnessCredentialExchangeState.CredentialIssued;
+
+            return Ok(THCredentialExchange);
         }
 
         [HttpPost("store")]
         public async Task<IActionResult> StoreCredentialAsync(OperationBody body)
         {
-            var credentialRecordId = body.Id;
+            var threadId = body.Id;
+            var context = await _agentContextProvider.GetContextAsync();
+            var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
+            var credentialRecord = _credentialService.GetAsync(context, THCredentialExchange.RecordId);
 
-            throw new NotImplementedException();
+            // TODO: Should we do some checks here??
+            THCredentialExchange.State = TestHarnessCredentialExchangeState.Done;
+
+            return Ok(THCredentialExchange);
+        }
+
+        /// <summary>
+        /// prevent mime type not supported error when mime type is null
+        /// </summary>
+        /// <param name="attributes"></param>
+        /// <returns></returns>
+        private CredentialPreviewAttribute[] CleanCredentialPreviewAttributes(CredentialPreviewAttribute[] attributes) => attributes.Select(x =>
+            new CredentialPreviewAttribute
+            {
+                Name = x.Name,
+                MimeType = x.MimeType == null ? CredentialMimeTypes.TextMimeType : x.MimeType,
+                Value = x.Value?.ToString()
+            }).ToArray();
+
+        private void UpdateStateOnMessage(TestHarnessCredentialExchange testHarnessCredentialExchange, TestHarnessCredentialExchangeState nextState, Func<ServiceMessageProcessingEvent, bool> predicate)
+        {
+            System.Console.WriteLine($"Waiting to update state to ${nextState}, on credential {testHarnessCredentialExchange.ThreadId}, from state: {testHarnessCredentialExchange.State} ");
+            _eventAggregator.GetEventByType<ServiceMessageProcessingEvent>()
+            .Where(predicate)
+            .Take(1)
+            .Subscribe(_ => { System.Console.WriteLine($"Updated state to ${nextState}, on credential {testHarnessCredentialExchange.ThreadId}, from state: {testHarnessCredentialExchange.State} "); testHarnessCredentialExchange.State = nextState; });
         }
     }
 }

--- a/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using Hyperledger.Aries.Decorators.Attachments;
 using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Decorators.Threading;
-using Newtonsoft.Json;
 
 namespace DotNet.Backchannel.Controllers
 {
@@ -64,17 +63,19 @@ namespace DotNet.Backchannel.Controllers
         {
             var context = await _agentContextProvider.GetContextAsync();
 
-            var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
-            if (THCredentialExchange != null) return Ok(THCredentialExchange);
+            try
+            {
+                var credentialRecord = await _credentialService.GetByThreadIdAsync(context, threadId);
+                var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);
+                if (THCredentialExchange == null) return NotFound();
 
-            return NotFound();
-            // TODO
-            // var credentialRecord = await _credentialService.GetByThreadIdAsync(context, threadId); // TODO: Handle AriesFrameworkException if credential record not found
-            // return Ok(new
-            // {
-            //     connection_id = connection.Id,
-            //     state = connection.State
-            // });
+                return Ok(THCredentialExchange);
+            }
+            catch
+            {
+                // Can't find the credential record
+                return NotFound();
+            }
         }
 
         [HttpPost("send-proposal")]

--- a/aries-backchannels/dotnet/server/Handlers/CredentialHandler.cs
+++ b/aries-backchannels/dotnet/server/Handlers/CredentialHandler.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Extensions;
+using Hyperledger.Aries.Storage;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries;
+using DotNet.Backchannel.Messages;
+using DotNet.Backchannel.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Utils;
+using Hyperledger.Aries.Decorators.Threading;
+using Hyperledger.Aries.Models.Events;
+using Hyperledger.Aries.Features.DidExchange;
+
+namespace DotNet.Backchannel.Handlers
+{
+    // Because the framework doesn't handle credential propose message, and also needs a custom implementation for the credential offer
+    // for now we override the credential handler.
+    internal class AATHCredentialHandler : IMessageHandler
+    {
+        private readonly IEventAggregator _eventAggregator;
+        private readonly ICredentialService _credentialService;
+        private readonly IWalletRecordService _recordService;
+        private readonly IMessageService _messageService;
+        private IMemoryCache _credentialCache;
+
+        /// <summary>Initializes a new instance of the <see cref="DefaultCredentialHandler"/> class.</summary>
+        /// <param name="eventAggregator">The event aggregator.</param>
+        /// <param name="credentialService">The credential service.</param>
+        /// <param name="recordService">The wallet record service.</param>
+        /// <param name="messageService">The message service.</param>
+        /// <param name="memoryCache">The memory cache</param>
+        public AATHCredentialHandler(
+            IEventAggregator eventAggregator,
+            ICredentialService credentialService,
+            IWalletRecordService recordService,
+            IMessageService messageService,
+            IMemoryCache memoryCache)
+        {
+            _eventAggregator = eventAggregator;
+            _credentialService = credentialService;
+            _recordService = recordService;
+            _messageService = messageService;
+            _credentialCache = memoryCache;
+        }
+
+        /// <summary>
+        /// Gets the supported message types.
+        /// </summary>
+        /// <value>
+        /// The supported message types.
+        /// </value>
+        public IEnumerable<MessageType> SupportedMessageTypes => new MessageType[]
+        {
+            MessageTypes.IssueCredentialNames.ProposeCredential,
+            MessageTypes.IssueCredentialNames.OfferCredential,
+            MessageTypes.IssueCredentialNames.RequestCredential,
+            MessageTypes.IssueCredentialNames.IssueCredential,
+        };
+
+        /// <summary>
+        /// Processes the agent message
+        /// </summary>
+        /// <param name="agentContext"></param>
+        /// <param name="messageContext">The agent message.</param>
+        /// <returns></returns>
+        /// <exception cref="AriesFrameworkException">Unsupported message type {messageType}</exception>
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, UnpackedMessageContext messageContext)
+        {
+            switch (messageContext.GetMessageType())
+            {
+                case MessageTypes.IssueCredentialNames.ProposeCredential:
+                    {
+                        var credentialProposal = messageContext.GetMessage<CustomCredentialProposeMessage>();
+
+                        CredentialRecord credentialRecord;
+                        TestHarnessCredentialExchange THCredentialExchange;
+                        try
+                        {
+                            // Credential can be proposed for an existing exchange
+                            // so we must first check if the message contains 
+                            THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(credentialProposal.GetThreadId());
+                            credentialRecord = await _credentialService.GetByThreadIdAsync(agentContext, THCredentialExchange.ThreadId);
+
+                            // TODO: we should check if the proposal came from the same connection
+                            // if (messageContext.Connection?.Id == credentialRecord.ConnectionId)
+                        }
+                        catch
+                        {
+                            // Create new CredentialRecord if no existing credential record exists
+                            credentialRecord = new CredentialRecord
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                ConnectionId = messageContext.Connection?.Id,
+                            };
+
+                            credentialRecord.SetTag(TagConstants.Role, TagConstants.Issuer);
+                            credentialRecord.SetTag(TagConstants.LastThreadId, credentialProposal.GetThreadId());
+
+                            await _recordService.AddAsync(agentContext.Wallet, credentialRecord);
+
+                            THCredentialExchange = new TestHarnessCredentialExchange
+                            {
+                                RecordId = credentialRecord.Id,
+                                ThreadId = credentialProposal.GetThreadId(),
+                                State = TestHarnessCredentialExchangeState.ProposalReceived,
+                            };
+                            _credentialCache.Set(THCredentialExchange.ThreadId, THCredentialExchange);
+                        }
+
+                        // Updates that should be applied both when the credential record already exists or not
+                        credentialRecord.CredentialDefinitionId = credentialProposal.CredentialDefinitionId;
+                        credentialRecord.SchemaId = credentialProposal.SchemaId;
+                        credentialRecord.CredentialAttributesValues = credentialProposal.CredentialProposal?.Attributes
+                                    .Select(x => new CredentialPreviewAttribute
+                                    {
+                                        Name = x.Name,
+                                        MimeType = x.MimeType,
+                                        Value = x.Value
+                                    }).ToArray();
+                        // State should be proposal-received
+                        credentialRecord.State = CredentialState.Offered;
+
+                        await _recordService.UpdateAsync(agentContext.Wallet, credentialRecord);
+
+                        _eventAggregator.Publish(new ServiceMessageProcessingEvent
+                        {
+                            RecordId = credentialRecord.Id,
+                            MessageType = credentialProposal.Type,
+                            ThreadId = credentialProposal.GetThreadId()
+                        });
+
+                        messageContext.ContextRecord = credentialRecord;
+
+                        return null;
+                    }
+                case MessageTypes.IssueCredentialNames.OfferCredential:
+                    {
+                        var offer = messageContext.GetMessage<CredentialOfferMessage>();
+                        var recordId = await this.ProcessOfferAsync(
+                            agentContext, offer, messageContext.Connection);
+
+                        messageContext.ContextRecord = await _credentialService.GetAsync(agentContext, recordId);
+
+                        return null;
+                    }
+                case MessageTypes.IssueCredentialNames.RequestCredential:
+                    {
+                        var request = messageContext.GetMessage<CredentialRequestMessage>();
+                        var recordId = await _credentialService.ProcessCredentialRequestAsync(
+                                agentContext: agentContext,
+                                credentialRequest: request,
+                                connection: messageContext.Connection);
+                        if (request.ReturnRoutingRequested() && messageContext.Connection == null)
+                        {
+                            var (message, record) = await _credentialService.CreateCredentialAsync(agentContext, recordId);
+                            messageContext.ContextRecord = record;
+                            return message;
+                        }
+                        else
+                        {
+                            messageContext.ContextRecord = await _credentialService.GetAsync(agentContext, recordId);
+                            return null;
+                        }
+                    }
+
+                case MessageTypes.IssueCredentialNames.IssueCredential:
+                    {
+                        var credential = messageContext.GetMessage<CredentialIssueMessage>();
+                        var recordId = await _credentialService.ProcessCredentialAsync(
+                            agentContext, credential, messageContext.Connection);
+
+                        messageContext.ContextRecord = await UpdateValuesAsync(
+                            credentialId: recordId,
+                            credentialIssue: messageContext.GetMessage<CredentialIssueMessage>(),
+                            agentContext: agentContext);
+
+                        return null;
+                    }
+                default:
+                    throw new AriesFrameworkException(ErrorCode.InvalidMessage,
+                        $"Unsupported message type {messageContext.GetMessageType()}");
+            }
+        }
+
+        /// <summary>
+        /// Process an offer, taking previous proposals into account. The framework doesn't fully
+        /// support credential proposals, and I don't know how to override one service function
+        /// so for now we just use a custom handler and this function.
+        /// </summary>
+        /// <param name="agentContext"></param>
+        /// <param name="credentialOffer"></param>
+        /// <param name="connection"></param>
+        /// <returns></returns>
+        private async Task<string> ProcessOfferAsync(IAgentContext agentContext, CredentialOfferMessage credentialOffer,
+                 ConnectionRecord connection)
+        {
+            var offerAttachment = credentialOffer.Offers.FirstOrDefault(x => x.Id == "libindy-cred-offer-0")
+                                  ?? throw new ArgumentNullException(nameof(CredentialOfferMessage.Offers));
+
+            var offerJson = offerAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
+            var offer = JObject.Parse(offerJson);
+            var definitionId = offer["cred_def_id"].ToObject<string>();
+            var schemaId = offer["schema_id"].ToObject<string>();
+
+            // TODO: does it throw or return nil
+            // check if credential already exists
+            CredentialRecord credentialRecord;
+            try
+            {
+                credentialRecord = await _credentialService.GetByThreadIdAsync(agentContext, credentialOffer.GetThreadId());
+                // TODO: check if same connection id
+                // credentialRecord.ConnectionId == connection.Id
+            }
+            catch
+            {
+                // Write offer record to local wallet
+                credentialRecord = new CredentialRecord
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    ConnectionId = connection?.Id,
+                };
+                credentialRecord.SetTag(TagConstants.Role, TagConstants.Holder);
+                credentialRecord.SetTag(TagConstants.LastThreadId, credentialOffer.GetThreadId());
+
+                await _recordService.AddAsync(agentContext.Wallet, credentialRecord);
+
+                var THCredentialExchange = new TestHarnessCredentialExchange
+                {
+                    RecordId = credentialRecord.Id,
+                    ThreadId = credentialOffer.GetThreadId(),
+                    State = TestHarnessCredentialExchangeState.OfferReceived
+                };
+
+                // TODO: move away from handler.
+                _credentialCache.Set(THCredentialExchange.ThreadId, THCredentialExchange);
+            }
+
+            credentialRecord.OfferJson = offerJson;
+            credentialRecord.CredentialDefinitionId = definitionId;
+            credentialRecord.SchemaId = schemaId;
+            credentialRecord.CredentialAttributesValues = credentialOffer.CredentialPreview?.Attributes
+                .Select(x => new CredentialPreviewAttribute
+                {
+                    Name = x.Name,
+                    MimeType = x.MimeType,
+                    Value = x.Value
+                }).ToArray();
+            credentialRecord.State = CredentialState.Offered;
+
+            await _recordService.UpdateAsync(agentContext.Wallet, credentialRecord);
+
+            _eventAggregator.Publish(new ServiceMessageProcessingEvent
+            {
+                RecordId = credentialRecord.Id,
+                MessageType = credentialOffer.Type,
+                ThreadId = credentialOffer.GetThreadId()
+            });
+
+            return credentialRecord.Id;
+        }
+
+        private async Task<CredentialRecord> UpdateValuesAsync(string credentialId, CredentialIssueMessage credentialIssue, IAgentContext agentContext)
+        {
+            var credentialAttachment = credentialIssue.Credentials.FirstOrDefault(x => x.Id == "libindy-cred-0")
+                ?? throw new ArgumentException("Credential attachment not found");
+
+            var credentialJson = credentialAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
+
+            var jcred = JObject.Parse(credentialJson);
+            var values = jcred["values"].ToObject<Dictionary<string, AttributeValue>>();
+
+            var credential = await _credentialService.GetAsync(agentContext, credentialId);
+            credential.CredentialAttributesValues = values.Select(x => new CredentialPreviewAttribute { Name = x.Key, Value = x.Value.Raw, MimeType = CredentialMimeTypes.TextMimeType }).ToList();
+            await _recordService.UpdateAsync(agentContext.Wallet, credential);
+
+            return credential;
+        }
+
+        private class AttributeValue
+        {
+            [JsonProperty("raw")]
+            public string Raw { get; set; }
+
+            [JsonProperty("encoded")]
+            public string Encoded { get; set; }
+        }
+    }
+}

--- a/aries-backchannels/dotnet/server/Messages/CustomCredentialPreviewMessage.cs
+++ b/aries-backchannels/dotnet/server/Messages/CustomCredentialPreviewMessage.cs
@@ -1,0 +1,32 @@
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Features.IssueCredential;
+using Newtonsoft.Json;
+
+namespace DotNet.Backchannel.Messages
+{
+    /// <summary>
+    /// A credential content message.
+    /// </summary>
+    public class CustomCredentialPreviewMessage
+    {
+        /// <inheritdoc />
+        public CustomCredentialPreviewMessage()
+        {
+            Type = MessageTypes.IssueCredentialNames.PreviewCredential;
+        }
+
+        /// <summary>
+        ///  Gets or sets the type.
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("@type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the attributes
+        /// </summary>kk
+        /// <value></value>
+        [JsonProperty("attributes")]
+        public CredentialPreviewAttribute[] Attributes { get; set; }
+    }
+}

--- a/aries-backchannels/dotnet/server/Messages/CustomCredentialProposeMessage.cs
+++ b/aries-backchannels/dotnet/server/Messages/CustomCredentialProposeMessage.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Text.Json.Serialization;
+using Hyperledger.Aries.Agents;
+using Newtonsoft.Json;
+
+namespace DotNet.Backchannel.Messages
+{
+    /// <summary>
+    /// A credential content message.
+    /// </summary>
+    public class CustomCredentialProposeMessage : AgentMessage
+    {
+        /// <inheritdoc />
+        public CustomCredentialProposeMessage()
+        {
+            Id = Guid.NewGuid().ToString();
+            Type = MessageTypes.IssueCredentialNames.ProposeCredential;
+        }
+
+        /// <summary>
+        /// Gets or sets human readable information about this Credential Proposal
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("comment")]
+        public string Comment { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schema identifier
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("schema_id")]
+        [JsonPropertyName("schema_id")]
+        public string SchemaId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the credential definition identifier
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("cred_def_id")]
+        [JsonPropertyName("cred_def_id")]
+        public string CredentialDefinitionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Credential Preview
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("credential_proposal")]
+        [JsonPropertyName("credential_proposal")]
+        public CustomCredentialPreviewMessage CredentialProposal { get; set; }
+    }
+}

--- a/aries-backchannels/dotnet/server/Middlewares/MessageMiddleware.cs
+++ b/aries-backchannels/dotnet/server/Middlewares/MessageMiddleware.cs
@@ -7,18 +7,13 @@ using Hyperledger.Aries.Agents;
 
 namespace DotNet.Backchannel.Middlewares
 {
-
-
     public class MessageAgentMiddleware : IAgentMiddleware
     {
-
-        private IMemoryCache _connectionCache;
-
+        private IMemoryCache _cache;
         public MessageAgentMiddleware(
-
-       IMemoryCache memoryCache)
+            IMemoryCache memoryCache)
         {
-            _connectionCache = memoryCache;
+            _cache = memoryCache;
         }
 
         /// <inheritdoc />
@@ -33,14 +28,13 @@ namespace DotNet.Backchannel.Middlewares
             {
                 var message = messageContext.GetMessage<TrustPingMessage>();
 
-                var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(messageContext.Connection.Id);
+                var THConnection = _cache.Get<TestHarnessConnection>(messageContext.Connection.Id);
 
-                if (testHarnessConnection != null && testHarnessConnection.State == TestHarnessConnectionState.Responded)
+                if (THConnection != null && THConnection.State == TestHarnessConnectionState.Responded)
                 {
-                    testHarnessConnection.State = TestHarnessConnectionState.Complete;
+                    THConnection.State = TestHarnessConnectionState.Complete;
                 }
             }
-
         }
     }
 }

--- a/aries-backchannels/dotnet/server/Middlewares/MessageMiddleware.cs
+++ b/aries-backchannels/dotnet/server/Middlewares/MessageMiddleware.cs
@@ -35,9 +35,9 @@ namespace DotNet.Backchannel.Middlewares
 
                 var testHarnessConnection = _connectionCache.Get<TestHarnessConnection>(messageContext.Connection.Id);
 
-                if (testHarnessConnection != null && testHarnessConnection.State == TestHarnessConnectionState.Response)
+                if (testHarnessConnection != null && testHarnessConnection.State == TestHarnessConnectionState.Responded)
                 {
-                    testHarnessConnection.State = TestHarnessConnectionState.Active;
+                    testHarnessConnection.State = TestHarnessConnectionState.Complete;
                 }
             }
 

--- a/aries-backchannels/dotnet/server/Models/TestHarnessConnection.cs
+++ b/aries-backchannels/dotnet/server/Models/TestHarnessConnection.cs
@@ -7,17 +7,17 @@ namespace DotNet.Backchannel.Models
 {
     public enum TestHarnessConnectionState
     {
-        [EnumMember(Value = "invitation")]
-        Invitation,
+        [EnumMember(Value = "invited")]
+        Invited,
 
-        [EnumMember(Value = "request")]
-        Request,
+        [EnumMember(Value = "requested")]
+        Requested,
 
-        [EnumMember(Value = "response")]
-        Response,
+        [EnumMember(Value = "responded")]
+        Responded,
 
-        [EnumMember(Value = "active")]
-        Active,
+        [EnumMember(Value = "complete")]
+        Complete,
     }
 
     public class TestHarnessConnection

--- a/aries-backchannels/dotnet/server/Models/TestHarnessConnection.cs
+++ b/aries-backchannels/dotnet/server/Models/TestHarnessConnection.cs
@@ -23,10 +23,14 @@ namespace DotNet.Backchannel.Models
     public class TestHarnessConnection
     {
 
+        [JsonProperty("connection_id")]
         public string ConnectionId;
 
+        [JsonProperty("state")]
         [JsonConverter(typeof(StringEnumConverter))]
         public TestHarnessConnectionState State;
+
+        [JsonIgnore]
         public ConnectionRequestMessage Request;
     }
 }

--- a/aries-backchannels/dotnet/server/Models/TestHarnessCredentialExchange.cs
+++ b/aries-backchannels/dotnet/server/Models/TestHarnessCredentialExchange.cs
@@ -1,0 +1,52 @@
+using System.Runtime.Serialization;
+using Hyperledger.Aries.Features.IssueCredential;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace DotNet.Backchannel.Models
+{
+    public enum TestHarnessCredentialExchangeState
+    {
+        [EnumMember(Value = "proposal-sent")]
+        ProposalSent,
+
+        [EnumMember(Value = "proposal-received")]
+        ProposalReceived,
+
+        [EnumMember(Value = "offer-sent")]
+        OfferSent,
+
+        [EnumMember(Value = "offer-received")]
+        OfferReceived,
+
+        [EnumMember(Value = "request-sent")]
+        RequestSent,
+
+        [EnumMember(Value = "request-received")]
+        RequestReceived,
+
+        [EnumMember(Value = "credential-issued")]
+        CredentialIssued,
+
+        [EnumMember(Value = "credential-received")]
+        CredentialReceived,
+
+        [EnumMember(Value = "done")]
+        Done,
+    }
+
+    public class TestHarnessCredentialExchange
+    {
+
+        [JsonProperty("thread_id")]
+        public string ThreadId;
+
+
+        [JsonProperty("credential_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string RecordId;
+
+        [JsonProperty("state")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TestHarnessCredentialExchangeState State;
+    }
+}

--- a/aries-backchannels/dotnet/server/Startup.cs
+++ b/aries-backchannels/dotnet/server/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using DotNet.Backchannel.Handlers;
 using DotNet.Backchannel.Middlewares;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Storage;
@@ -36,9 +37,12 @@ namespace DotNet.Backchannel
             // Add in memory cache to store invitations
             services.AddMemoryCache();
 
+
+
             services.AddAriesFramework(builder =>
             {
                 builder.Services.AddSingleton<IAgentMiddleware, MessageAgentMiddleware>();
+                builder.Services.AddSingleton<AATHCredentialHandler>();
 
                 builder.RegisterAgent<DotNet.Backchannel.TestAgent>(c =>
                 {

--- a/aries-backchannels/dotnet/server/TestAgent.cs
+++ b/aries-backchannels/dotnet/server/TestAgent.cs
@@ -1,5 +1,6 @@
 
 using System;
+using DotNet.Backchannel.Handlers;
 using Hyperledger.Aries.Agents;
 
 namespace DotNet.Backchannel
@@ -16,9 +17,10 @@ namespace DotNet.Backchannel
             AddConnectionHandler();
             AddTrustPingHandler();
             AddBasicMessageHandler();
-            AddCredentialHandler();
             AddProofHandler();
             AddForwardHandler();
+            // We use a custom credential handler
+            AddHandler<AATHCredentialHandler>();
         }
     }
 }

--- a/aries-backchannels/dotnet/server/appsettings.Development.json
+++ b/aries-backchannels/dotnet/server/appsettings.Development.json
@@ -3,7 +3,12 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Hyperledger": "Trace",
+      "DotNet.Backchannel": "Trace"
+    },
+    "Console": {
+      "DisableColors": true
     }
   }
 }

--- a/aries-backchannels/dotnet/server/appsettings.json
+++ b/aries-backchannels/dotnet/server/appsettings.json
@@ -3,7 +3,12 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Hyperledger": "Trace",
+      "DotNet.Backchannel": "Trace"
+    },
+    "Console": {
+      "DisableColors": true
     }
   },
   "AllowedHosts": "*"

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -37,10 +37,15 @@ tags:
     description: Agent commands related to schema topic
   - name: Credential Definition
     description: Agent commands related to credential-definition topic
+  - name: Issue Credential
+    description: Agent commands related to issue-credential topic
+  - name: Present Proof
+    description: Agent commands related to present-proof topic
 paths:
   /agent/command/status:
     get:
       summary: Get agent/backchannel status
+      operationId: StatusGet
       tags:
         - Status
       responses:
@@ -132,6 +137,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               required:
                 - data
               properties:
@@ -143,6 +149,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   connection_id:
                     $ref: "#/components/schemas/ConnectionId"
@@ -159,6 +166,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               required:
                 - id
               properties:
@@ -170,6 +178,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   connection_id:
                     $ref: "#/components/schemas/ConnectionId"
@@ -189,6 +198,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               required:
                 - id
               properties:
@@ -200,6 +210,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   connection_id:
                     $ref: "#/components/schemas/ConnectionId"
@@ -219,6 +230,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               required:
                 - id
                 - data
@@ -226,19 +238,20 @@ paths:
                 id:
                   $ref: "#/components/schemas/ConnectionId"
                 data:
+                  type: object
                   required:
                     - comment
                   properties:
                     comment:
-                      title: Comment
-                      type: string
-                      example: Hello
+                      $ref: "#/components/schemas/Comment"
+
       responses:
         200:
           description: Trust ping send
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   connection_id:
                     $ref: "#/components/schemas/ConnectionId"
@@ -260,6 +273,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   did:
                     $ref: "#/components/schemas/Did"
@@ -298,30 +312,23 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               required:
                 - data
               properties:
                 data:
-                  # TODO: combine with Schema schema
+                  type: object
                   required:
                     - schema_name
                     - schema_version
                     - attributes
                   properties:
                     schema_name:
-                      type: string
-                      example: "test_schema"
+                      $ref: "#/components/schemas/SchemaName"
                     schema_version:
-                      type: string
-                      example: "1.0.0"
+                      $ref: "#/components/schemas/SchemaVersion"
                     attributes:
-                      type: array
-                      example:
-                        - "attr_1"
-                        - "attr_2"
-                        - "attr_3"
-                      items:
-                        type: string
+                      $ref: "#/components/schemas/SchemaAttributes"
 
       responses:
         200:
@@ -329,6 +336,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   schema_id:
                     $ref: "#/components/schemas/SchemaId"
@@ -367,10 +375,12 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               required:
                 - data
               properties:
                 data:
+                  type: object
                   # TODO: combine with CredentialDefinition schema
                   required:
                     - support_revocation
@@ -395,20 +405,270 @@ paths:
                   credential_definition_id:
                     $ref: "#/components/schemas/CredentialDefinitionId"
 
+  /agent/command/issue-credential/send-proposal:
+    post:
+      tags:
+        - Issue Credential
+      summary: Send credential proposal
+      description: >
+        Send a `propose-credential` message to connection with `connection_id` in body.
+      externalDocs:
+        url: https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential#propose-credential
+      operationId: IssueCredentialSendProposal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: object
+                  required:
+                    - connection_id
+                  properties:
+                    comment:
+                      $ref: "#/components/schemas/Comment"
+                    credential_proposal:
+                      $ref: "#/components/schemas/CredentialPreview"
+                    schema_issuer_did:
+                      $ref: "#/components/schemas/Did"
+                    schema_id:
+                      $ref: "#/components/schemas/SchemaId"
+                    schema_name:
+                      $ref: "#/components/schemas/SchemaName"
+                    schema_version:
+                      $ref: "#/components/schemas/SchemaVersion"
+                    cred_def_id:
+                      $ref: "#/components/schemas/CredentialDefinitionId"
+                    issuer_did:
+                      $ref: "#/components/schemas/Did"
+                    connection_id:
+                      $ref: "#/components/schemas/ConnectionId"
+      responses:
+        200:
+          description: Credential proposal send
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: proposal-sent
+  /agent/command/issue-credential/send-offer:
+    post:
+      tags:
+        - Issue Credential
+      summary: Send credential offer
+      description: >
+        Send an `offer-credential` message.
+      externalDocs:
+        url: https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential#offer-credential
+      operationId: IssueCredentialSendOffer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              anyOf:
+                - title: Send Offer to start credential issuance flow
+                  required:
+                    - data
+                  properties:
+                    data:
+                      type: object
+                      required:
+                        - connection_id
+                        - credential_preview
+                      properties:
+                        comment:
+                          $ref: "#/components/schemas/Comment"
+                        credential_preview:
+                          $ref: "#/components/schemas/CredentialPreview"
+                        cred_def_id:
+                          $ref: "#/components/schemas/CredentialDefinitionId"
+                        connection_id:
+                          $ref: "#/components/schemas/ConnectionId"
+                - title: Send Offer in response to Proposal
+                  required:
+                    - id
+                  properties:
+                    id:
+                      $ref: "#/components/schemas/ThreadId"
+            examples:
+              new:
+                summary: Send Offer to start credential issuance flow
+                description: >
+                  When sending an offer to start the credential issuance flow, the data
+                  of the credential that is going to be issued must be passed as value to the data key.
+                value:
+                  data:
+                    comment:
+                      $ref: "#/components/schemas/Comment/example"
+                    credential_preview:
+                      $ref: "#/components/schemas/CredentialPreview/example"
+                    cred_def_id:
+                      $ref: "#/components/schemas/CredentialDefinitionId/example"
+                    connection_id:
+                      $ref: "#/components/schemas/ConnectionId/example"
+              response:
+                summary: Send Offer in response to Proposal
+                description: >
+                  When sending an offer in response to a received proposal only the
+                  thread id should be passed
+                value:
+                  id:
+                    $ref: "#/components/schemas/ThreadId/example"
+      responses:
+        200:
+          description: Credential offer send
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: offer-sent
+  /agent/command/issue-credential/send-request:
+    post:
+      tags:
+        - Issue Credential
+      summary: Send credential request
+      externalDocs:
+        url: https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential#request-credential
+      operationId: IssueCredentialSendRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - title: Send Request to start credential issuance flow
+                  required:
+                    - id
+                  properties:
+                    id:
+                      $ref: "#/components/schemas/ConnectionId"
+                - title: Send Request in response to Offer
+                  required:
+                    - id
+                  properties:
+                    id:
+                      $ref: "#/components/schemas/ThreadId"
+            examples:
+              response:
+                summary: Send Request in response to Offer
+                description: >
+                  When sending a Request in response to a received offer only the
+                  thread id should be passed
+                value:
+                  id:
+                    $ref: "#/components/schemas/ThreadId/example"
+              new:
+                summary: Send Request to start credential issuance flow
+                description: >
+                  This is not possible with Indy based credentials. TODO.
+                value:
+                  id:
+                    $ref: "#/components/schemas/ConnectionId/example"
+      responses:
+        200:
+          description: Credential request send
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: request-sent
+  /agent/command/issue-credential/issue:
+    post:
+      tags:
+        - Issue Credential
+      summary: Issue Credential
+      externalDocs:
+        url: https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential#issue-credential
+      operationId: IssueCredentialIssue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+              properties:
+                id:
+                  $ref: "#/components/schemas/ThreadId"
+                data:
+                  type: object
+                  properties:
+                    comment:
+                      $ref: "#/components/schemas/Comment"
+      responses:
+        200:
+          description: Credential issued
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: credential-issued
+  /agent/command/issue-credential/store:
+    post:
+      tags:
+        - Issue Credential
+      summary: Store Credential
+      operationId: IssueCredentialStore
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+              properties:
+                id:
+                  $ref: "#/components/schemas/ThreadId"
+      responses:
+        200:
+          description: Credential stored
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: done
+
 components:
   schemas:
     ConnectionInvitation:
       title: Connection Invitation
+      type: object
       example:
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation"
-        "@id": 11640bd1-cdc2-45e4-9fcc-43ccc27fc9d4
-        serviceEndpoint: "http://192.168.65.3:9021"
-        recipientKeys:
-          - GqQh9pLeMrE7E2ZxA47GbW4XQuLYsyd1bdfZvxLi7aZ6
-        label: aca-py
+        {
+          "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation",
+          "@id": "11640bd1-cdc2-45e4-9fcc-43ccc27fc9d4",
+          "serviceEndpoint": "http://192.168.65.3:9021",
+          "recipientKeys": ["GqQh9pLeMrE7E2ZxA47GbW4XQuLYsyd1bdfZvxLi7aZ6"],
+          "label": "aca-py",
+        }
     ConnectionId:
       title: Connection Id
       example: "8fb9ea21-d094-4506-86b6-c7c1627d753a"
+      type: string
+    ThreadId:
+      title: Thread Id
+      example: "e7280776-5315-4569-8cac-42cae108adfe"
       type: string
     SchemaId:
       title: Schema Id
@@ -431,8 +691,10 @@ components:
     Connection:
       title: Connection
       example: {}
+      type: object
     ConnectionResponse:
       title: Connection Response
+      type: object
       required:
         - connection_id
         - state
@@ -451,37 +713,131 @@ components:
       title: Verkey
       example: HymVhRozF7o9Sh9iyKXu5WKHP95YERhrpZxGx5d6WhYw
       type: string
+    Comment:
+      title: Comment
+      example: Hello World
+      type: string
+    SchemaName:
+      title: Schema Name
+      type: string
+      example: test_schema
+    SchemaVersion:
+      title: Schema Version
+      type: string
+      example: "1.0.0"
+    SchemaAttributes:
+      title: Schema Attributes
+      type: array
+      items:
+        type: string
+      example:
+        - attr_1
+        - attr_2
+        - attr_3
     Schema:
       title: Schema
       description: Schema definition
+      type: object
       # TODO: add required fields?
       example:
-        ver: "1.0"
-        id: "Y9oNbFNTgxrRuvxQk3xEzr:2:test_schema:1.0.0"
-        name: "test_schema"
-        version: "1.0.0"
-        attrNames:
-          - "attr_1"
-          - "attr_2"
-          - "attr_3"
-        seqNo: 11
+        {
+          "ver": "1.0",
+          "id": "Y9oNbFNTgxrRuvxQk3xEzr:2:test_schema:1.0.0",
+          "name": "test_schema",
+          "version": "1.0.0",
+          "attrNames": ["attr_1", "attr_2", "attr_3"],
+          "seqNo": 11,
+        }
+    CredentialPreview:
+      title: Credential Preview
+      type: object
+      required:
+        - "@type"
+        - attributes
+      properties:
+        "@type":
+          type: string
+          enum:
+            - "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview"
+          example: "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview"
+        attributes:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - value
+            properties:
+              name:
+                type: string
+              mime-type:
+                type: string
+              value:
+                type: string
+      example:
+        {
+          "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview",
+          "attributes":
+            [
+              { "name": "attr_1", "value": "value_1" },
+              { "name": "attr_2", "value": "value_2" },
+              { "name": "attr_3", "value": "value_3" },
+            ],
+        }
+
+    IssueCredentialState:
+      title: Issue Credential State
+      description: All possible issue credential state values
+      type: string
+      example: proposal-sent
+      enum:
+        - proposal-sent
+        - proposal-received
+        - offer-sent
+        - offer-received
+        - request-sent
+        - request-received
+        - credential-issued
+        - credential-received
+        - done
+
     CredentialDefinition:
       title: Credential Definition
+      type: object
       # TODO: add required fields?
       example:
-        ver: "1.0"
-        id: "TTK1F3HKKBdtb6HrhrxYtC:3:CL:12:default"
-        schemaId: "12"
-        type: CL
-        tag: default
-        value:
-          primary:
-            "n": "127473542495438147573510476102476902133854813754098957204867619522405674317018859941864352419933227338200593131633863547249552725335523634158360861379038920996404174540285309296147612235783265529767167904996672533424299318502061201785710802874714294174143582682739350240229266415073900875507216317608608419590749758007624873612987354273561597672087026667313974344205743513108098303412867935178289607206971675919540105355234142077505442787841104628317493214564810784261197466701597725036470989697050855442369151927195340336984787674149053901429543050018150008478471976322268372173725164950897146486534208375313658743913"
-            s: "65818689269823967224337061200277779392234203780958681071979765611348839168322943966737475112261896111357320138778757065891281921197440097002615498509033425652242864586741386765592821062979097745378937128174004971762786640103105629442159475365159836976073886029307851026908970994829903300109597230301114225997246242679312570675015835522760053319269527084928663538396971295690506335377466402252848447042892658905613203874434705837943677780063921041179819697545228811016183063967989936330561640506841490120102577693339579651117393959310406568508979515298779995407222937217220638869118337307458754771745779882842551583957"
-            r:
-              attr_2: "51288787261098209501918361017434738039396559240181084024072376043981733617197124422285362785531867106205259059511012989265257750815057229625776239902268148159240026351692626846471237370316944382717070664579921786642246297025320221128643932326231901994502071437080527938105845057316611594317815585962995630440264494906187392024263524589040353791190656247954182173035217728619640076109690946048473714974821555775006753553400010494644755834190135206012433445625838647683519920548605994424810625611229251495082321603992265565001261836732982193329161683683007877406661513473331737004850593281692214631901319662119982702922"
-              attr_3: "49181762688290033657446628790584551868718995111464422170653915452393747911840814545440872765372893672471205136395434982292712460522218700053539095558984733806664620823639102136028452144009159713045675694364042524060684443787233750663981609531778189390047496947791414470032823060753313065437518080235878845351585405484399614405394732610591997574454401630571733355205236989435994214291321960467589480432939966179940916409629940016780143983651757105859829934723575147299207641665320314894905208079668584551936316156492573527926041185621509809863665431708246846967753137673120991441299733316834328405117780995288938831960"
-              master_secret: "55538424482357179006904475057212929303648337854551436067860163418580875286658754309614134356521736148588690128194367442517503542151131893353616029898291001113787008415246944257559064252055726634969959428779277791311649310859911986025543178916305739383261726815449892298017969062336790138195201464646418205024584174631846494837622469674261184752618226770681209326126925275817705162548925201642177095627695920338858257041172323289863931904819081634906164566038325643344387794492965878883835475209080317985881686751050847796692787879655322665209901159744163351765059041544796505393057421762647235069315054477528853561473"
-              attr_1: "30886155743965686596111154816080405248462718126264612304549353774874576024335575570672949599223811931464968785591555429018481986959035338465010646916129018856811265590112946954474656478128827689132913637543377270592217574931365985240940393300396509940083648506176813465677576969450791064392913905672340945666537607742715770967118252787128981065813564952993994324545119742090220379288320480251447895567821617698929571634776885837657497224943766401548060195388838088667649983419151624233451714099262934942791309973082062184242430968684229937149556567677716686322793149698990735633517128615499672788711239033452193882997"
-            rctxt: "118794108011306418186599966013685417259067451572329168338986396401718511272829290486080995212827126457817056257265484527810068143652813250691318847597106924333754555635689923547896416240741937417433198117397677657367813549201117642415892893893381488036182474297804412028150810635810333104761444058436184382989414463435135399687357899136817489918140316906972132553030427022094507232967240719401668656063683319995507797481327116566453773630750501126563798296642025598222840921566196961717932895723665756200235727569096614264333988899662958311074895571782854329655460918882500227649533684869211196542823703742125337784110"
-            z: "105630626525262054412237755083369001506042501169646719098603962721650276426684319172879455142677137798560163792358891628363088368803209632822777508716551660571988904519705987074094883201485589766095616179828793397893771789008873400971460093284769835475804783847161628863255694379113641839797171437881461956336479878362639116657891310026976287218412427465483710278481629012528677992951433715775723708478290067190705706789707748967166740980626023098110954588495187304096367803794208972671801623501450811525547654409352588261071510140289955775228914918919001173412112332959725654909432886608249741918119912786853133051762"
+        {
+          "ver": "1.0",
+          "id": "TTK1F3HKKBdtb6HrhrxYtC:3:CL:12:default",
+          "schemaId": "12",
+          "type": "CL",
+          "tag": "default",
+          "value":
+            {
+              "primary":
+                {
+                  "n": "127473542495438147573510476102476902133854813754098957204867619522405674317018859941864352419933227338200593131633863547249552725335523634158360861379038920996404174540285309296147612235783265529767167904996672533424299318502061201785710802874714294174143582682739350240229266415073900875507216317608608419590749758007624873612987354273561597672087026667313974344205743513108098303412867935178289607206971675919540105355234142077505442787841104628317493214564810784261197466701597725036470989697050855442369151927195340336984787674149053901429543050018150008478471976322268372173725164950897146486534208375313658743913",
+                  "s": "65818689269823967224337061200277779392234203780958681071979765611348839168322943966737475112261896111357320138778757065891281921197440097002615498509033425652242864586741386765592821062979097745378937128174004971762786640103105629442159475365159836976073886029307851026908970994829903300109597230301114225997246242679312570675015835522760053319269527084928663538396971295690506335377466402252848447042892658905613203874434705837943677780063921041179819697545228811016183063967989936330561640506841490120102577693339579651117393959310406568508979515298779995407222937217220638869118337307458754771745779882842551583957",
+                  "r":
+                    {
+                      "attr_2": "51288787261098209501918361017434738039396559240181084024072376043981733617197124422285362785531867106205259059511012989265257750815057229625776239902268148159240026351692626846471237370316944382717070664579921786642246297025320221128643932326231901994502071437080527938105845057316611594317815585962995630440264494906187392024263524589040353791190656247954182173035217728619640076109690946048473714974821555775006753553400010494644755834190135206012433445625838647683519920548605994424810625611229251495082321603992265565001261836732982193329161683683007877406661513473331737004850593281692214631901319662119982702922",
+                      "attr_3": "49181762688290033657446628790584551868718995111464422170653915452393747911840814545440872765372893672471205136395434982292712460522218700053539095558984733806664620823639102136028452144009159713045675694364042524060684443787233750663981609531778189390047496947791414470032823060753313065437518080235878845351585405484399614405394732610591997574454401630571733355205236989435994214291321960467589480432939966179940916409629940016780143983651757105859829934723575147299207641665320314894905208079668584551936316156492573527926041185621509809863665431708246846967753137673120991441299733316834328405117780995288938831960",
+                      "master_secret": "55538424482357179006904475057212929303648337854551436067860163418580875286658754309614134356521736148588690128194367442517503542151131893353616029898291001113787008415246944257559064252055726634969959428779277791311649310859911986025543178916305739383261726815449892298017969062336790138195201464646418205024584174631846494837622469674261184752618226770681209326126925275817705162548925201642177095627695920338858257041172323289863931904819081634906164566038325643344387794492965878883835475209080317985881686751050847796692787879655322665209901159744163351765059041544796505393057421762647235069315054477528853561473",
+                      "attr_1": "30886155743965686596111154816080405248462718126264612304549353774874576024335575570672949599223811931464968785591555429018481986959035338465010646916129018856811265590112946954474656478128827689132913637543377270592217574931365985240940393300396509940083648506176813465677576969450791064392913905672340945666537607742715770967118252787128981065813564952993994324545119742090220379288320480251447895567821617698929571634776885837657497224943766401548060195388838088667649983419151624233451714099262934942791309973082062184242430968684229937149556567677716686322793149698990735633517128615499672788711239033452193882997",
+                    },
+                  "rctxt": "118794108011306418186599966013685417259067451572329168338986396401718511272829290486080995212827126457817056257265484527810068143652813250691318847597106924333754555635689923547896416240741937417433198117397677657367813549201117642415892893893381488036182474297804412028150810635810333104761444058436184382989414463435135399687357899136817489918140316906972132553030427022094507232967240719401668656063683319995507797481327116566453773630750501126563798296642025598222840921566196961717932895723665756200235727569096614264333988899662958311074895571782854329655460918882500227649533684869211196542823703742125337784110",
+                  "z": "105630626525262054412237755083369001506042501169646719098603962721650276426684319172879455142677137798560163792358891628363088368803209632822777508716551660571988904519705987074094883201485589766095616179828793397893771789008873400971460093284769835475804783847161628863255694379113641839797171437881461956336479878362639116657891310026976287218412427465483710278481629012528677992951433715775723708478290067190705706789707748967166740980626023098110954588495187304096367803794208972671801623501450811525547654409352588261071510140289955775228914918919001173412112332959725654909432886608249741918119912786853133051762",
+                },
+            },
+        }
+    IssueCredentialOperationResponse:
+      title: Issue Credential Operation Response
+      type: object
+      required:
+        - state
+        - thread_id
+      properties:
+        state:
+          $ref: "#/components/schemas/IssueCredentialState"
+        thread_id:
+          $ref: "#/components/schemas/ThreadId"

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -39,6 +39,8 @@ tags:
     description: Agent commands related to credential-definition topic
   - name: Issue Credential
     description: Agent commands related to issue-credential topic
+  - name: Credential
+    description: Agent commands realted to credential topic
   - name: Present Proof
     description: Agent commands related to present-proof topic
 paths:
@@ -405,6 +407,27 @@ paths:
                   credential_definition_id:
                     $ref: "#/components/schemas/CredentialDefinitionId"
 
+  /agent/command/issue-credential/{credentialExchangeThreadId}:
+    get:
+      tags:
+        - Issue Credential
+      summary: Get credential exchange record by thread id
+      operationId: IssueCredentialGetByThreadId
+      parameters:
+        - in: path
+          name: credentialExchangeThreadId
+          required: true
+          schema:
+            $ref: "#/components/schemas/ThreadId"
+      responses:
+        200:
+          description: Credential Exchange
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialId"
+        404:
+          description: Credential Exchange not found
   /agent/command/issue-credential/send-proposal:
     post:
       tags:
@@ -645,10 +668,43 @@ paths:
               schema:
                 allOf:
                   - $ref: "#/components/schemas/IssueCredentialOperationResponse"
-                  - properties:
+                  - required:
+                      - credential_id
+                    properties:
                       state:
                         example: done
 
+  /agent/command/credential/{credentialId}:
+    get:
+      tags:
+        - Credential
+      summary: Get credential by id
+      operationId: CredentialGetById
+      parameters:
+        - in: path
+          name: credentialId
+          required: true
+          schema:
+            $ref: "#/components/schemas/CredentialId"
+      responses:
+        200:
+          description: Credential
+          content:
+            application/json:
+              schema:
+                required:
+                  - referent
+                  - schema_id
+                  - cred_def_id
+                properties:
+                  referent:
+                    $ref: "#/components/schemas/CredentialId"
+                  schema_id:
+                    $ref: "#/components/schemas/SchemaId"
+                  cred_def_id:
+                    $ref: "#/components/schemas/CredentialDefinitionId"
+        404:
+          description: Credential not found
 components:
   schemas:
     ConnectionInvitation:
@@ -841,3 +897,9 @@ components:
           $ref: "#/components/schemas/IssueCredentialState"
         thread_id:
           $ref: "#/components/schemas/ThreadId"
+        credential_id:
+          $ref: "#/components/schemas/CredentialId"
+    CredentialId:
+      title: Credential Id
+      example: "828761d2-65e9-44a5-852e-1f60b943ab65"
+      type: string


### PR DESCRIPTION
It's getting greener and greener.

- Update connection states to match RFC
- Add issue credential / credential operations
- Add issue credential / credential openapi spec

There are some interoperability issues between .NET and ACA-Py. But I think the test framework is here to discover these. I think they should be resolved in either .NET or ACA-Py, but I would like your input on this @ianco @nodlesh @swcurran :
- ACA-Py requires the `comment` property for the propose-credential and offer-credential messages. However this is not required per the RFC. This is now handled by an empty string (`""`). Is this issue known within the ACA-Py team, or should I open an issue?
- .NET adds an `@id` in the credential proposal of the of the credential offer message. ACA-Py does not allow this. I think .NET shouldn't add the `@id` property. But from what I understand, fields that are not mentioned in the RFCs should be ignored instead of rejected. So maybe ACA-Py should also allow it? Whats your opinion? This only happens when ACA-Py is holder and .NET is issuer. So for now tests fail when .NET creates the offer (see test score below)
- .NET doesn't fully support the propose-credential message. As this is important for the tests, I now implemented this in the backchannel. The framework allows for this extension. My plan was to create a PR for the framework, but properly implementing this in the framework requires more work than I thought, so for now I'll leave it.


## All agents dotnet

`-d dotnet -t @AcceptanceTest -t ~@wip`

```
Failing scenarios:
  features/0037-present-proof.feature:18  Present Proof where the prover does not propose a presentation of the proof and is acknowledged -- @1.1
  features/0037-present-proof.feature:19  Present Proof where the prover does not propose a presentation of the proof and is acknowledged -- @1.2
  features/0037-present-proof.feature:37  Present Proof of specific types and proof is acknowledged -- @1.1
  features/0037-present-proof.feature:38  Present Proof of specific types and proof is acknowledged -- @1.2
  features/0037-present-proof.feature:56  Present Proof of specific types and proof is acknowledged -- @1.1

2 features passed, 1 failed, 0 skipped
7 scenarios passed, 5 failed, 15 skipped
96 steps passed, 5 failed, 142 skipped, 0 undefined
Took 4m11.334s
```

## All agents dotnet, Acme is ACA-Py

`-d dotnet -a acapy -t @AcceptanceTest -t ~@wip`

```
Failing scenarios:
  features/0037-present-proof.feature:18  Present Proof where the prover does not propose a presentation of the proof and is acknowledged -- @1.1
  features/0037-present-proof.feature:19  Present Proof where the prover does not propose a presentation of the proof and is acknowledged -- @1.2
  features/0037-present-proof.feature:37  Present Proof of specific types and proof is acknowledged -- @1.1
  features/0037-present-proof.feature:38  Present Proof of specific types and proof is acknowledged -- @1.2
  features/0037-present-proof.feature:56  Present Proof of specific types and proof is acknowledged -- @1.1

2 features passed, 1 failed, 0 skipped
7 scenarios passed, 5 failed, 15 skipped
96 steps passed, 5 failed, 142 skipped, 0 undefined
Took 3m10.790s
```

## All agents ACA-Py, Acme is dotnet

`-d dotnet -b acapy -t @AcceptanceTest -t ~@wip`

The issue credential tests fail because of the `@id` present in the credential preview of the credential offer. Which ACA-Py doesn't accept

```
Failing scenarios:
  features/0036-issue-credential.feature:11  Issue a credential with the Holder beginning with a proposal
  features/0036-issue-credential.feature:25  Issue a credential with the Holder beginning with a proposal with negotiation
  features/0036-issue-credential.feature:41  Issue a credential with the Issuer beginning with an offer
  features/0036-issue-credential.feature:54  Issue a credential with the Issuer beginning with an offer with negotiation
  features/0037-present-proof.feature:18  Present Proof where the prover does not propose a presentation of the proof and is acknowledged -- @1.1
  features/0037-present-proof.feature:19  Present Proof where the prover does not propose a presentation of the proof and is acknowledged -- @1.2
  features/0037-present-proof.feature:37  Present Proof of specific types and proof is acknowledged -- @1.1
  features/0037-present-proof.feature:38  Present Proof of specific types and proof is acknowledged -- @1.2
  features/0037-present-proof.feature:56  Present Proof of specific types and proof is acknowledged -- @1.1

1 feature passed, 2 failed, 0 skipped
3 scenarios passed, 9 failed, 15 skipped
67 steps passed, 9 failed, 167 skipped, 0 undefined
Took 3m59.526s
```
