### PR TITLE
Secondary connection fix with test scoping for daily runs

### DIFF
--- a/.github/workflows/test-harness-acapy-dotnet.yml
+++ b/.github/workflows/test-harness-acapy-dotnet.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           DEFAULT_AGENT: acapy-master
           BOB_AGENT: dotnet-master
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@ProofProposal"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@ProofProposal -t ~@RFC0023"
           REPORT_PROJECT: acapy-b-dotnet
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           DEFAULT_AGENT: afgo-master
           BOB_AGENT: afgo-master
-          TEST_SCOPE: "-t @RFC0023 -t ~@wip"
+          TEST_SCOPE: "-t @RFC0023 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023"
           REPORT_PROJECT: afgo 
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-dotnet.yml
+++ b/.github/workflows/test-harness-dotnet.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           DEFAULT_AGENT: dotnet-master
           BOB_AGENT: dotnet-master
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@RFC0011 -t ~@ProofProposal"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@RFC0011 -t ~@ProofProposal -t ~@RFC0023"
           REPORT_PROJECT: dotnet
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -518,8 +518,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         elif operation == "receive-invitation":
             # TODO check for Alias and Auto_accept in data to add to the call (works without for now)
+            # TODO add use_existing_connection=false in data in the test to pass to here. 
+            use_existing_connection = "false"
             auto_accept = "false"
-            agent_operation = agent_operation + "receive-invitation" + "?auto_accept=" + auto_accept
+            agent_operation = agent_operation + "receive-invitation" + "?auto_accept=" + auto_accept + "&use_existing_connection=" + use_existing_connection
             #agent_operation = "/didexchange/" + "receive-invitation"
         
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -48,10 +48,13 @@ def step_impl(context, prover, issuer, credential_data):
 @given('"{prover}" has an issued credential from {issuer}')
 def step_impl(context, prover, issuer):
     # create the Connection between the prover and the issuer
-    # TODO: May need to check for an existing connection here instead of creating one.
-    context.execute_steps('''
-        Given "''' + issuer + '''" and "''' + prover + '''" have an existing connection
-    ''')
+    # TODO: May need to check for an existing connection established from other tests here instead of creating one.
+    # Check if a connection between the players has already been established in this test. 
+    if prover not in context.connection_id_dict or issuer not in context.connection_id_dict[prover]:
+        context.execute_steps('''
+            Given "''' + issuer + '''" and "''' + prover + '''" have an existing connection
+        ''')
+
 
     # make sure the issuer has the credential definition
     # If there is a schema_dict then we are working with mulitple credential types, loop as many times as 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This submission fixes a problem with creating a second connection in a test scenario with DID-Exchange. 

Also included are fixes to the scope of tests to run for the daily test runs. Removes tests that are not supported by the agent under test. 