### PR TITLE
Changed RFC0011 to revocation in acapy-javascript runset

### DIFF
--- a/.github/workflows/test-harness-acapy-javascript.yml
+++ b/.github/workflows/test-harness-acapy-javascript.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           DEFAULT_AGENT: acapy-main
           BOB_AGENT: javascript
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@RFC0011 -t ~@RFC0023 -t ~@DIDExchangeConnection"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@revocation -t ~@RFC0023 -t ~@DIDExchangeConnection"
           REPORT_PROJECT: acapy-b-javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Changed the exclusion tag `RFC0011` to `revocation` in the acapy-javascript runset. This will stop any revocation tests from executing in the daily test run. 