### PR TITLE
Test Coverage Matrix documented for AIP 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-# Aries Agent Test Harness: Let's Make Interoperability Boring<!-- omit in toc -->
+# Aries Agent Test Harness: Smashing Complexity in Interoperability Testing<!-- omit in toc -->
 
 The Aries Agent Test Harness (AATH) is a [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development)-based test execution engine and set of tests for evaluating the interoperability of Aries Agents and Agent Frameworks. The tests are agnostic to the components under test but rather are designed based on the [Aries RFCs](https://github.com/hyperledger/aries) and the interaction protocols documented there. The AATH enables the creation of an interop lab much like the [labs](https://www.iol.unh.edu/) used by the telcos when introducing new hardware into the markets&mdash;routers, switchers and the like. Aries agent and agent framework builders can easily incorporate these tests into the their CI/CD pipelines to ensure that interoperability is core to the development process.
 
@@ -172,3 +172,6 @@ or all the ExceptionTests...
 To read more on how one can control the execution of test sets based on tags see the [behave documentation](https://behave.readthedocs.io/en/stable/tutorial.html#controlling-things-with-tags)
 
 The option `-i <inifile>` can be used to pass a file in the `behave.ini` format into behave. With that, any behave configuration settings can be specified to control how behave behaves. See the behave documentation about the `behave.ini` configuration file [here](https://behave.readthedocs.io/en/stable/behave.html#configuration-files).
+
+### Test Coverage
+To read about what protocols and features from Aries Interop Profile 1.0, see the [Test Coverage Matrix](./TEST-COVERAGE.md). 

--- a/TEST-COVERAGE.md
+++ b/TEST-COVERAGE.md
@@ -1,0 +1,68 @@
+# Aries Agent Test Harness: Test Coverage
+The following test coverage is as of September 1, 2020. 
+
+**AIP 1.0 Status:** 
+
+ - Full Coverage of Positive Test Scenarios
+ - Minimal Coverage of Exception and Negative Test Scenarios
+
+**Terminology**
+*Directly Tested*: There is a Test Scenario that has it as it's goal to test that protocol feature.
+*Tested as Inclusion*: The Test Scenario's focus is not on this test case however it uses all or portions of other tests that use the protocol feature.
+*Tested Indicrectly*: The Test Scenario is testing a Protocol that is using, as part of it's operations, another protocol. 
+
+The  [Google Sheets Version of Coverage Matrix](https://docs.google.com/spreadsheets/d/175TOl6O_S6fOq403x0781N2YX5ZuPKXqKz5RR7Bunq0/edit?usp=sharing) is also made available for better viewing.
+
+|   |  |  |  |  | **Tested Indirectly** | **Tested Indirectly** | **Tested Indirectly** | **Tested Indirectly** |
+| :---: | :---: | :---: | :---: | :---: | :---: | --- | --- | --- |
+|  **RFC** | **Feature Variation** | **Test Type(s)** | **Directly Tested** | **Tested as Inclusion** | [**RFC0056 Service Decorator**](https://github.com/hyperledger/aries-rfcs/tree/master/features/0056-service-decorator) | [**RFC0035 Report Problem**](https://github.com/hyperledger/aries-rfcs/tree/master/features/0035-report-problem) | [**RFC0025 DIDComm Transports**](https://github.com/hyperledger/aries-rfcs/tree/master/features/0025-didcomm-transports) | [**RFC0015 Acks**](https://github.com/hyperledger/aries-rfcs/tree/master/features/0015-acks) |
+|  [RFC0160 - Connection Protocol](https://github.com/hyperledger/aries-rfcs/tree/master/features/0160-connection-protocol) | Establish Connection w/ Trust Ping | Functional | T001-AIP10-RFC0160 | T001-AIP10-RFC0036 |  |  | X |  |
+|   |  |  |  | T002-AIP10-RFC0036 |  |  | X |  |
+|   |  |  |  | T003-AIP10-RFC0036 |  |  | X |  |
+|   |  |  |  | T004-AIP10-RFC0036 |  |  | X |  |
+|   |  |  |  | T001-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T001.2-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T001.3-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T001.4-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T002-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T003-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T003.1-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T006-AIP10-RFC0037 |  |  | X |  |
+|   | Establish Connection w/ Acks | Functional |  |  |  |  | X |  |
+|   | Establish Connection Reversed Roles | Functional | T001.2-AIP10-RFC0160 |  |  |  | X |  |
+|   | Establish Connection final acknowledgment comes from inviter | Functional | T002-AIP10-RFC0160 |  |  |  | X |  |
+|   | Establish Connection Single Use Invite | Functional, Exception | T003-AIP10-RFC0160 |  |  |  | X |  |
+|   |  |  | T004-AIP10-RFC0160 |  |  |  | X |  |
+|   | Establish Connection Mult Use Invite | Functional | T005-AIP10-RFC0160 (wip) |  |  |  | X |  |
+|   | Establish Multiple Connections Between the Same Agents | Functional | T006-AIP10-RFC0160 |  |  |  | X |  |
+|   | Establish Connection Single Try on Exception | Funtional, Exception | T007-AIP10-RFC0160 (wip) |  |  | X | X |  |
+|  [RFC0036 - Issue Credential](https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential) | Issue Credential Start w/ Proposal | Functional | T001-AIP10-RFC0036 | T001-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T001.2-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T001.3-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T001.4-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T002-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T003-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T003.1-AIP10-RFC0037 |  |  | X |  |
+|   |  |  |  | T006-AIP10-RFC0037 |  |  | X |  |
+|   | Issue Credential Negotiated w/ Proposal | Functional | T002-AIP10-RFC0036 |  |  |  | X |  |
+|   | Issue Credential Start w/ Offer | Functional | T003-AIP10-RFC0036 |  |  |  | X |  |
+|   | Issue Credential w/ Offer w/ Negotiation | Functional | T004-AIP10-RFC0036 |  |  |  | X |  |
+|   | Issue Credential Start w/ Request w/ Negotiation | Functional | T005-AIP10-RFC0036 (wip) |  |  |  | X |  |
+|   | Issue Credential Start w/ Request | Functional | T006-AIP10-RFC0036 (wip) |  |  |  | X |  |
+|  [RFC0037 - Present Proof](https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential) | Present Proof w/o Proposal, Verifier is not the Issuer, 1 Cred Type | Functional | T001-AIP10-RFC0037 |  |  |  | X | X |
+|   |  |  | T001.2-AIP10-RFC0037 |  |  |  | X | X |
+|   |  |  | T001.3-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/o Proposal, Verifier is the Issuer, 1 Cred Type | Functional | T001-AIP10-RFC0037 |  |  |  | X | X |
+|   |  |  | T001.2-AIP10-RFC0037 |  |  |  | X | X |
+|   |  |  | T001.3-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/o Proposal, Verifier is the Issuer, Multi Cred Types | Functional | T001.4-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/o Proposal, Verifier is not the Issuer, Multi Cred Types | Functional | T001.4-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof Connectionless w/o Proposal | Functional | T002-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/ Proposal as Response to a Request w/ Same Cred Type Different Attribute, Verifier is the Issuer | Functional | T003-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/ Proposal as Response to a Request w/ Same Cred Type Different Attribute, Verifier is not the Issuer | Functional | T003-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/ Proposal as Response to a Request w/ Different Cred Type, Verifier is the Issuer | Functional | T003.1-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof w/ Proposal as Response to a Request w/ Different Cred Type, Verifier is not the Issuer | Functional | T003.1-AIP10-RFC0037 |  |  |  | X | X |
+|   | Present Proof Connectionless w/ Proposal, Verifier is the Issuer | Functional | T004-AIP10-RFC0037 (wip) |  | X |  | X | X |
+|   | Present Proof Connectionless w/ Proposal, Verifier is not the Issuer | Functional | T004-AIP10-RFC0037 (wip) |  | X |  | X | X |
+|   | Present Proof w/o Proposal, Verifier Rejects Presentation | Functional, Exception | T005-AIP10-RFC0037 (wip) |  |  | X | X |  |
+|   | Present Proof Start w/ Proposal | Functional | T006-AIP10-RFC0037 |  |  |  | X | X |


### PR DESCRIPTION
Added the Test Coverage Matrix for AIP 1.0. There is a pointer to it in the Main README. Also changed the README title.