### PR TITLE
Rename AF-JS to AFJ for aries interop overview

### DIFF
--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -1,17 +1,21 @@
-name: test-harness-javascript-javascript
-# RUNSET_NAME: "AF-JS to AF-JS"
+name: test-harness-acapy-javascript
+# RUNSET_NAME: "ACA-PY to AFJ"
 # Scope: AIP 1.0 except revocation
-# 
+#
 # Summary
 #
-# This runset uses the current main branch of Aries Framework - JavaScript for all of the agents. The runset runs all of the tests in the suite
-# that are expected to pass given the current state of the framework's support for AIP 1. Tests related to revocation (Indy HIPE 0011) are not included.
+# This runset uses the current main branch of ACA-Py for all of the agents except Bob (holder),
+# which uses the master branch of Aries Framework JavaScript. The runset covers all of the AIP 1.0 tests
+# except those that are known **not** to work with the Aries Framework JavaScript as the holder,
+# notably those that involve revocation.
 #
 # Current
 # 
-# All of the tests being executed in this runset are passing.
+# Only about half of the tests are currently running. The issues seem to be related to the set of tags
+# of the test cases being run as a number of the revocation tests are running and shouldn't be. As well,
+# the tests with the holder proposing a proof are not running, as that feature is not supported in AFJ.
 # 
-# *Updated: 2021.03.05*
+# *Updated: 2021.03.08*
 #
 # End
 on:
@@ -37,13 +41,14 @@ jobs:
       - name: run-test-harness-wo-reports
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
-          DEFAULT_AGENT: javascript
+          DEFAULT_AGENT: acapy-main
+          BOB_AGENT: javascript
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@revocation -t ~@RFC0023 -t ~@DIDExchangeConnection"
-          REPORT_PROJECT: javascript
+          REPORT_PROJECT: acapy-b-javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
-          REPORT_PROJECT: javascript
+          REPORT_PROJECT: acapy-b-javascript
           ADMIN_USER: ${{ secrets.AllureAdminUser }}
           ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-afj-dotnet.yml
+++ b/.github/workflows/test-harness-afj-dotnet.yml
@@ -1,5 +1,5 @@
 name: test-harness-javascript-dotnet
-# RUNSET_NAME: "AF-JS to AF-.NET"
+# RUNSET_NAME: "AFJ to AF-.NET"
 # Scope: AIP 1.0 except revocation and proof proposals
 # 
 # Summary

--- a/.github/workflows/test-harness-afj.yml
+++ b/.github/workflows/test-harness-afj.yml
@@ -1,19 +1,15 @@
-name: test-harness-acapy-javascript
-# RUNSET_NAME: "ACA-PY to AF-JS"
+name: test-harness-javascript-javascript
+# RUNSET_NAME: "AFJ to AFJ"
 # Scope: AIP 1.0 except revocation
-#
+# 
 # Summary
 #
-# This runset uses the current main branch of ACA-Py for all of the agents except Bob (holder),
-# which uses the master branch of Aries Framework JavaScript. The runset covers all of the AIP 1.0 tests
-# except those that are known **not** to work with the Aries Framework JavaScript as the holder,
-# notably those that involve revocation.
+# This runset uses the current main branch of Aries Framework - JavaScript for all of the agents. The runset runs all of the tests in the suite
+# that are expected to pass given the current state of the framework's support for AIP 1. Tests related to revocation (Indy HIPE 0011) are not included.
 #
 # Current
 # 
-# Only about half of the tests are currently running. The issues seem to be related to the set of tags
-# of the test cases being run as a number of the revocation tests are running and shouldn't be. As well,
-# the tests with the holder proposing a proof are not running, as that feature is not supported in AFJ.
+# All of the tests being executed in this runset are passing.
 # 
 # *Updated: 2021.03.05*
 #
@@ -41,14 +37,13 @@ jobs:
       - name: run-test-harness-wo-reports
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
-          DEFAULT_AGENT: acapy-main
-          BOB_AGENT: javascript
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@RFC0011 -t ~@RFC0023 -t ~@DIDExchangeConnection"
-          REPORT_PROJECT: acapy-b-javascript
+          DEFAULT_AGENT: javascript
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@revocation -t ~@RFC0023 -t ~@DIDExchangeConnection"
+          REPORT_PROJECT: javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
-          REPORT_PROJECT: acapy-b-javascript
+          REPORT_PROJECT: javascript
           ADMIN_USER: ${{ secrets.AllureAdminUser }}
           ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ The following test agents are currently included in the runsets:
 
 - [Aries Cloud Agent Python](https://github.com/hyperledger/aries-cloudagent-python) (ACA-Py)
 - [Aries Framework .NET](https://github.com/hyperledger/aries-framework-dotnet) (AF-.NET)
-- [Aries Framework - JavaScript](https://github.com/hyperledger/aries-framework-javascript) (AF-JS)
+- [Aries Framework JavaScript](https://github.com/hyperledger/aries-framework-javascript) (AFJ)
 - [Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (AF-Go)
 
 Want to add your Aries component to this page? You need to add a runset to the
@@ -22,13 +22,13 @@ Want to add your Aries component to this page? You need to add a runset to the
 |   #   | Runset Name     | Scope | Results |
 | :---- | :-------------- | ----- | ------: |
 | 1 | [ACA-PY to AF-Go](./acapy-afgo.md) | AIP 2.0 RFC0023 Only | **0 / 5** (0%) |
-| 2 | [ACA-PY to AF-.NET](./acapy-dotnet.md) | AIP 1.0 except proof proposals | **25 / 25** (100%) |
-| 3 | [ACA-PY to AF-JS](./acapy-javascript.md) | AIP 1.0 except revocation | **15 / 30** (50%) |
+| 2 | [ACA-PY to AFJ](./acapy-afj.md) | AIP 1.0 except revocation | **15 / 30** (50%) |
+| 3 | [ACA-PY to AF-.NET](./acapy-dotnet.md) | AIP 1.0 except proof proposals | **25 / 25** (100%) |
 | 4 | [ACA-PY to ACA-Py](./acapy.md) | AIP 1.0, AIP 2.0 (RFC0023 Only) | **41 / 41** (100%) |
 | 5 | [AF-Go to AF-Go](./afgo.md) | AP 2.0 RFC0023 Only | **3 / 5** (60%) |
-| 6 | [AF-.NET to AF-.NET](./dotnet.md) | AIP 1.0 except revocation and proof proposals | **13 / 13** (100%) |
-| 7 | [AF-JS to AF-.NET](./javascript-dotnet.md) | AIP 1.0 except revocation and proof proposals | **12 / 13** (92%) |
-| 8 | [AF-JS to AF-JS](./javascript.md) | AIP 1.0 except revocation | **17 / 18** (94%) |
+| 6 | [AFJ to AF-.NET](./afj-dotnet.md) | AIP 1.0 except revocation and proof proposals | **13 / 13** (100%) |
+| 7 | [AFJ to AFJ](./afj.md) | AIP 1.0 except revocation | **17 / 18** (94%) |
+| 8 | [AF-.NET to AF-.NET](./dotnet.md) | AIP 1.0 except revocation and proof proposals | **13 / 13** (100%) |
 
-*Results last updated: Fri Mar 5 14:31:59 PST 2021*
+*Results last updated: Mon 8 Mar 2021 12:43:34 CET*
 

--- a/docs/acapy-afgo.md
+++ b/docs/acapy-afgo.md
@@ -11,13 +11,13 @@
 
 |  ACME (Issuer) | Bob (Holder) | Faber (Verfier) | Mallory (Holder) | Scope of Tests |
 | :------------: | :----------: | :-------------: | :--------------: | -------------- |
-| acapy-master | afgo-master | acapy-master | acapy-master | AIP 2.0 RFC0023 Only |
+| acapy-main | afgo-master | acapy-main | acapy-main | AIP 2.0 RFC0023 Only |
 
 ```tip
 **Latest results: 0 out of 5 (0%)**
 
 
-*Last updated: Fri Mar 5 14:31:59 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:36 CET*
 ```
 
 ## Current Status of Tests

--- a/docs/acapy-afj.md
+++ b/docs/acapy-afj.md
@@ -1,4 +1,4 @@
-# ACA-PY to AF-JS
+# ACA-PY to AFJ
 
 ## Summary of Tests
 
@@ -12,13 +12,13 @@
 
 |  ACME (Issuer) | Bob (Holder) | Faber (Verfier) | Mallory (Holder) | Scope of Tests |
 | :------------: | :----------: | :-------------: | :--------------: | -------------- |
-| acapy-master | javascript | acapy-master | acapy-master | AIP 1.0 except revocation |
+| acapy-main | javascript | acapy-main | acapy-main | AIP 1.0 except revocation |
 
 ```tip
 **Latest results: 15 out of 30 (50%)**
 
 
-*Last updated: Fri Mar 5 14:32:01 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:39 CET*
 ```
 
 ## Current Status of Tests
@@ -27,7 +27,7 @@ Only about half of the tests are currently running. The issues seem to be relate
 of the test cases being run as a number of the revocation tests are running and shouldn't be. As well,
 the tests with the holder proposing a proof are not running, as that feature is not supported in AFJ.
 
-*Updated: 2021.03.05*
+*Updated: 2021.03.08*
 
 ## Test Run Details
 See the tests results grouped by the Aries RFCs executed [acapy-b-javascript](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors)

--- a/docs/acapy-dotnet.md
+++ b/docs/acapy-dotnet.md
@@ -11,13 +11,13 @@
 
 |  ACME (Issuer) | Bob (Holder) | Faber (Verfier) | Mallory (Holder) | Scope of Tests |
 | :------------: | :----------: | :-------------: | :--------------: | -------------- |
-| acapy-master | dotnet-master | acapy-master | acapy-master | AIP 1.0 except proof proposals |
+| acapy-main | dotnet-master | acapy-main | acapy-main | AIP 1.0 except proof proposals |
 
 ```tip
 **Latest results: 25 out of 25 (100%)**
 
 
-*Last updated: Fri Mar 5 14:32:00 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:42 CET*
 ```
 
 ## Current Status of Tests

--- a/docs/acapy.md
+++ b/docs/acapy.md
@@ -10,13 +10,13 @@
 
 |  ACME (Issuer) | Bob (Holder) | Faber (Verfier) | Mallory (Holder) | Scope of Tests |
 | :------------: | :----------: | :-------------: | :--------------: | -------------- |
-| acapy-master | acapy-master | acapy-master | acapy-master | AIP 1.0, AIP 2.0 (RFC0023 Only) |
+| acapy-main | acapy-main | acapy-main | acapy-main | AIP 1.0, AIP 2.0 (RFC0023 Only) |
 
 ```tip
 **Latest results: 41 out of 41 (100%)**
 
 
-*Last updated: Fri Mar 5 14:32:01 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:47 CET*
 ```
 
 ## Current Status of Tests

--- a/docs/afgo.md
+++ b/docs/afgo.md
@@ -16,7 +16,7 @@
 **Latest results: 3 out of 5 (60%)**
 
 
-*Last updated: Fri Mar 5 14:32:02 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:50 CET*
 ```
 
 ## Current Status of Tests

--- a/docs/afj-dotnet.md
+++ b/docs/afj-dotnet.md
@@ -1,4 +1,4 @@
-# AF-JS to AF-.NET
+# AFJ to AF-.NET
 
 ## Summary of Tests
 
@@ -15,10 +15,10 @@
 | javascript | dotnet-master | javascript | javascript | AIP 1.0 except revocation and proof proposals |
 
 ```tip
-**Latest results: 12 out of 13 (92%)**
+**Latest results: 13 out of 13 (100%)**
 
 
-*Last updated: Fri Mar 5 14:32:02 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:52 CET*
 ```
 
 ## Current Status of Tests

--- a/docs/afj.md
+++ b/docs/afj.md
@@ -1,4 +1,4 @@
-# AF-JS to AF-JS
+# AFJ to AFJ
 
 ## Summary of Tests
 
@@ -16,7 +16,7 @@
 **Latest results: 17 out of 18 (94%)**
 
 
-*Last updated: Fri Mar 5 14:32:03 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:54 CET*
 ```
 
 ## Current Status of Tests

--- a/docs/dotnet.md
+++ b/docs/dotnet.md
@@ -17,7 +17,7 @@
 **Latest results: 13 out of 13 (100%)**
 
 
-*Last updated: Fri Mar 5 14:32:02 PST 2021*
+*Last updated: Mon 8 Mar 2021 12:43:56 CET*
 ```
 
 ## Current Status of Tests

--- a/gen-interop.sh
+++ b/gen-interop.sh
@@ -92,7 +92,7 @@ The following test agents are currently included in the runsets:
 
 - [Aries Cloud Agent Python](https://github.com/hyperledger/aries-cloudagent-python) (ACA-Py)
 - [Aries Framework .NET](https://github.com/hyperledger/aries-framework-dotnet) (AF-.NET)
-- [Aries Framework - JavaScript](https://github.com/hyperledger/aries-framework-javascript) (AF-JS)
+- [Aries Framework JavaScript](https://github.com/hyperledger/aries-framework-javascript) (AFJ)
 - [Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (AF-Go)
 
 Want to add your Aries component to this page? You need to add a runset to the


### PR DESCRIPTION
The new https://aries-interop.info site and scripts are amazing, great work!!

I've renamed AF-JS to AFJ as that's the name we generally use and we'd like to create a single abbreviation for the framework. I hope this is okay. I've also regenerated the interop files, and changed `~@RFC0011` to `~@revocation` in the ACA-Py-AFJ script.



