### PR TITLE
Proof Request requested_values changed to attributes

### DIFF
--- a/CONFIGURE-CRED-TYPES.md
+++ b/CONFIGURE-CRED-TYPES.md
@@ -148,7 +148,7 @@ The following is an example of a simple proof request for one attribute with som
 ```
 {
    "presentation_proposal": {
-      "requested_values": {
+      "requested_attributes": {
          "address_attrs": {
             "name": "address",
             "restrictions": [
@@ -168,7 +168,7 @@ The following is an example of a proof request using more than one credential.
 {
    "presentation_proposal": {
       "name": "Health Consent Proof",
-      "requested_values": {
+      "requested_attributes": {
          "bioindicators_attrs": {
             "names": [
                "name",

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -632,10 +632,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
             if operation == "send-request":
                 
-                if data.get("presentation_proposal", {}).get("request_presentations~attach", {}).get("data", {}).get("requested_values") == None:
+                if data.get("presentation_proposal", {}).get("request_presentations~attach", {}).get("data", {}).get("requested_attributes") == None:
                     requested_attributes = {}
                 else:
-                    requested_attributes = data["presentation_proposal"]["request_presentations~attach"]["data"]["requested_values"]
+                    requested_attributes = data["presentation_proposal"]["request_presentations~attach"]["data"]["requested_attributes"]
 
                 if data.get("presentation_proposal", {}).get("request_presentations~attach", {}).get("data", {}).get("requested_predicates") == None:
                     requested_predicates = {}

--- a/aries-test-harness/features/data/proof_request_DL_address.json
+++ b/aries-test-harness/features/data/proof_request_DL_address.json
@@ -1,6 +1,6 @@
 {
    "presentation_proposal": {
-      "requested_values": {
+      "requested_attributes": {
          "address_attrs": {
             "name": "address",
             "restrictions": [

--- a/aries-test-harness/features/data/proof_request_DL_age_over_19.json
+++ b/aries-test-harness/features/data/proof_request_DL_age_over_19.json
@@ -1,6 +1,6 @@
 {
    "presentation_proposal": {
-      "requested_values": {
+      "requested_attributes": {
          "address_attrs": {
             "name": "address",
             "restrictions": [

--- a/aries-test-harness/features/data/proof_request_biological_indicator_a.json
+++ b/aries-test-harness/features/data/proof_request_biological_indicator_a.json
@@ -1,7 +1,7 @@
 {
     "presentation_proposal": {
         "name": "Biological Indicator A Proof",
-        "requested_values": {
+        "requested_attributes": {
             "bioindicators_attrs": {
                 "name": "name",
                 "restrictions": [

--- a/aries-test-harness/features/data/proof_request_biological_indicator_a_2.0.json
+++ b/aries-test-harness/features/data/proof_request_biological_indicator_a_2.0.json
@@ -1,7 +1,7 @@
 {
     "presentation_proposal": {
         "name": "Biological Indicator A Proof",
-        "requested_values": {
+        "requested_attributes": {
             "bioindicators_attrs": {
                 "names": [
                     "name"

--- a/aries-test-harness/features/data/proof_request_health_consent.json
+++ b/aries-test-harness/features/data/proof_request_health_consent.json
@@ -1,7 +1,7 @@
 {
     "presentation_proposal": {
         "name": "Health Consent Proof",
-        "requested_values": {
+        "requested_attributes": {
             "bioindicators_attrs": {
                 "names": [
                     "name",

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -118,7 +118,7 @@ def step_impl(context, verifier, prover):
         data = context.request_for_proof
     else:   
         data = {
-                    "requested_values": {
+                    "requested_attributes": {
                         "attr_1": {
                             "name": "attr_1",
                             "restrictions": [


### PR DESCRIPTION
All references to requested_values in proof requests are now called requested_attributes.

closes #87 