### PR TITLE
added the NEW EMIT params to the afgo/acapy workflow

### DIFF
--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -25,6 +25,9 @@ jobs:
           BOB_AGENT: afgo-master
           TEST_SCOPE: "-t @RFC0023 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023"
           REPORT_PROJECT: acapy-b-afgo
+        env:
+          EMIT-NEW-DIDCOMM-PREFIX: true
+          EMIT-NEW-DIDCOMM-MIME-TYPE: true
         continue-on-error: true
       - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Forgot this update in the last PR. The tests for acapy/afgo will still not pass, but at least acapy is starting with the appropriate args. 