### PR TITLE
gitignore the environment.properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ reports/
 allure-report/
 allure-results/
 New-KGR-File.json
+aries-test-harness/allure/allure-results/environment.properties
 
 # Jekyll
 _site/


### PR DESCRIPTION
I keep having to restore the environment.properties file.  I'm assuming it should be ignored and so added it 
to the .gitignore file in this PR.  @nodlesh  -- please confirm that's ok to do.

I notice that there is a ".gitkeep" file in the /allure_results file, and that the file is mentioned in the
.gitignore file as well.  Is the intention that the folder needs to exist as empty in the repo but not 
to have any of the files in it saved to the repo?


