### PR TITLE
RFC 441 test calibration

### DIFF
--- a/aries-test-harness/features/0011-0183-revocation.feature
+++ b/aries-test-harness/features/0011-0183-revocation.feature
@@ -80,8 +80,8 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
-   @T004-RFC0011 @RFC0011 @P2 @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy @delete_cred_from_wallet @willfail
-   Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential but presents the revoked credential
+   @T004-RFC0011 @RFC0011 @P2 @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy @delete_cred_from_wallet @wip
+   Scenario Outline: Credential revoked and replaced with a new updated credential, get possible credentials from agent wallet
       Given "2" agents
          | name  | role     |
          | Bob   | prover   |

--- a/aries-test-harness/features/steps/0011-0183-revocation.py
+++ b/aries-test-harness/features/steps/0011-0183-revocation.py
@@ -17,6 +17,7 @@
 
 from behave import *
 import json
+from time import sleep
 from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST, agent_backchannel_DELETE#, expected_agent_state
 from agent_test_utils import create_non_revoke_interval
 
@@ -86,6 +87,8 @@ def step_impl(context, issuer, timeframe):
 @when('"{verifier}" sends a {request_for_proof} presentation to "{prover}" with credential validity during {timeframe}')
 def step_impl(context, verifier, request_for_proof, prover, timeframe):
     
+    # Sleep here just to give a little space between the revocation and the request.
+    sleep(2)
     context.non_revoked_timeframe = create_non_revoke_interval(timeframe)
 
     context.execute_steps('''


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Tests updated for best practices and logic changes in Revocation because of RFC 441.
Note: Test Scenario T004-RFC0011 will fail with at least acapy. At this time, the expectation of this scenario is to pass, but it does not. 