### PR TITLE
add rfc tags to features

### DIFF
--- a/aries-test-harness/features/0036-issue-credential.feature
+++ b/aries-test-harness/features/0036-issue-credential.feature
@@ -7,7 +7,7 @@ Feature: Aries agent issue credential functions RFC 0036
     Then "Acme" has an existing schema
     And "Acme" has an existing credential definition
 
-  @T001-AIP10-RFC0036 @AcceptanceTest @P1 @Indy
+  @T001-AIP10-RFC0036 @AcceptanceTest @P1 @Indy @RFC0036
   Scenario: Issue a credential with the Holder beginning with a proposal
     Given "2" agents
       | name  | role   |
@@ -21,7 +21,7 @@ Feature: Aries agent issue credential functions RFC 0036
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T002-AIP10-RFC0036 @AcceptanceTest @P2 @Indy
+  @T002-AIP10-RFC0036 @AcceptanceTest @P2 @Indy @RFC0036
     Scenario: Issue a credential with the Holder beginning with a proposal with negotiation
     Given "2" agents
       | name  | role   |
@@ -37,7 +37,7 @@ Feature: Aries agent issue credential functions RFC 0036
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
   
-  @T003-AIP10-RFC0036 @AcceptanceTest @P1 @Indy
+  @T003-AIP10-RFC0036 @AcceptanceTest @P1 @Indy @RFC0036
   Scenario: Issue a credential with the Issuer beginning with an offer
     Given "2" agents
       | name  | role   |
@@ -50,7 +50,7 @@ Feature: Aries agent issue credential functions RFC 0036
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T004-AIP10-RFC0036 @AcceptanceTest @P2 @Indy
+  @T004-AIP10-RFC0036 @AcceptanceTest @P2 @Indy @RFC0036
   Scenario: Issue a credential with the Issuer beginning with an offer with negotiation
     Given "2" agents
       | name  | role   |
@@ -65,7 +65,7 @@ Feature: Aries agent issue credential functions RFC 0036
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T005-AIP10-RFC0036 @wip @AcceptanceTest @P3
+  @T005-AIP10-RFC0036 @wip @AcceptanceTest @P3 @RFC0036
   Scenario: Issue a credential with negotiation beginning from a credential request
     Given "2" agents
       | name  | role   |
@@ -80,7 +80,7 @@ Feature: Aries agent issue credential functions RFC 0036
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T006-AIP10-RFC0036 @wip @AcceptanceTest @P1
+  @T006-AIP10-RFC0036 @wip @AcceptanceTest @P1 @RFC0036
   Scenario: Issue a credential with the Holder beginning with a request and is accepted
     Given "2" agents
       | name  | role   |

--- a/aries-test-harness/features/0037-present-proof.feature
+++ b/aries-test-harness/features/0037-present-proof.feature
@@ -1,6 +1,6 @@
 Feature: Aries agent present proof functions RFC 0037
 
-   @T001-AIP10-RFC0037 @P1 @AcceptanceTest @Indy
+   @T001-AIP10-RFC0037 @P1 @AcceptanceTest @Indy @RFC0037
    Scenario Outline: Present Proof where the prover does not propose a presentation of the proof and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -19,7 +19,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Faber  |
 
 
-   @T001.2-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_DriversLicense @Indy
+   @T001.2-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_DriversLicense @Indy @RFC0037
    Scenario Outline: Present Proof of specific types and proof is acknowledged
       Given "2" agents
          | name  | role     |
@@ -38,7 +38,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Faber  | Data_DL_MinValues | proof_request_DL_age_over_19 | presentation_DL_age_over_19 |
 
 
-   @T001.3-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_Biological_Indicators @Indy
+   @T001.3-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_Biological_Indicators @Indy @RFC0037
    Scenario Outline: Present Proof of specific types and proof is acknowledged
       Given "2" agents
          | name  | role     |
@@ -55,7 +55,7 @@ Feature: Aries agent present proof functions RFC 0037
          | issuer | credential_data          | request for proof                    | presentation                        |
          | Acme   | Data_BI_NormalizedValues | proof_request_biological_indicator_a | presentation_biological_indicator_a |
 
-   @T001.4-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_Biological_Indicators @Schema_Health_Consent @Indy
+   @T001.4-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_Biological_Indicators @Schema_Health_Consent @Indy @RFC0037
    Scenario Outline: Present Proof of specific types and proof is acknowledged
       Given "2" agents
          | name  | role     |
@@ -73,7 +73,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Faber  | Data_BI_HealthValues | proof_request_health_consent | presentation_health_consent |
 
    # See issue #90 for when work on this test will resume - https://app.zenhub.com/workspaces/von---verifiable-organization-network-5adf53987ccbaa70597dbec0/issues/bcgov/aries-agent-test-harness/90
-   @T002-AIP10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview @Indy
+   @T002-AIP10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview @Indy @RFC0037
    Scenario Outline: Present Proof where the prover and verifier are connectionless, the prover does not propose a presentation of the proof, and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -90,7 +90,7 @@ Feature: Aries agent present proof functions RFC 0037
          | issuer |
          | Acme   |
 
-   @T003-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_DriversLicense @Indy
+   @T003-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_DriversLicense @Indy @RFC0037
    Scenario Outline: Present Proof where the prover has proposed the presentation of proof in response to a presentation request and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -110,7 +110,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Acme   | Data_DL_MaxValues | proof_request_DL_address     | proposal_DL_age_over_19 | proof_request_DL_age_over_19     | presentation_DL_age_over_19 |
          | Faber  | Data_DL_MinValues | proof_request_DL_age_over_19 | proposal_DL_address     | proof_request_DL_address         | presentation_DL_address     |
 
-   @T003.1-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_DriversLicense @Schema_Health_ID @Indy
+   @T003.1-AIP10-RFC0037 @P1 @AcceptanceTest @Schema_DriversLicense @Schema_Health_ID @Indy @RFC0037
    Scenario Outline: Present Proof where the prover has proposed the presentation of proof from a different credential in response to a presentation request and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -131,7 +131,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Faber  | Data_HealthID_NormalizedValues | proof_request_Health_ID_Num | proposal_DL_address    | proof_request_DL_address         | presentation_DL_address    |
 
    # See issue #90 for when work on this test will resume - https://app.zenhub.com/workspaces/von---verifiable-organization-network-5adf53987ccbaa70597dbec0/issues/bcgov/aries-agent-test-harness/90
-   @T004-AIP10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview
+   @T004-AIP10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview @RFC0037
    Scenario Outline: Present Proof where the verifier and prover are connectionless, prover has proposed the presentation of proof, and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -151,7 +151,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Acme   |
          | Faber  |
 
-   @T005-AIP10-RFC0037 @AcceptanceTest @ExceptionTest @P2 @Schema_DriversLicense @Indy @wip @NeedsReview
+   @T005-AIP10-RFC0037 @AcceptanceTest @ExceptionTest @P2 @Schema_DriversLicense @Indy @wip @NeedsReview @RFC0037
    Scenario Outline: Present Proof where the verifier rejects the presentation of the proof
       Given "2" agents
          | name  | role     |
@@ -169,7 +169,7 @@ Feature: Aries agent present proof functions RFC 0037
          | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_age_over_19 |
 
 
-   @T006-AIP10-RFC0037 @P3 @AcceptanceTest @Schema_Health_ID @Indy
+   @T006-AIP10-RFC0037 @P3 @AcceptanceTest @Schema_Health_ID @Indy @RFC0037
    Scenario Outline: Present Proof where the prover starts with a proposed the presentation of proof and is acknowledged
       Given "2" agents
          | name  | role     |

--- a/aries-test-harness/features/0160-connection.feature
+++ b/aries-test-harness/features/0160-connection.feature
@@ -1,6 +1,6 @@
 Feature: Aries agent connection functions RFC 0160
 
-   @T001-AIP10-RFC0160 @P1 @AcceptanceTest
+   @T001-AIP10-RFC0160 @P1 @AcceptanceTest @RFC0160
    Scenario Outline: establish a connection between two agents
       Given we have "2" agents
          | name  | role    |
@@ -22,7 +22,7 @@ Feature: Aries agent connection functions RFC 0160
                         # implemented trustping which is not part of the AIP 1.0. The acks is removed here in favor of trustping until the RFC is changed or
                         # the agents under test implement acks.
 
-   @T001.2-AIP10-RFC0160 @P1 @AcceptanceTest
+   @T001.2-AIP10-RFC0160 @P1 @AcceptanceTest @RFC0160
    Scenario Outline: establish a connection between two agents with role reversal
       Given we have "2" agents
          | name  | role    |
@@ -45,7 +45,7 @@ Feature: Aries agent connection functions RFC 0160
                         # the agents under test implement acks.
 
 
-   @T002-AIP10-RFC0160 @P1 @AcceptanceTest
+   @T002-AIP10-RFC0160 @P1 @AcceptanceTest @RFC0160
    Scenario Outline: Connection established between two agents but inviter sends next message to establish full connection state
       Given we have "2" agents
          | name  | role    |
@@ -68,7 +68,7 @@ Feature: Aries agent connection functions RFC 0160
                         # the agents under test implement acks.
 
 
-   @T003-AIP10-RFC0160 @SingleUseInvite @P2 @ExceptionTest @WillFail @OutstandingBug..418..https://github.com/hyperledger/aries-cloudagent-python/issues/418
+   @T003-AIP10-RFC0160 @SingleUseInvite @P2 @ExceptionTest @WillFail @OutstandingBug..418..https://github.com/hyperledger/aries-cloudagent-python/issues/418 @RFC0160
    Scenario: Inviter Sends invitation for one agent second agent tries after connection
       Given we have "3" agents
          | name    | role              |
@@ -85,7 +85,7 @@ Feature: Aries agent connection functions RFC 0160
       When "Mallory" sends a connection request to "Acme" based on the connection invitation
       Then "Acme" sends a request_not_accepted error
 
-   @T004-AIP10-RFC0160 @SingleUseInvite @P2 @ExceptionTest @WillFail @OutstandingBug..418..https://github.com/hyperledger/aries-cloudagent-python/issues/418
+@T004-AIP10-RFC0160 @SingleUseInvite @P2 @ExceptionTest @WillFail @OutstandingBug..418..https://github.com/hyperledger/aries-cloudagent-python/issues/418 @RFC0160
    Scenario: Inviter Sends invitation for one agent second agent tries during first share phase
       Given we have "3" agents
          | name    | role              |
@@ -98,7 +98,7 @@ Feature: Aries agent connection functions RFC 0160
       When "Mallory" sends a connection request to "Acme" based on the connection invitation
       Then "Acme" sends a request_not_accepted error
 
-   @T005-AIP10-RFC0160 @MultiUseInvite @P3 @DerivedFunctionalTest @NeedsReview @wip
+   @T005-AIP10-RFC0160 @MultiUseInvite @P3 @DerivedFunctionalTest @NeedsReview @wip @RFC0160
    Scenario: Inviter Sends invitation for multiple agents
       Given we have "3" agents
          | name    | role              |
@@ -115,7 +115,7 @@ Feature: Aries agent connection functions RFC 0160
    #And "Acme" and "Bob" are able to complete the connection
    #And "Acme" and "Mallory" are able to complete the connection
 
-   @T006-AIP10-RFC0160 @P4 @DerivedFunctionalTest
+   @T006-AIP10-RFC0160 @P4 @DerivedFunctionalTest @RFC0160
    Scenario: Establish a connection between two agents who already have a connection initiated from invitee
       Given we have "2" agents
          | name  | role    |
@@ -126,7 +126,7 @@ Feature: Aries agent connection functions RFC 0160
       And "Bob" and "Acme" complete the connection process
       Then "Acme" and "Bob" have another connection
 
-   @T007-AIP10-RFC0160 @P2 @ExceptionTest @SingleTryOnException @NeedsReview @wip
+   @T007-AIP10-RFC0160 @P2 @ExceptionTest @SingleTryOnException @NeedsReview @wip @RFC0160
    Scenario Outline: Establish a connection between two agents but gets a request not accepted report problem message
       Given we have "2" agents
          | name  | role    |


### PR DESCRIPTION
This PR adds the RFC tag to all scenarios. This allows to run all tests related to one RFC. I couldn't get it to work with the current tags and wildcards (e.g. `@*-RFC0160`) but If this is already possible with the current tags, please let me know.

example:
```sh
./manage run -d javascript -b acapy -t @AcceptanceTest -t ~@wip -t @RFC0160
```