### PR TITLE
Updated first DID Exchange Test Step to make connection_id optional

### DIFF
--- a/aries-test-harness/features/0023-did-exchange.feature
+++ b/aries-test-harness/features/0023-did-exchange.feature
@@ -15,3 +15,33 @@ Feature: Establishing Connections with DID Exchange RFC 0023
       And "Acme" sends complete to "Bob"
       Then "Acme" and "Bob" have a connection
 
+   @T002-RFC0023 @P1 @critical @AcceptanceTest @RFC0023
+   Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with role reversal
+      Given we have "2" agents
+         | name | role      |
+         | Acme | responder |
+         | Bob  | requester |
+      When "Acme" sends an explicit invitation
+      And "Bob" receives the invitation
+      And "Bob" sends the request to "Acme"
+      And "Acme" receives the request
+      And "Acme" sends a response to "Bob"
+      And "Bob" receives the response
+      And "Bob" sends complete to "Acme"
+      Then "Bob" and "Acme" have a connection
+
+   @T003-RFC0023 @P1 @critical @AcceptanceTest @RFC0023 @wip
+   Scenario: Establish a connection with DID Exchange between two agents with an implicit invitation
+      Given we have "2" agents
+         | name | role      |
+         | Acme | requester |
+         | Bob  | responder |
+      When "Bob" publishes a public DID
+      When "Bob" sends an implicit invitation
+      And "Acme" receives the invitation
+      And "Acme" sends the request to "Bob"
+      And "Bob" receives the request
+      And "Bob" sends a response to "Acme"
+      And "Acme" receives the response
+      And "Acme" sends complete to "Bob"
+      Then "Acme" and "Bob" have a connection

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -46,6 +46,73 @@ def step_impl(context, responder):
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
 
+    # Some agents (afgo) do not have a webhook that give a connection id at this point in the protocol. 
+    # IF it is not here, skit this and check for one later in the process and add it then.
+    if "connection_id" in resp_text:
+        context.connection_id_dict[responder][context.requester_name] = resp_json["connection_id"]
+
+    # Check to see if the responder name is the same as this person. If not, it is a 3rd person acting as an issuer that needs a connection
+    if context.responder_name != responder:
+        context.responder_name = responder
+
+
+@when('"{responder}" publishes a public DID')
+def step_impl(context, responder):
+    responder_url = context.config.userdata.get(responder)
+
+    (resp_status, resp_text) = agent_backchannel_GET(responder_url + "/agent/command/", "did")
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+    resp_json = json.loads(resp_text)
+    responder_did = resp_json
+
+    context.responder_public_did = responder_did["did"]
+
+    # if "schema" not in context:
+    #     # check for a schema already loaded in the context. If it is not, load the template
+    #     if "schema" not in context:
+    #         context.schema = SCHEMA_TEMPLATE.copy()
+    #         context.schema["schema_name"] = context.schema["schema_name"] + issuer
+
+    # if 'issuer_did_dict' in context:
+    #     context.issuer_did_dict[context.schema['schema_name']] = issuer_did["did"]
+    # else:
+    #     context.issuer_did_dict = {context.schema['schema_name']: issuer_did["did"]}
+
+
+
+@when('"{responder}" sends an implicit invitation')
+def step_impl(context, responder):
+    responder_url = context.config.userdata.get(responder)
+
+    data = {
+        "include_handshake": True,
+        "use_public_did": False
+    }
+
+    (resp_status, resp_text) = agent_backchannel_POST(responder_url + "/agent/command/", "out-of-band", operation="send-invitation-message", data=data)
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+    resp_json = json.loads(resp_text)
+    assert resp_json["state"] == "invitation-sent"
+    assert "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/v1.0" in resp_text
+    context.responder_invitation = resp_json["invitation"]
+    # TODO drill into the handshake protocol in the invitation and remove anything else besides didexchange.
+
+    # setup the initial connection id dictionary if one doesn't exist.
+    if not hasattr(context, 'connection_id_dict'):
+        context.connection_id_dict = {}
+
+    # Check for responder key existing in dict
+    if responder not in context.connection_id_dict:
+        context.connection_id_dict[responder] = {}
+    
+    # Get the responders's connection id from the above request's response webhook in the backchannel
+    invitation_id = context.responder_invitation["@id"]
+    (resp_status, resp_text) = agent_backchannel_GET(responder_url + "/agent/response/", "did-exchange", id=invitation_id)
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+    resp_json = json.loads(resp_text)
+
     context.connection_id_dict[responder][context.requester_name] = resp_json["connection_id"]
 
     # Check to see if the responder name is the same as this person. If not, it is a 3rd person acting as an issuer that needs a connection


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Updated the first `When` step in DID Exchange tests since afgo does not produce a connection_id at this point. Will update later steps for afgo when connection_id comes into play.

Also a bonus DID Exchange test is here that does a role swap. 
Implicit Invitation DID Exchange test included is wip.

FYI @murpheux