### PR TITLE
Updated Allure API URL, -api was missed in last submission

### DIFF
--- a/actions/run-send-gen-test-results/action.yml
+++ b/actions/run-send-gen-test-results/action.yml
@@ -10,7 +10,7 @@ inputs:
   ALLURE_SERVER:
     description: "URL of the Allure Service"
     required: true
-    default: "https://allure.vonx.io"
+    default: "https://allure-api.vonx.io"
   REPORT_PROJECT:
     description: "Name of the project the Allure Service is using to store these results"
     required: true


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

URL for the Allure api as not originally updated to include -api in allure-api.vonx.io