### PR TITLE
Clarification on how to use default behave.ini with docker manage & DeIndyisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ There are two ways to control the behave test engine's selection of test cases t
 
 > Note that the `<tag>` arguments passed in on the command line **cannot** have a space, even if you double-quote the tag or escape the space. This is because the args are going through multiple layers shells (the script, calling docker, calling a script in the docker instance that in turn calls behave...). In all that argument passing, the wrappers around the args get lost. That should be OK in most cases, but if it is a problem, we have the `-i` option as follows...
 
-To enable full control over behave's behaviour (if you will...), the `-i <ini file>` option can be used to pass a behave "ini" format file into the test harness container. The ini file enables full control over the behave engine, add handles the shortcoming of not being able to pass tags arguments with spaces in them. See the behave configuration file options [here](https://behave.readthedocs.io/en/stable/behave.html#configuration-files). Note that the file name can be whatever you want. When it lands in the test harness container, it will be called `behave.ini`.
+To enable full control over behave's behaviour (if you will...), the `-i <ini file>` option can be used to pass a behave "ini" format file into the test harness container. The ini file enables full control over the behave engine, add handles the shortcoming of not being able to pass tags arguments with spaces in them. See the behave configuration file options [here](https://behave.readthedocs.io/en/stable/behave.html#configuration-files). Note that the file name can be whatever you want. When it lands in the test harness container, it will be called `behave.ini`. The default ini file is located in `aries-agent-test-harness/aries-test-harness/behave.ini`. To run the tests with the default behave.ini,
+ ```
+ ./manage run -d acapy -t @AcceptanceTest -t ~@wip -i aries-test-harness/behave.ini
+ ```
 
 For a full inventory of tests available to run, use the `./manage tests`. Note that tests in the list tagged @wip are works in progress and should not run.
 

--- a/aries-test-harness/behave.ini
+++ b/aries-test-harness/behave.ini
@@ -1,4 +1,7 @@
 # -- FILE: behave.ini
+[behave]
+#include_re=0036-issue-credential.feature
+
 [behave.userdata]
 # these should be set dynamically, when running under Docker
 #Acme = http://localhost:8020

--- a/aries-test-harness/features/0036-issue-credential.feature
+++ b/aries-test-harness/features/0036-issue-credential.feature
@@ -2,10 +2,7 @@ Feature: Aries agent issue credential functions RFC 0036
 
   Background: create a schema and credential definition in order to issue a credential
     Given "Acme" has a public did
-    When "Acme" creates a new schema
-    And "Acme" creates a new credential definition
-    Then "Acme" has an existing schema
-    And "Acme" has an existing credential definition
+    And "Acme" is ready to issue a credential
 
   @T001-AIP10-RFC0036 @AcceptanceTest @P1 @Indy
   Scenario: Issue a credential with the Holder beginning with a proposal

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -47,6 +47,17 @@ def step_impl(context, issuer):
     else:
         context.issuer_did_dict = {context.schema['schema_name']: issuer_did["did"]}
 
+@given('"{issuer}" is ready to issue a credential')
+def step_impl(context, issuer):
+    # TODO remove these references to schema and cred def, move them to one call to the API and let the Backchannel take care of
+    # what to do to be ready to issie a credential
+    context.execute_steps('''
+      When "''' + issuer + '''" creates a new schema
+       And "''' + issuer + '''" creates a new credential definition
+      Then "''' + issuer + '''" has an existing schema
+       And "''' + issuer + '''" has an existing credential definition
+    ''')
+
 @when('"{issuer}" creates a new schema')
 def step_impl(context, issuer):
     issuer_url = context.config.userdata.get(issuer)
@@ -330,8 +341,10 @@ def step_impl(context, holder):
 
         # Make sure the issuer is not holding the credential
         # get the credential from the holders wallet
-        (resp_status, resp_text) = agent_backchannel_GET(context.issuer_url + "/agent/command/", "credential", id=context.credential_id_dict[context.schema['schema_name']])
-        assert resp_status == 404, f'resp_status {resp_status} is not 404; {resp_text}'
+        # TODO this expected error is not displaying in the agent output until after all the tests are executed. Uncomment this out when
+        # there is a solution to the error messaging happening at the end. 
+        #(resp_status, resp_text) = agent_backchannel_GET(context.issuer_url + "/agent/command/", "credential", id=context.credential_id_dict[context.schema['schema_name']])
+        #assert resp_status == 404, f'resp_status {resp_status} is not 404; {resp_text}'
 
 
 


### PR DESCRIPTION
Updated the documentation to make it clear how to use the default behave.ini with the ./manage script.
Also added a section and a line to the behave.ini file to show how to restrict test execution to one feature file. 

The schema and credential def has been removed from the feature files. Anyone running the tests now should not see these Indyisms in the test output. This is just superficial however, the step code still references the old steps and the removal of these and pushing things into the backchannels will come in another PR.

This submission also includes the suppression of a 404 error message that was displaying after all the tests ran. This error is expected and is a part of the tests but is not displaying in the output when it happens. This check in the test is now disabled until the logs are fixed. 