### PR TITLE
fix for send-results not sending on test failure

### DIFF
--- a/.github/workflows/test-harness-acapy-dotnet.yml
+++ b/.github/workflows/test-harness-acapy-dotnet.yml
@@ -24,6 +24,7 @@ jobs:
           DEFAULT_AGENT: acapy-master
           BOB_AGENT: dotnet-master
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@ProofProposal"
+        continue-on-error: true
       - name: run-send-gen-test-results
         uses: ./test-harness/actions/run-send-gen-test-results
         with:

--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           DEFAULT_AGENT: acapy-master
           BOB_AGENT: acapy-master
+        continue-on-error: true
       - name: run-send-gen-test-results
         uses: ./test-harness/actions/run-send-gen-test-results
         with:

--- a/.github/workflows/test-harness-dotnet.yml
+++ b/.github/workflows/test-harness-dotnet.yml
@@ -24,6 +24,7 @@ jobs:
           DEFAULT_AGENT: dotnet-master
           BOB_AGENT: dotnet-master
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@RFC0011 -t ~@ProofProposal"
+        continue-on-error: true
       - name: run-send-gen-test-results
         uses: ./test-harness/actions/run-send-gen-test-results
         with:


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

continue-on-error added to all workflow actions. This will allow the send-test-results section of the job to still run, even when the test harness fails.  