### PR TITLE
Adding all the new runsets; reworked the agent-to-mapping method to use Allure

### DIFF
--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -12,11 +12,9 @@ name: test-harness-acapy-javascript
 #
 # Current
 # 
-# Only about half of the tests are currently running. The issues seem to be related to the set of tags
-# of the test cases being run as a number of the revocation tests are running and shouldn't be. As well,
-# the tests with the holder proposing a proof are not running, as that feature is not supported in AFJ.
+# Most of the tests are running. The tests not passing are being investigated.
 # 
-# *Status Note Updated: 2021.03.08*
+# *Status Note Updated: 2021.03.18*
 #
 # End
 on:

--- a/.github/workflows/test-harness-acapy-dotnet-javascript.yml
+++ b/.github/workflows/test-harness-acapy-dotnet-javascript.yml
@@ -2,20 +2,19 @@ name: test-harness-acapy-dotnet-javascript
 # RUNSET_NAME: "ACA-PY to AF-.NET to AFJ"
 # Scope: AIP 1.0
 # Exceptions: Proof Proposals
-# SKIP
 #
 # Summary
 #
 # This runset uses the current main branch of ACA-Py for the Acme agent. Bob (holder)
-# uses the master branch of Aries Framework Javascript, and faber(verifier) uses the 
+# uses the master branch of Aries Framework Javascript, and Faber (verifier) uses the 
 # master branch of Aries Framework .NET. The runset covers all of the AIP 1.0 tests that 
 # are known to work with the Aries Framework .NET as the holder and Aries Framework .NET as a verifier.
 # Proof Proposals and Revocation are not included.
 #
 # Current
 # 
-# All tests are working, except for three tests that include faber in the test run as an issuer.
-# These tests are; T001-RFC0037@1.2, T001.2-RFC0037@1.2, T001.4-RFC0037@1.1 . Furthere investigation 
+# All tests are working, except for three tests that include Faber in the test run as an issuer.
+# These tests are; T001-RFC0037@1.2, T001.2-RFC0037@1.2, T001.4-RFC0037@1.1 . Further investigation 
 # is required to determine the issue in these three tests.
 # 
 # *Status Note Updated: 2021.03.18*

--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -2,6 +2,7 @@ name: test-harness-acapy-acapy
 # RUNSET_NAME: "ACA-PY to ACA-Py"
 # Scope: AIP 1.0
 # Exceptions: None
+# SKIP
 # 
 # Summary
 #
@@ -12,7 +13,7 @@ name: test-harness-acapy-acapy
 # 
 # All of the tests being executed in this runset are passing.
 # 
-# *Status Note Updated: 2021.03.05*
+# *Status Note Updated: 2021.03.18*
 #
 # End
 on:

--- a/.github/workflows/test-harness-afgo-acapy.yml
+++ b/.github/workflows/test-harness-afgo-acapy.yml
@@ -2,7 +2,6 @@ name: test-harness-afgo-acapy
 # RUNSET_NAME: "AF-Go to ACA-PY"
 # Scope: pre-AIP 2.0
 # Exceptions: None
-# SKIP
 # 
 # Summary
 #

--- a/.github/workflows/test-harness-afj-acapy.yml
+++ b/.github/workflows/test-harness-afj-acapy.yml
@@ -2,7 +2,6 @@ name: test-harness-javascript-acapy
 # RUNSET_NAME: "AFJ to ACA-PY"
 # Scope: AIP 1.0
 # Exceptions: Proof Proposal
-# SKIP
 #
 # Summary
 #

--- a/.github/workflows/test-harness-afj-dotnet.yml
+++ b/.github/workflows/test-harness-afj-dotnet.yml
@@ -5,14 +5,14 @@ name: test-harness-javascript-dotnet
 # 
 # Summary
 #
-# This runset uses the current main branch of Aries Framework - JavaScript for all of the agents except for Bob (the Holder), which
+# This runset uses the current main branch of Aries Framework JavaScript for all of the agents except for Bob (the Holder), which
 # uses Aries Framework .NET. The runset executes all of the AIP 1.0 tests that are expected to be pass given the two state of the
-# two frameworks involved. Tests involving revocation (not supported in Aries Framework - JavaScript) and proof proposals (not supported
+# two frameworks involved. Tests involving revocation (not supported in Aries Framework JavaScript) and proof proposals (not supported
 # in Aries Framework .NET) are not executed.
 #
 # Current
 # 
-# All but one of the tests being executed in this runset are passing. The failure is being investigated.
+# All of the tests being executed in this runset are passing.
 # 
 # *Status Note Updated: 2021.03.05*
 #

--- a/.github/workflows/test-harness-dotnet-acapy.yml
+++ b/.github/workflows/test-harness-dotnet-acapy.yml
@@ -2,7 +2,6 @@ name: test-harness-dotnet-acapy
 # RUNSET_NAME: "AF-.NET to ACA-PY"
 # Scope: AIP 1.0
 # Exceptions: Proof Proposals
-# SKIP
 #
 # Summary
 #

--- a/.github/workflows/test-harness-dotnet-javascript.yml
+++ b/.github/workflows/test-harness-dotnet-javascript.yml
@@ -2,7 +2,6 @@ name: test-harness-dotnet-javascript
 # RUNSET_NAME: "AF-.NET to AFJ"
 # Scope: AIP 1.0
 # Exceptions: Proof Proposals
-# SKIP
 #
 # Summary
 #

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,17 @@
 # Aries Interoperability Information
 
 
-This web site shows the current status of Aries Interoperability amongst Aries frameworks and agents. while
-not included in these results yet, we have a working prototype for testing Aries mobile wallets using the
-identical tests.
+This web site shows the current status of Aries Interoperability between Aries frameworks and agents. While
+not yet included in these results, we have a working prototype for testing Aries mobile wallets using the
+same tests.
 
-The latest interoperability test results are provided below. Each item is for a test runset, a combination
-of Aries agents and frameworks running a subset (see scope and exceptions) of the overall tests in the repository.
-The subset of tests run represent the set of tests expected to be supported by the combination of components
-being tested, with a narrative on the scope on the details page.
+The latest interoperability test results are below. Each row is a test agent, its columns
+the results of tests executed in combination with other test agents.
+The bolded cell per row shows the results of all tests run for the given test agent. The link on each test
+agent name provides more details about results for all test combinations for that test agent. On
+that page are links to a full history of the test runs and full details on every executed test. 
 
-The following test agents are currently included in the runsets:
+The following test agents are currently supported:
 
 - [Aries Cloud Agent Python](https://github.com/hyperledger/aries-cloudagent-python) (ACA-Py)
 - [Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (AF-Go)
@@ -20,19 +21,19 @@ The following test agents are currently included in the runsets:
 Want to add your Aries component to this page? You need to add a runset to the
 [Aries Agent Test Harness](https://github.com/hyperledger/aries-agent-test-harness).
 
-## Aries Continuous Interoperability Results
+## Latest Interoperability Results
 
 | Test Agent | Scope | Exceptions | ACA-Py | AF-Go | AFJ | AF-.NET |
 | ----- | ----- | ----- | :----: | :----: | :----: | :----: |
-| [ACA-Py](acapy.md)| AIP 1, 2 | None | **80 / 90<br>88%** | 0 / 5<br>0% | 13 / 18<br>72% | 25 / 25<br>100% |
-| [AF-Go](afgo.md)| AIP 2 | None | 0 / 5<br>0% | **3 / 10<br>30%** | 0 / 0<br>0% | 0 / 0<br>0% |
-| [AFJ](javascript.md)| AIP 1 | Revocation | 13 / 18<br>72% | 0 / 0<br>0% | **44 / 49<br>89%** | 13 / 13<br>100% |
-| [AF-.NET](dotnet.md)| AIP 1 | Proof Proposal | 25 / 25<br>100% | 0 / 0<br>0% | 13 / 13<br>100% | **51 / 51<br>100%** |
+| [ACA-Py](acapy.md)| AIP 1, 2 | None | **124 / 152<br>81%** | 0 / 10<br>0% | 53 / 62<br>85% | 39 / 51<br>76% |
+| [AF-Go](afgo.md)| AIP 2 | None | 0 / 10<br>0% | **3 / 15<br>20%** | 0 / 0<br>0% | 0 / 0<br>0% |
+| [AFJ](javascript.md)| AIP 1 | Revocation | 53 / 62<br>85% | 0 / 0<br>0% | **70 / 88<br>79%** | 27 / 39<br>69% |
+| [AF-.NET](dotnet.md)| AIP 1 | Proof Proposal | 39 / 51<br>76% | 0 / 0<br>0% | 27 / 39<br>69% | **69 / 90<br>76%** |
 
-- The **bolded results** include all tests involving the "Test Agent" (first column), including tests using only that Test Agent.
+- The **bolded results** show all tests involving the "Test Agent", including tests involving only that Test Agent.
 - Wondering what the results mean? Please read the brief [introduction to Aries interoperability](aries-interop-intro.md) for some background.
-- Click on the "Test Agent" links to drill into the tests being run for each.
+- Select the "Test Agent" links to drill down into the tests being run.
 
 
-*Results last updated: Thu Mar 18 12:47:23 PDT 2021*
+*Results last updated: Thu Mar 18 15:45:22 PDT 2021*
 

--- a/docs/acapy.md
+++ b/docs/acapy.md
@@ -4,10 +4,16 @@
 
 | Runset | ACME<br>(Issuer) | Bob<br>(Holder) | Faber<br>(Verfier) | Mallory<br>(Holder) | Scope | Results | 
 | ------ | :--------------: | :-------------: | :----------------: | :-----------------: | ----- | :-----: | 
-| [acapy-afgo](#runset-acapy-afgo) | acapy-main | afgo-master | acapy-main | acapy-main | pre-AIP 2.0 | [**0 / 5<br>0%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-afgo/reports/latest/index.html?redirect=false#behaviors) |
-| [acapy-afj](#runset-acapy-afj) | acapy-main | javascript | acapy-main | acapy-main | AIP 1.0 | [**13 / 18<br>72%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors) |
-| [acapy-dotnet](#runset-acapy-dotnet) | acapy-main | dotnet-master | acapy-main | acapy-main | AIP 1.0 | [**25 / 25<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
-| [acapy](#runset-acapy) | acapy-main | acapy-main | acapy-main | acapy-main | AIP 1.0 | [**42 / 42<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-afgo](#runset-acapy-afgo) | acapy-main<br>0.6.0 | afgo-master<br>unknown | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | pre-AIP 2.0 | [**0 / 5<br>0%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-afgo/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-afj](#runset-acapy-afj) | acapy-main<br>0.6.0 | javascript<br>1.0.0 | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | AIP 1.0 | [**13 / 18<br>72%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-aip10](#runset-acapy-aip10) | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | AIP 1.0 | [**18 / 18<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-aip10/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-aip20](#runset-acapy-aip20) | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | AIP 2.0 | [**24 / 24<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-aip20/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-dotnet-javascript](#runset-acapy-dotnet-javascript) | acapy-main<br>0.6.0 | javascript<br>1.0.0 | dotnet-master<br> | acapy-main<br>0.6.0 | AIP 1.0 | [**10 / 13<br>76%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript-f-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-dotnet](#runset-acapy-dotnet) | acapy-main<br>0.6.0 | dotnet-master<br> | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | AIP 1.0 | [**25 / 25<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [afgo-acapy](#runset-afgo-acapy) | afgo-master<br>unknown | acapy-main<br>0.6.0 | afgo-master<br>unknown | afgo-master<br>unknown | pre-AIP 2.0 | [**0 / 5<br>0%**](https://allure.vonx.io/api/allure-docker-service/projects/afgo-b-acapy/reports/latest/index.html?redirect=false#behaviors) |
+| [afj-acapy](#runset-afj-acapy) | javascript<br>1.0.0 | acapy-main<br>0.6.0 | javascript<br>1.0.0 | javascript<br>1.0.0 | AIP 1.0 | [**12 / 13<br>92%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-acapy/reports/latest/index.html?redirect=false#behaviors) |
+| [afj](#runset-afj) | javascript<br>1.0.0 | acapy<br>0.6.0 | javascript<br>1.0.0 | javascript<br>1.0.0 | AIP 1.0 | [**18 / 18<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript/reports/latest/index.html?redirect=false#behaviors) |
+| [dotnet-acapy](#runset-dotnet-acapy) | dotnet-master<br> | acapy-main<br>0.6.0 | dotnet-master<br> | dotnet-master<br> | AIP 1.0 | [**4 / 13<br>30%**](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-acapy/reports/latest/index.html?redirect=false#behaviors) |
 
 ## Runset Notes
 
@@ -48,16 +54,85 @@ Runset Name: ACA-PY to AFJ
 
 #### Current Runset Status
 
-Only about half of the tests are currently running. The issues seem to be related to the set of tags
-of the test cases being run as a number of the revocation tests are running and shouldn't be. As well,
-the tests with the holder proposing a proof are not running, as that feature is not supported in AFJ.
+Most of the tests are running. The tests not passing are being investigated.
 
-*Status Note Updated: 2021.03.08*
+*Status Note Updated: 2021.03.18*
 
 #### Runset Details
 
 - Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors)
 - Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-javascript/reports/latest)
+
+
+### Runset **acapy-aip10**
+
+Runset Name: ACA-PY to ACA-Py
+
+```tip
+**Latest results: 18 out of 18 (100%)**
+
+
+*Last run: Thu Mar 18 13:24:35 PDT 2021*
+```
+
+#### Current Runset Status
+
+All of the tests being executed in this runset are passing.
+
+*Status Note Updated: 2021.03.18*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-aip10/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-aip10/reports/latest)
+
+
+### Runset **acapy-aip20**
+
+Runset Name: ACA-PY to ACA-Py
+
+```tip
+**Latest results: 24 out of 24 (100%)**
+
+
+*Last run: Thu Mar 18 13:39:30 PDT 2021*
+```
+
+#### Current Runset Status
+
+All of the tests being executed in this runset are passing.
+
+*Status Note Updated: 2021.03.16*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-aip20/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-aip20/reports/latest)
+
+
+### Runset **acapy-dotnet-javascript**
+
+Runset Name: ACA-PY to AF-.NET to AFJ
+
+```tip
+**Latest results: 10 out of 13 (76%)**
+
+
+*Last run: Thu Mar 18 13:41:35 PDT 2021*
+```
+
+#### Current Runset Status
+
+All tests are working, except for three tests that include Faber in the test run as an issuer.
+These tests are; T001-RFC0037@1.2, T001.2-RFC0037@1.2, T001.4-RFC0037@1.1 . Further investigation 
+is required to determine the issue in these three tests.
+
+*Status Note Updated: 2021.03.18*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript-f-dotnet/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-javascript-f-dotnet/reports/latest)
 
 
 ### Runset **acapy-dotnet**
@@ -75,7 +150,7 @@ Runset Name: ACA-PY to AF-.NET
 
 All of the tests are currently running.
 
-*Status Note Updated: 2021.03.05*
+*Status Note Updated: 2021.03.18*
 
 #### Runset Details
 
@@ -83,15 +158,63 @@ All of the tests are currently running.
 - Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-dotnet/reports/latest)
 
 
-### Runset **acapy**
+### Runset **afgo-acapy**
 
-Runset Name: ACA-PY to ACA-Py
+Runset Name: AF-Go to ACA-PY
 
 ```tip
-**Latest results: 42 out of 42 (100%)**
+**Latest results: 0 out of 5 (0%)**
 
 
-*Last run: Wed Mar 17 17:13:23 PDT 2021*
+*Last run: Thu Mar 18 13:38:27 PDT 2021*
+```
+
+#### Current Runset Status
+
+None of the tests are currently working and issues have been created to try to determine three identified issues.
+One might be in the test suite, while two others appear to be in the Aries Framework Go.
+
+*Status Note Updated: 2021.03.17*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/afgo-b-acapy/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/afgo-b-acapy/reports/latest)
+
+
+### Runset **afj-acapy**
+
+Runset Name: AFJ to ACA-PY
+
+```tip
+**Latest results: 12 out of 13 (92%)**
+
+
+*Last run: Thu Mar 18 14:06:01 PDT 2021*
+```
+
+#### Current Runset Status
+
+All AIP10 tests are currently running, except for the tests with the holder proposing a proof, 
+as that feature is not supported in AFJ.
+
+*Status Note Updated: 2021.03.17*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-acapy/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/javascript-b-acapy/reports/latest)
+
+
+### Runset **afj**
+
+Runset Name: AFJ to AFJ
+
+```tip
+**Latest results: 18 out of 18 (100%)**
+
+
+*Last run: Wed Mar 17 17:12:09 PDT 2021*
 ```
 
 #### Current Runset Status
@@ -102,8 +225,31 @@ All of the tests being executed in this runset are passing.
 
 #### Runset Details
 
-- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy/reports/latest/index.html?redirect=false#behaviors)
-- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy/reports/latest)
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/javascript/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/javascript/reports/latest)
+
+
+### Runset **dotnet-acapy**
+
+Runset Name: AF-.NET to ACA-PY
+
+```tip
+**Latest results: 4 out of 13 (30%)**
+
+
+*Last run: Thu Mar 18 14:04:29 PDT 2021*
+```
+
+#### Current Runset Status
+
+More tests are failing than are passing when Aries Framework .NET is playing the issuer role. More investigation is needed.
+
+*Status Note Updated: 2021.03.17*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-acapy/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/dotnet-b-acapy/reports/latest)
 
 Jump back to the [interoperability summary](./README.md).
 

--- a/docs/afgo.md
+++ b/docs/afgo.md
@@ -4,8 +4,9 @@
 
 | Runset | ACME<br>(Issuer) | Bob<br>(Holder) | Faber<br>(Verfier) | Mallory<br>(Holder) | Scope | Results | 
 | ------ | :--------------: | :-------------: | :----------------: | :-----------------: | ----- | :-----: | 
-| [acapy-afgo](#runset-acapy-afgo) | acapy-main | afgo-master | acapy-main | acapy-main | pre-AIP 2.0 | [**0 / 5<br>0%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-afgo/reports/latest/index.html?redirect=false#behaviors) |
-| [afgo](#runset-afgo) | afgo-master | afgo-master | afgo-master | afgo-master | pre-AIP 2.0 | [**3 / 5<br>60%**](https://allure.vonx.io/api/allure-docker-service/projects/afgo/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-afgo](#runset-acapy-afgo) | acapy-main<br>0.6.0 | afgo-master<br>unknown | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | pre-AIP 2.0 | [**0 / 5<br>0%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-afgo/reports/latest/index.html?redirect=false#behaviors) |
+| [afgo-acapy](#runset-afgo-acapy) | afgo-master<br>unknown | acapy-main<br>0.6.0 | afgo-master<br>unknown | afgo-master<br>unknown | pre-AIP 2.0 | [**0 / 5<br>0%**](https://allure.vonx.io/api/allure-docker-service/projects/afgo-b-acapy/reports/latest/index.html?redirect=false#behaviors) |
+| [afgo](#runset-afgo) | afgo-master<br>unknown | afgo-master<br>unknown | afgo-master<br>unknown | afgo-master<br>unknown | pre-AIP 2.0 | [**3 / 5<br>60%**](https://allure.vonx.io/api/allure-docker-service/projects/afgo/reports/latest/index.html?redirect=false#behaviors) |
 
 ## Runset Notes
 
@@ -31,6 +32,30 @@ One might be in the test suite, while two others appear to be in the Aries Frame
 
 - Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-afgo/reports/latest/index.html?redirect=false#behaviors)
 - Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-afgo/reports/latest)
+
+
+### Runset **afgo-acapy**
+
+Runset Name: AF-Go to ACA-PY
+
+```tip
+**Latest results: 0 out of 5 (0%)**
+
+
+*Last run: Thu Mar 18 13:38:27 PDT 2021*
+```
+
+#### Current Runset Status
+
+None of the tests are currently working and issues have been created to try to determine three identified issues.
+One might be in the test suite, while two others appear to be in the Aries Framework Go.
+
+*Status Note Updated: 2021.03.17*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/afgo-b-acapy/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/afgo-b-acapy/reports/latest)
 
 
 ### Runset **afgo**

--- a/docs/dotnet.md
+++ b/docs/dotnet.md
@@ -4,11 +4,39 @@
 
 | Runset | ACME<br>(Issuer) | Bob<br>(Holder) | Faber<br>(Verfier) | Mallory<br>(Holder) | Scope | Results | 
 | ------ | :--------------: | :-------------: | :----------------: | :-----------------: | ----- | :-----: | 
-| [acapy-dotnet](#runset-acapy-dotnet) | acapy-main | dotnet-master | acapy-main | acapy-main | AIP 1.0 | [**25 / 25<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
-| [afj-dotnet](#runset-afj-dotnet) | javascript | dotnet-master | javascript | javascript | AIP 1.0 | [**13 / 13<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
-| [dotnet](#runset-dotnet) | dotnet-master | dotnet-master | dotnet-master | dotnet-master | AIP 1.0 | [**13 / 13<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-dotnet-javascript](#runset-acapy-dotnet-javascript) | acapy-main<br>0.6.0 | javascript<br>1.0.0 | dotnet-master<br> | acapy-main<br>0.6.0 | AIP 1.0 | [**10 / 13<br>76%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript-f-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-dotnet](#runset-acapy-dotnet) | acapy-main<br>0.6.0 | dotnet-master<br> | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | AIP 1.0 | [**25 / 25<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [afj-dotnet](#runset-afj-dotnet) | javascript<br>1.0.0 | dotnet-master<br> | javascript<br>1.0.0 | javascript<br>1.0.0 | AIP 1.0 | [**13 / 13<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [dotnet-acapy](#runset-dotnet-acapy) | dotnet-master<br> | acapy-main<br>0.6.0 | dotnet-master<br> | dotnet-master<br> | AIP 1.0 | [**4 / 13<br>30%**](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-acapy/reports/latest/index.html?redirect=false#behaviors) |
+| [dotnet-javascript](#runset-dotnet-javascript) | dotnet-master<br> | javascript<br>1.0.0 | dotnet-master<br> | dotnet-master<br> | AIP 1.0 | [**4 / 13<br>30%**](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-javascript/reports/latest/index.html?redirect=false#behaviors) |
+| [dotnet](#runset-dotnet) | dotnet-master<br> | dotnet-master<br> | dotnet-master<br> | dotnet-master<br> | AIP 1.0 | [**13 / 13<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/dotnet/reports/latest/index.html?redirect=false#behaviors) |
 
 ## Runset Notes
+
+### Runset **acapy-dotnet-javascript**
+
+Runset Name: ACA-PY to AF-.NET to AFJ
+
+```tip
+**Latest results: 10 out of 13 (76%)**
+
+
+*Last run: Thu Mar 18 13:41:35 PDT 2021*
+```
+
+#### Current Runset Status
+
+All tests are working, except for three tests that include Faber in the test run as an issuer.
+These tests are; T001-RFC0037@1.2, T001.2-RFC0037@1.2, T001.4-RFC0037@1.1 . Further investigation 
+is required to determine the issue in these three tests.
+
+*Status Note Updated: 2021.03.18*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript-f-dotnet/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-javascript-f-dotnet/reports/latest)
+
 
 ### Runset **acapy-dotnet**
 
@@ -25,7 +53,7 @@ Runset Name: ACA-PY to AF-.NET
 
 All of the tests are currently running.
 
-*Status Note Updated: 2021.03.05*
+*Status Note Updated: 2021.03.18*
 
 #### Runset Details
 
@@ -46,7 +74,7 @@ Runset Name: AFJ to AF-.NET
 
 #### Current Runset Status
 
-All but one of the tests being executed in this runset are passing. The failure is being investigated.
+All of the tests being executed in this runset are passing.
 
 *Status Note Updated: 2021.03.05*
 
@@ -54,6 +82,52 @@ All but one of the tests being executed in this runset are passing. The failure 
 
 - Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-dotnet/reports/latest/index.html?redirect=false#behaviors)
 - Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/javascript-b-dotnet/reports/latest)
+
+
+### Runset **dotnet-acapy**
+
+Runset Name: AF-.NET to ACA-PY
+
+```tip
+**Latest results: 4 out of 13 (30%)**
+
+
+*Last run: Thu Mar 18 14:04:29 PDT 2021*
+```
+
+#### Current Runset Status
+
+More tests are failing than are passing when Aries Framework .NET is playing the issuer role. More investigation is needed.
+
+*Status Note Updated: 2021.03.17*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-acapy/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/dotnet-b-acapy/reports/latest)
+
+
+### Runset **dotnet-javascript**
+
+Runset Name: AF-.NET to AFJ
+
+```tip
+**Latest results: 4 out of 13 (30%)**
+
+
+*Last run: Thu Mar 18 14:05:45 PDT 2021*
+```
+
+#### Current Runset Status
+
+More tests are failing than are passing when Aries Framework .NET is playing the issuer role. More investigation is needed.
+
+*Status Note Updated: 2021.03.18*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-javascript/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/dotnet-b-javascript/reports/latest)
 
 
 ### Runset **dotnet**

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -4,9 +4,12 @@
 
 | Runset | ACME<br>(Issuer) | Bob<br>(Holder) | Faber<br>(Verfier) | Mallory<br>(Holder) | Scope | Results | 
 | ------ | :--------------: | :-------------: | :----------------: | :-----------------: | ----- | :-----: | 
-| [acapy-afj](#runset-acapy-afj) | acapy-main | javascript | acapy-main | acapy-main | AIP 1.0 | [**13 / 18<br>72%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors) |
-| [afj-dotnet](#runset-afj-dotnet) | javascript | dotnet-master | javascript | javascript | AIP 1.0 | [**13 / 13<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
-| [afj](#runset-afj) | javascript | javascript | javascript | javascript | AIP 1.0 | [**18 / 18<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-afj](#runset-acapy-afj) | acapy-main<br>0.6.0 | javascript<br>1.0.0 | acapy-main<br>0.6.0 | acapy-main<br>0.6.0 | AIP 1.0 | [**13 / 18<br>72%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors) |
+| [acapy-dotnet-javascript](#runset-acapy-dotnet-javascript) | acapy-main<br>0.6.0 | javascript<br>1.0.0 | dotnet-master<br> | acapy-main<br>0.6.0 | AIP 1.0 | [**10 / 13<br>76%**](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript-f-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [afj-acapy](#runset-afj-acapy) | javascript<br>1.0.0 | acapy-main<br>0.6.0 | javascript<br>1.0.0 | javascript<br>1.0.0 | AIP 1.0 | [**12 / 13<br>92%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-acapy/reports/latest/index.html?redirect=false#behaviors) |
+| [afj-dotnet](#runset-afj-dotnet) | javascript<br>1.0.0 | dotnet-master<br> | javascript<br>1.0.0 | javascript<br>1.0.0 | AIP 1.0 | [**13 / 13<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-dotnet/reports/latest/index.html?redirect=false#behaviors) |
+| [afj](#runset-afj) | javascript<br>1.0.0 | acapy<br>0.6.0 | javascript<br>1.0.0 | javascript<br>1.0.0 | AIP 1.0 | [**18 / 18<br>100%**](https://allure.vonx.io/api/allure-docker-service/projects/javascript/reports/latest/index.html?redirect=false#behaviors) |
+| [dotnet-javascript](#runset-dotnet-javascript) | dotnet-master<br> | javascript<br>1.0.0 | dotnet-master<br> | dotnet-master<br> | AIP 1.0 | [**4 / 13<br>30%**](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-javascript/reports/latest/index.html?redirect=false#behaviors) |
 
 ## Runset Notes
 
@@ -23,16 +26,63 @@ Runset Name: ACA-PY to AFJ
 
 #### Current Runset Status
 
-Only about half of the tests are currently running. The issues seem to be related to the set of tags
-of the test cases being run as a number of the revocation tests are running and shouldn't be. As well,
-the tests with the holder proposing a proof are not running, as that feature is not supported in AFJ.
+Most of the tests are running. The tests not passing are being investigated.
 
-*Status Note Updated: 2021.03.08*
+*Status Note Updated: 2021.03.18*
 
 #### Runset Details
 
 - Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript/reports/latest/index.html?redirect=false#behaviors)
 - Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-javascript/reports/latest)
+
+
+### Runset **acapy-dotnet-javascript**
+
+Runset Name: ACA-PY to AF-.NET to AFJ
+
+```tip
+**Latest results: 10 out of 13 (76%)**
+
+
+*Last run: Thu Mar 18 13:41:35 PDT 2021*
+```
+
+#### Current Runset Status
+
+All tests are working, except for three tests that include Faber in the test run as an issuer.
+These tests are; T001-RFC0037@1.2, T001.2-RFC0037@1.2, T001.4-RFC0037@1.1 . Further investigation 
+is required to determine the issue in these three tests.
+
+*Status Note Updated: 2021.03.18*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/acapy-b-javascript-f-dotnet/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/acapy-b-javascript-f-dotnet/reports/latest)
+
+
+### Runset **afj-acapy**
+
+Runset Name: AFJ to ACA-PY
+
+```tip
+**Latest results: 12 out of 13 (92%)**
+
+
+*Last run: Thu Mar 18 14:06:01 PDT 2021*
+```
+
+#### Current Runset Status
+
+All AIP10 tests are currently running, except for the tests with the holder proposing a proof, 
+as that feature is not supported in AFJ.
+
+*Status Note Updated: 2021.03.17*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/javascript-b-acapy/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/javascript-b-acapy/reports/latest)
 
 
 ### Runset **afj-dotnet**
@@ -48,7 +98,7 @@ Runset Name: AFJ to AF-.NET
 
 #### Current Runset Status
 
-All but one of the tests being executed in this runset are passing. The failure is being investigated.
+All of the tests being executed in this runset are passing.
 
 *Status Note Updated: 2021.03.05*
 
@@ -79,6 +129,29 @@ All of the tests being executed in this runset are passing.
 
 - Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/javascript/reports/latest/index.html?redirect=false#behaviors)
 - Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/javascript/reports/latest)
+
+
+### Runset **dotnet-javascript**
+
+Runset Name: AF-.NET to AFJ
+
+```tip
+**Latest results: 4 out of 13 (30%)**
+
+
+*Last run: Thu Mar 18 14:05:45 PDT 2021*
+```
+
+#### Current Runset Status
+
+More tests are failing than are passing when Aries Framework .NET is playing the issuer role. More investigation is needed.
+
+*Status Note Updated: 2021.03.18*
+
+#### Runset Details
+
+- Results grouped by [executed Aries RFCs executed](https://allure.vonx.io/api/allure-docker-service/projects/dotnet-b-javascript/reports/latest/index.html?redirect=false#behaviors)
+- Results by [history](https://allure.vonx.io/allure-docker-service-ui/projects/dotnet-b-javascript/reports/latest)
 
 Jump back to the [interoperability summary](./README.md).
 


### PR DESCRIPTION
Adding all of the new runsets into the results, so we now have more combinations of tests.

Because of a change in the workflow files, had to change the method of getting the what roles is played by what test-agent.  
Probably a good thing anyway -- that was dependent on "active" YAML, and is now dependent on Allure data. The data
from the workflows are now only comments.

As a bonus, collected the version of each agent added it to the data displayed.
