### PR TITLE
Forced actions to only run in Hyperledger

### DIFF
--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-acapy-dotnet.yml
+++ b/.github/workflows/test-harness-acapy-dotnet.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-acapy-full.yml
+++ b/.github/workflows/test-harness-acapy-full.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-acapy-javascript.yml
+++ b/.github/workflows/test-harness-acapy-javascript.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-dotnet.yml
+++ b/.github/workflows/test-harness-dotnet.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-javascript-dotnet.yml
+++ b/.github/workflows/test-harness-javascript-dotnet.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/.github/workflows/test-harness-javascript.yml
+++ b/.github/workflows/test-harness-javascript.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v2

--- a/TEST_REPORTING.md
+++ b/TEST_REPORTING.md
@@ -60,6 +60,8 @@ The AATH is executed with varying configurations and Aries Agent types at pre-de
 - [Dotnet to Dotnet Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/dotnet/reports/latest)
 - [JavaScript to JavaScript Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/javascript/reports/latest)
 - [JavaScript to Dotnet Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/javascript-b-dotnet/reports/latest)
+- [Acapy to AFGO Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-afgo/reports/latest)
+- [AFGO to AFGO Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/afgo/reports/latest)
 
 ## Other Reporting Options
 

--- a/actions/run-send-gen-test-results-secure/action.yml
+++ b/actions/run-send-gen-test-results-secure/action.yml
@@ -9,7 +9,7 @@ inputs:
   ALLURE_SERVER:
     description: "URL of the Allure Service"
     required: true
-    default: "https://allure-von.apps.silver.devops.gov.bc.ca/api"
+    default: "https://allure.vonx.io/api"
   REPORT_PROJECT:
     description: "Name of the project the Allure Service is using to store these results"
     required: true

--- a/actions/run-test-harness/action.yml
+++ b/actions/run-test-harness/action.yml
@@ -33,7 +33,7 @@ inputs:
   ALLURE_SERVER_SECURE:
     description: "URL of the Allure Service"
     required: true
-    default: "https://allure-von.apps.silver.devops.gov.bc.ca/api"
+    default: "https://allure.vonx.io/api"
   ADMIN_USER:
     description: "Username of the Allure Adminstrator"
     required: true

--- a/aries-test-harness/allure/README.md
+++ b/aries-test-harness/allure/README.md
@@ -41,6 +41,8 @@ The AATH is executed with varying configurations and Aries Agent types at pre-de
 - [Dotnet to Dotnet Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/dotnet/reports/latest)
 - [JavaScript to JavaScript Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/javascript/reports/latest)
 - [JavaScript to Dotnet Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/javascript-b-dotnet/reports/latest)
+- [Acapy to AFGO Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-afgo/reports/latest)
+- [AFGO to AFGO Agent Interop Testing](https://allure.vonx.io/allure-docker-service-ui/projects/afgo/reports/latest)
 
 
 ## REFERENCES


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This submission should force the actions to only run in the Hyperledger/aries-agent-test-harness repo. In any other fork you can still manually run it, though that would be frowned upon since it would push reports to allure. 

Also updated the final allure service URLs, and added the newly added AFGO test run reports to the documentation. 

closes #162