### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Aries Agent Test Harness: Let's Make Interoperability Boring<!-- omit in toc -->
 
-The Aries Agent Test Harness (AATH) is a [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development)-based test execution engine and set of tests for evaluating the interoperability of Aries Agents and Agent Frameworks. The tests are agnostic to the components under test but rather are designed based on   the [Aries RFCs](https://github.com/hyperledger/aries) and the interaction protocols documented there. The AATH enables the creation of an interop lab much like the [labs](https://www.iol.unh.edu/) used by the telcos when introducing new hardware into the markets&mdash;routers, switchers and the like. Aries agent and agent framework builders can easily incorporate these tests into the their CI/CD pipelines to ensure that interoperability is core to the development process.
+The Aries Agent Test Harness (AATH) is a [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development)-based test execution engine and set of tests for evaluating the interoperability of Aries Agents and Agent Frameworks. The tests are agnostic to the components under test but rather are designed based on the [Aries RFCs](https://github.com/hyperledger/aries) and the interaction protocols documented there. The AATH enables the creation of an interop lab much like the [labs](https://www.iol.unh.edu/) used by the telcos when introducing new hardware into the markets&mdash;routers, switchers and the like. Aries agent and agent framework builders can easily incorporate these tests into the their CI/CD pipelines to ensure that interoperability is core to the development process.
 
-Want to see the Aries Agent Test Harness in action?  Give it a try using using a git and bash enabled system, or run it in your browser using Play with Docker (startup instructions here).  Once you are in a bash shell, run the following commands to execute a set of RFC tests using the [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python):
+Want to see the Aries Agent Test Harness in action? Give it a try using a git and bash enabled system, or run it in your browser using Play with Docker (startup instructions here). Once you are in a bash shell, run the following commands to execute a set of RFC tests using the [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python):
 
 ```bash
 git clone https://github.com/bcgov/von-network
@@ -23,11 +23,11 @@ The commands take a while to run (you know...building modern apps always means d
 
 - The `von-network` commands are building and starting a docker-ized Hyperledger Indy network needed for some of the tests.
 - The AATH build command builds docker images for testing the ACA-Py agent framework and the test harness.
-- The AATH run command executes a set of tests (those tagged "AcceptanceTest" but not tagger "@wip") with the ACA-Py agent playing all of the roles&mdash;Acme, Bob and Mallory.
+- The AATH run command executes a set of tests (those tagged "AcceptanceTest" but not tagged "@wip") with the ACA-Py agent playing all of the roles&mdash;Acme, Bob, Faber and Mallory.
 
-It's that last part makes the AATH powerful. On every run, different AATH-enabled components can be assigned any role (Acme, Bob, Mallory and others to come, like Carol and Faber). For some initial pain (AATH-enabling a component), interoperability testing becomes routine, and we can make hit our goal: to make interoperability boring.
+It's that last part makes the AATH powerful. On every run, different AATH-enabled components can be assigned any role (Acme, Bob, Faber, Mallory and others to come, like Carol). For some initial pain (AATH-enabling a component), interoperability testing becomes routine, and we can make hit our goal: to make interoperability boring.
 
-Interesting to you?  Read on for more about the architecture, how to build tests, how to AATH-enable the Aries agents and agent frameworks that you are building and how you can run these tests on a continuous basis. For a brief set of slides covering the process and goals, check [this](https://docs.google.com/presentation/d/1tNttxlHE8iwyOr7LDOZ6VrCwh8AuINfzuI2Gl0WEld0/edit?usp=sharing) out.
+Interesting to you? Read on for more about the architecture, how to build tests, how to AATH-enable the Aries agents and agent frameworks that you are building and how you can run these tests on a continuous basis. For a brief set of slides covering the process and goals, check [this](https://docs.google.com/presentation/d/1tNttxlHE8iwyOr7LDOZ6VrCwh8AuINfzuI2Gl0WEld0/edit?usp=sharing) out.
 
 We'd love to have help in building out a full Aries interoperability lab.
 
@@ -56,8 +56,9 @@ The following diagram provides an overview of the architecture of the AATH.
 - The general roles of the test participants are:
   - Acme: an enterprise issuer/verifier
   - Bob: a holder/prover
+  - Faber: another enterprise issuer/verifier
   - Mallory: a malicious holder/prover
-  - Other roles are likely to be added, such as Carol (another holder/prover), Faber (another enterprise issuer/verifier) and perhaps even Thing (an IOT device).
+  - Other roles are likely to be added, such as Carol (another holder/prover) and perhaps even Thing (an IOT device).
 - The test harness is the Python [behave](https://behave.readthedocs.io/en/latest/) engine, with the "features" (as they are called in BDD-speak) written in [Gherkin](https://behave.readthedocs.io/en/latest/gherkin.html#gherkin-feature-testing-language) and the feature steps in Python.
 - Dockerfiles are used to package the backchannel and the component under test (an agent or agent framework) into a single container image with a pre-defined set of port mappings.
   - One of the ports is for the test harness to backchannel interface and the rest can be used as needed by the component under test and it's backchannel.
@@ -71,7 +72,7 @@ The following diagram provides an overview of the architecture of the AATH.
 There are a couple of layers of abstraction involved in the test harness architecture, and it's worth formalizing some terminology to make it easier to communicate about what's what when we are are running tests.
 
 - **Test Harness**: An engine that executes the selected tests and collects the results.
-- **Backchannel**: A piece of integration software that receives HTTP requests from the Test Harness and interacts with tanhe agent or agent framework under test to execute the requests. A backchannel is needed for each agent or agent framework. The same backchannel will likely work for multiple agent and agent framework versions and/or configurations.
+- **Backchannel**: A piece of integration software that receives HTTP requests from the Test Harness and interacts with the agent or agent framework under test to execute the requests. A backchannel is needed for each agent or agent framework. The same backchannel will likely work for multiple agent and agent framework versions and/or configurations.
 - **Components under Test (CUTs)**: external Aries agents or agent frameworks being tested.
   - The CUT might be an agent framework like aries-framework-dotnet or aries-cloudagent-python. In those cases, the backchannel is a controller that directly operates an instance of the agent framework.
   - The CUT might be a full agent; a combination of an agent framework instance and a controller. In those cases, the backchannel must be able to operate the controller, which in turn controls the agent framework. For example, a mobile agent has a user interface (a controller), perhaps with some automation rules. Its' AATH backchannel will interact with the controller, not the agent framework directly.
@@ -92,7 +93,7 @@ A further complication is that as tests are added to the test suite, the backcha
 
 Backchannels can be found in the [`aries-backchannels`](aries-backchannels) folder of this repo. For more information on building a backchannel, see the documentation in the [`aries-backchannels` README](aries-backchannels/README.md), and look at the code of the existing backchannels. To get help in building a backchannel for a component you want tested, please use GitHub issues and/or ask questions on the [Hyperledger Rocketchat](https://chat.hyperledger.org) `#aries-agent-test-harness` channel (free Linux Foundation account required).
 
-Two backchannels have been implemented, for the [ACA-PY](https://github.com/hyperledger/aries-cloudagent-python) and [VCX](https://github.com/hyperledger/indy-sdk/tree/master/vcx) Aries agent frameworks. Both are built on a common Python base (./aries-backchannels/python/aries_backchannel.py) that sets up the backchannel API listener and performs some basic request validation and dispatching. The ACA-PY (./aries-backchannels/acapy/acapy_backchannel.py) and VCX (./aries-backchannels/vcx/vcx_backchannel.py) implementations extend the base to add support for their respective agent frameworks.
+Three backchannels have been implemented, for the [ACA-PY](https://github.com/hyperledger/aries-cloudagent-python), [VCX](https://github.com/hyperledger/indy-sdk/tree/master/vcx) and [.NET](https://github.com/hyperledger/aries-framework-dotnet) Aries agent frameworks. The ACA-Py and VCX are built on a common Python base (./aries-backchannels/python/aries_backchannel.py) that sets up the backchannel API listener and performs some basic request validation and dispatching. The ACA-PY (./aries-backchannels/acapy/acapy_backchannel.py) and VCX (./aries-backchannels/vcx/vcx_backchannel.py) implementations extend the base to add support for their respective agent frameworks.
 
 ## The `manage` bash script
 

--- a/RunningLocally.md
+++ b/RunningLocally.md
@@ -2,6 +2,8 @@
 
 Note this is **not** recommended, however it may be desirable if you want to run outside of Docker containers. While this repo is in early iteration, we can only provide limited support in using this. These instructions cover what was done in initially setting up the ACA-Py and VCX backchannels before they were standardized. As such, they are included for historical purposes only, and may or may not still be accurate.
 
+> The backchannel for Aries Framework .NET only supports the standardized dockerized method for setting up backchannels. However the backchannel does support debugging the backchannel from inside the docker container, which is the most common reason for running locally. See [DEBUGGING.md](DEBUGGING.md) for more info on debugging.
+
 > We would **FAR** prefer help in being able in documenting the use of a debugger with the docker containers vs. documentation on running the test harness on bare-metal.
 
 To run each agent, install the appropriate pre-requisites (the VCX adapter requires a local install of indy-sdk and VCX) and then run as follows.

--- a/TEST_DEV_GUIDE.md
+++ b/TEST_DEV_GUIDE.md
@@ -49,9 +49,10 @@ The test cases should use the test persona as follows:
 
 - `Acme`: an enterprise agent with issuer and verifier capabilities
 - `Bob`: a holder/prover person
+- `Faber` another enterprise agent with issuer and verifier capabilities
 - `Mallory`: a malicious holder/prover person
 
-As necessary, other persona will be added. We expect adding `Carol` (another holder/prover person), `Faber` (another enterprise issuer and verifier) and perhaps `Thing` (an IOT thing, likely an issuer and verifier). Note that each additional persona requires updates to the running of tests (via the `./manage` script) and introduce operational overhead, so thought should be given before introducing new characters into the test suite.
+As necessary, other persona will be added. We expect adding `Carol` (another holder/prover person) and perhaps `Thing` (an IOT thing, likely an issuer and verifier). Note that each additional persona requires updates to the running of tests (via the `./manage` script) and introduce operational overhead, so thought should be given before introducing new characters into the test suite.
 
 ## Using Tags
 
@@ -90,10 +91,10 @@ Defining specific tags should be discussed with the Aries Protocol test communit
 
 ## Defining Backchannel Operations
 
-Defining test steps require using and extending the commands and operations to be implemented by the backchannels. The commands and operations are documented in a Google Sheet, located [here](https://bit.ly/AriesTestHarnessScenarios). As test developers add new steps to test cases, document the new operations oon which they depend in the spreadsheet. The data from the Google Sheet is available to the backchannels and are used by some to implement the backchannel capabilities. Making the data available is currently a manual process that is done using the following process:
+Defining test steps require using and extending the commands and operations to be implemented by the backchannels. The commands and operations are documented in a Google Sheet, located [here](https://bit.ly/AriesTestHarnessScenarios). All operations are also documented in an OpenAPI Spec located [here](./openapi-spec.yml). The OpenAPI spec can be viewed using [Swagger UI](https://github.com/swagger-api/swagger-ui) locally or online using a tool like [Swagger Editor](https://editor.swagger.io/). As test developers add new steps to test cases, document the new operations on which they depend in the spreadsheet and the OpenAPI spec. The data from the Google Sheet is available to the backchannels and are used by some to implement the backchannel capabilities. Making the data available is currently a manual process that is done using the following process:
 
 - prepare a branch in your fork of the repo that will be a PR
-- export the Google Sheet, saving it into this file in the repo: [steps/Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv](steps/../aries-test-harness/features/Mapping%20Aries%20Protocols%20for%20Testing%20-%20Aries%20Agent%20Test%20Scripts.csv)
+- export the Google Sheet, saving it into this file in the repo: [steps/Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv](./aries-test-harness/features/Mapping%20Aries%20Protocols%20for%20Testing%20-%20Aries%20Agent%20Test%20Scripts.csv)
 - run the command in the `aries-test-harness/steps` folder: `./genBCdata Mapping\ Aries\ Protocols\ for\ Testing\ -\ Aries\ Agent\ Test\ Scripts.csv`
   - this will replace the current data file in the `aries-backchannels/data` folder
 - submit a PR to update the file
@@ -102,7 +103,7 @@ Defining test steps require using and extending the commands and operations to b
 
 ## Implementing Test Steps
 
-Follow standard best practices for implementing test steps in Behave, writing the test steps as if the feature is fully supported and then adding code at all levels to supprt the new test. The process is something like this:
+Follow standard best practices for implementing test steps in Behave, writing the test steps as if the feature is fully supported and then adding code at all levels to support the new test. The process is something like this:
 
 - Study the RFC and define the tests needed to cover at least the happy path requirements of the RFC
   - Raise as issues in the [Aries RFCs](https://github.com/hyperledger/aries-rfcs) repo any deficiencies in the RFC
@@ -110,7 +111,7 @@ Follow standard best practices for implementing test steps in Behave, writing th
   - Add new persona only if really, really needed
 - Execute the new tests, grabbing the skeleton code for the new, unimplemented steps from the behave output, and adding them to the `steps` Python code
 - Implement the steps code, defining as needed commands and operations to be added to the backchannel interface
-- Update the Google Sheet to add the new commands and operations and regenerate the backchannel operations data file (see [subsection](#defining-backchannel-operations) above)
+- Update the Google Sheet and OpenAPI spec to add the new commands and operations and regenerate the backchannel operations data file (see [subsection](#defining-backchannel-operations) above)
 - If you are also responsible for implementing one or more backchannels, extend the backchannel(s) to support the new commands and operations
 - Notify the community of backchannel maintainers of the new tests, commands and operations
 
@@ -123,3 +124,4 @@ See the [README](../aries-agent-test-harness/aries-backchannels/README.md) in th
 ## Diving Deeper
 - [Accessing Connection ID in Test Code](ACCESS-CONNECTION-IDS.md)
 - [Configuring Tests with Credential Types and Proofs](CONFIGURE-CRED-TYPES.md)
+- [Debugging a Backchannel Running Inside a Docker Contaiener](DEBUGGING.md)

--- a/aries-backchannels/README.md
+++ b/aries-backchannels/README.md
@@ -20,13 +20,15 @@ Once you have the backchannel, you need to define one or more docker files to cr
 
 The test harness interacts with each backchannel using a small set of standard set of web services. Endpoints are here:
 
-- POST /agent/command/{topic}/
+- POST /agent/command/{topic}/{operation}
 - GET /agent/command/{topic}/
 - GET /agent/command/{topic}/{id}
 
 That's all of the endpoints your agent has to handle. Of course, your backchannel also has to be able to communicate
 with the CUT (the agent or agent framework being tested). Likely that means being able to generate requests to the
 CUT (mostly based on requests from the endpoints above) and monitor events from the CUT.
+
+See the OpenAPI definition located [here](../openapi-spec.yml) for an overview of all current topics and operations.
 
 ### Standard Backchannel Topics and Operations
 
@@ -43,6 +45,8 @@ Although the number of endpoints is small, the number of topic and operation par
 The Google Sheet data can help guide the implementation of the backchannel, providing a to do list of operations to handle. As well, a code-friendly version of the data from the spreadsheet is made available in the docker image of the Test Agent as the file `backchannel_operations.csv`. We recommend that in writing a backchannel, any `Not Implemented` commands and operations return an HTTP `501` result code ("Not Implemented")and dump the data related to the operation from the `backchannel_operations.csv` to the console to help guide the work to be done in implementing the operation in the backchannel.
 
 Support for testing new protocols will extend the data file with additional `topics` and related `operations`, adding to the workload of the backchannel maintainer.
+
+As mentioned above there is also an OpenAPI definition [available](../openapi-spec.yml) that contains all current topics and operations. When setting up the API of your backchannel this can be helpful to know what parameters the ATTH client will send with each operation, and what parameters it expects in return.
 
 ### Backchannel/Agent Interaction
 
@@ -68,7 +72,7 @@ The following lists the requirements for building AATH compatible docker images:
   - The lowest port number is passed to the TA on startup and is used by the test harness to send HTTP requests to the running TA.
   - The next nine higher ports are exposed across the docker network and can be used as needed by the TA.
 
-Examples are provided for aca-py [(`Dockerfile.acapy`)](acapy/Dockerfile.acapy) and VCX [(`Dockerfile.vcx`)](vcx/Dockerfile.vcx).
+Examples are provided for aca-py [(`Dockerfile.acapy`)](acapy/Dockerfile.acapy), VCX [(`Dockerfile.vcx`)](vcx/Dockerfile.vcx) and .NET [(`Dockerfile.dotnet`)](dotnet/Dockerfile.dotnet).
 
 ### `./manage` Script Integration
 

--- a/aries-backchannels/dotnet/Dockerfile.dotnet-master
+++ b/aries-backchannels/dotnet/Dockerfile.dotnet-master
@@ -1,0 +1,21 @@
+# Final image needs indy
+FROM streetcred/dotnet-indy:1.15.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+
+WORKDIR /
+RUN git clone https://github.com/hyperledger/aries-framework-dotnet.git
+
+WORKDIR /src
+
+COPY dotnet/server/DotNet.Backchannel.Master.csproj ./DotNet.Backchannel.Master.csproj
+RUN dotnet restore "DotNet.Backchannel.Master.csproj"
+
+COPY dotnet/server .
+RUN dotnet publish "DotNet.Backchannel.Master.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "DotNet.Backchannel.Master.dll"]

--- a/aries-backchannels/dotnet/server/Controllers/AgentStatusController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/AgentStatusController.cs
@@ -9,7 +9,8 @@ namespace DotNet.Backchannel.Controllers
         [HttpGet]
         public IActionResult AgentStatus()
         {
-            // TODO: check whether agent is active
+            // NOTE: Because the agent runs inside the backchannel (not separate processes)
+            // The agent is active as long as the backchannel is active
             var active = true;
 
             if (active) return Ok(new { status = "active" });

--- a/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/CredentialDefinitionController.cs
@@ -57,11 +57,10 @@ namespace DotNet.Backchannel.Controllers
             // Needed to construct credential definition id
             var schema = JObject.Parse(await _schemaService.LookupSchemaAsync(context, schemaId));
             var schemaSeqNo = (string)schema["seqNo"];
-            var signatureType = "CL"; // TODO: can we make this variable?
 
             // The test client sends multiple create credential definition requests with
             // the same parameters. First check whether the credential definition already exists.
-            var credentialDefinitionId = $"{issuer.IssuerDid}:3:{signatureType}:{schemaSeqNo}:{tag}";
+            var credentialDefinitionId = $"{issuer.IssuerDid}:3:CL:{schemaSeqNo}:{tag}";
             var credentialDefinitionString = await this.LookupCredentialDefinitionByIdAsync(credentialDefinitionId);
 
             // If the credential defintion doesn't already exists, create it

--- a/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
@@ -93,7 +93,7 @@ namespace DotNet.Backchannel.Controllers
         [HttpPost("send-request")]
         public async Task<IActionResult> SendPresentationRequestAsync(OperationBody body)
         {
-            // TODO: AATH doesn't yet support presentation request as response to other message
+            // NOTE: AATH can only start from presentation request, not respond to previous message
             var context = await _agentContextProvider.GetContextAsync();
 
             var presentationRequest = body.Data;
@@ -114,7 +114,7 @@ namespace DotNet.Backchannel.Controllers
 
             var (requestPresentationMessage, proofRecord) = await _proofService.CreateRequestAsync(context, proofRequest, connectionId);
 
-            var connection = await _connectionService.GetAsync(context, connectionId); // TODO: Handle AriesFrameworkException if connection not found
+            var connection = await _connectionService.GetAsync(context, connectionId);
 
             var THPresentationExchange = new TestHarnessPresentationExchange
             {
@@ -174,7 +174,6 @@ namespace DotNet.Backchannel.Controllers
 
             if (!isValid)
             {
-                // TODO: properly handle invalid proof
                 return Problem("Proof is not valid");
             }
 

--- a/aries-backchannels/dotnet/server/DotNet.Backchannel.Master.csproj
+++ b/aries-backchannels/dotnet/server/DotNet.Backchannel.Master.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\aries-framework-dotnet\src\Hyperledger.Aries.AspNetCore\Hyperledger.Aries.AspNetCore.csproj">
+      <GlobalPropertiesToRemove></GlobalPropertiesToRemove>
+    </ProjectReference>
+    <ProjectReference Include="..\aries-framework-dotnet\src\Hyperledger.Aries\Hyperledger.Aries.csproj">
+      <GlobalPropertiesToRemove></GlobalPropertiesToRemove>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
+++ b/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hyperledger.Aries" Version="1.2.14" />
-    <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.2.14" />
+    <PackageReference Include="Hyperledger.Aries" Version="1.3.3" />
+    <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.3.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
   </ItemGroup>

--- a/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
+++ b/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Hyperledger.Aries" Version="1.2.14" />
     <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.2.14" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
   </ItemGroup>
 
 </Project>

--- a/aries-backchannels/dotnet/server/Middlewares/MessageMiddleware.cs
+++ b/aries-backchannels/dotnet/server/Middlewares/MessageMiddleware.cs
@@ -30,7 +30,6 @@ namespace DotNet.Backchannel.Middlewares
             // received trust ping comes from the connection we send the connection response to.
             // For this reason we handle this specific case through a middleware where we do have the
             // connection from which the trust ping message came
-            // TODO: should we also move the other events to here, or should we keep it as is for the rest?
             if (messageContext.GetMessageType() == MessageTypes.TrustPingMessageType)
             {
                 var message = messageContext.GetMessage<TrustPingMessage>();
@@ -42,6 +41,8 @@ namespace DotNet.Backchannel.Middlewares
                     THConnection.State = TestHarnessConnectionState.Complete;
                 }
             }
+            // When we receive a request presentation message we need to create a TestHarnessPresentationExchange and
+            // store it in the cache for future use. This allow us to keep track of the current state of the presentation exchange
             else if (messageContext.GetMessageType() == MessageTypes.PresentProofNames.RequestPresentation)
             {
                 var message = messageContext.GetMessage<RequestPresentationMessage>();


### PR DESCRIPTION
- Add `dotnet-master` to run backchannel with master branch of framework .NET
- Update the framework to the latest release for the normal `dotnet` backchannel
- Update documentation a bit to mention OpenAPI and .NET backchannel
- Some general cleanup and improvements.

Test scores are the same