### PR TITLE
Clarified how to use the default behave.ini with manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ There are two ways to control the behave test engine's selection of test cases t
 
 > Note that the `<tag>` arguments passed in on the command line **cannot** have a space, even if you double-quote the tag or escape the space. This is because the args are going through multiple layers shells (the script, calling docker, calling a script in the docker instance that in turn calls behave...). In all that argument passing, the wrappers around the args get lost. That should be OK in most cases, but if it is a problem, we have the `-i` option as follows...
 
-To enable full control over behave's behaviour (if you will...), the `-i <ini file>` option can be used to pass a behave "ini" format file into the test harness container. The ini file enables full control over the behave engine, add handles the shortcoming of not being able to pass tags arguments with spaces in them. See the behave configuration file options [here](https://behave.readthedocs.io/en/stable/behave.html#configuration-files). Note that the file name can be whatever you want. When it lands in the test harness container, it will be called `behave.ini`.
+To enable full control over behave's behaviour (if you will...), the `-i <ini file>` option can be used to pass a behave "ini" format file into the test harness container. The ini file enables full control over the behave engine, add handles the shortcoming of not being able to pass tags arguments with spaces in them. See the behave configuration file options [here](https://behave.readthedocs.io/en/stable/behave.html#configuration-files). Note that the file name can be whatever you want. When it lands in the test harness container, it will be called `behave.ini`. The default ini file is located in `aries-agent-test-harness/aries-test-harness/behave.ini`. To run the tests with the default behave.ini,
+ ```
+ ./manage run -d acapy -t @AcceptanceTest -t ~@wip -i aries-test-harness/behave.ini
+ ```
 
 For a full inventory of tests available to run, use the `./manage tests`. Note that tests in the list tagged @wip are works in progress and should not run.
 

--- a/aries-test-harness/behave.ini
+++ b/aries-test-harness/behave.ini
@@ -1,4 +1,7 @@
 # -- FILE: behave.ini
+[behave]
+#include_re=0036-issue-credential.feature
+
 [behave.userdata]
 # these should be set dynamically, when running under Docker
 #Acme = http://localhost:8020


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Updated the documentation to make it clear how to use the default behave.ini with the ./manage script.
Also added a section and a line to the behave.ini file to show how to restrict test execution to one feature file. 