### PR TITLE
download google sheet as part of bcgendata.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ _site/
 .jekyll-metadata
 .env
 Gemfile.lock
+
+env
+.python-version
+.vscode/settings.json

--- a/TEST_DEV_GUIDE.md
+++ b/TEST_DEV_GUIDE.md
@@ -91,11 +91,13 @@ Defining specific tags should be discussed with the Aries Protocol test communit
 
 ## Defining Backchannel Operations
 
-Defining test steps require using and extending the commands and operations to be implemented by the backchannels. The commands and operations are documented in a Google Sheet, located [here](https://bit.ly/AriesTestHarnessScenarios). All operations are also documented in an OpenAPI Spec located [here](./docs/assets/openapi-spec.yml). The OpenAPI spec can be viewed using [Swagger UI](https://github.com/swagger-api/swagger-ui) locally or online using a tool like [Swagger Editor](https://editor.swagger.io/). As test developers add new steps to test cases, document the new operations on which they depend in the spreadsheet and the OpenAPI spec. The data from the Google Sheet is available to the backchannels and are used by some to implement the backchannel capabilities. Making the data available is currently a manual process that is done using the following process:
+Defining test steps require using and extending the commands and operations to be implemented by the backchannels. The commands and operations are documented in a Google Sheet, located [here](https://bit.ly/AriesTestHarnessScenarios). All operations are also documented in an OpenAPI Spec located [here](./docs/assets/openapi-spec.yml). The OpenAPI spec can be viewed on the Aries Interop page [here](http://aries-interop.info/api). As test developers add new steps to test cases, document the new operations on which they depend in the spreadsheet and the OpenAPI spec. The data from the Google Sheet is available to the backchannels and are used by some to implement the backchannel capabilities. Making the data available is currently a manual process that is done using the following process:
 
 - prepare a branch in your fork of the repo that will be a PR
-- export the Google Sheet, saving it into this file in the repo: [steps/Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv](./aries-test-harness/features/Mapping%20Aries%20Protocols%20for%20Testing%20-%20Aries%20Agent%20Test%20Scripts.csv)
-- run the command in the `aries-test-harness/features` folder: `python genBCdata.py Mapping\ Aries\ Protocols\ for\ Testing\ -\ Aries\ Agent\ Test\ Scripts.csv`
+  - [optional] export the Google Sheet, saving it into this file in the repo: [steps/Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv](./aries-test-harness/features/Mapping%20Aries%20Protocols%20for%20Testing%20-%20Aries%20Agent%20Test%20Scripts.csv)
+- run the command in the `aries-test-harness/features` folder: 
+  - If you used the public Google sheet, you can skip the previous [optional] step and run: `python genBCdata.py`. This wil download the latest version automatically
+  - Otherwise run: python genBCdata.py Mapping\ Aries\ Protocols\ for\ Testing\ -\ Aries\ Agent\ Test\ Scripts.csv
   - this will replace the current data file in the `aries-backchannels/data` folder
 - submit a PR to update the file
 

--- a/aries-test-harness/features/genBCData.py
+++ b/aries-test-harness/features/genBCData.py
@@ -3,12 +3,32 @@
 import csv
 import os.path
 import sys
+import urllib.request
 
-if ( (len(sys.argv) - 1 < 1) or ( not os.path.isfile(sys.argv[1]) ) ):
-    print("Error: Input file name saved from Google Sheet must be provided as a parameter and exist.")
-    exit(1)
 
-input = sys.argv[1]
+def download_sheet():
+    long_id = "1r40t6TRAoMrmDO7vM_o6eOmk6jvxUr189wZVNBcdgVs"
+    gid = "402169133"
+
+    csv_url = f"https://docs.google.com/spreadsheets/d/{long_id}/export?gid={gid}&format=csv&id={long_id}"
+    xlsx_url = f"https://docs.google.com/spreadsheets/d/{long_id}/export?format=xlsx&id={long_id}"
+
+    urllib.request.urlretrieve(xlsx_url, "./Mapping Aries Protocols for Testing - Aries Agent Test Scripts.xlsx")
+    urllib.request.urlretrieve(csv_url, "./Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv")
+
+# If filename provided use that
+if (len(sys.argv) - 1 >= 1):
+    if not os.path.isfile(sys.argv[1]):
+        print("Error: Input file name does not exist. Google Sheet must be provided as a parameter and exist.")
+        exit(1)
+
+    input = sys.argv[1]
+# Else download the public sheet
+else:
+    download_sheet()
+    input = "./Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv"
+
+
 rfc = None
 command_rows = {}
 fieldnames = None
@@ -49,7 +69,7 @@ with open(input, "r") as proto_file:
                     old_row[key] = new_row[key]
             command_rows[row_key] = old_row
 
-with open('../../aries-backchannel/data/backchannel_operations.csv', 'w') as command_file:
+with open('../../aries-backchannels/data/backchannel_operations.csv', 'w') as command_file:
     writer = csv.DictWriter(command_file, fieldnames=fieldnames)
     writer.writeheader()
     for key, val in command_rows.items():

--- a/docs/aries-interop-intro.md
+++ b/docs/aries-interop-intro.md
@@ -84,4 +84,4 @@ If you are a stakeholder interested in improving the results for an agent, this 
 
 Finally, if you want your Aries agent to be added to this website, or wish to expand the tests covered for your agent, your developers can reference the extensive information in the [Aries Agent Test Harness repo](https://github.com/hyperledger/aries-agent-test-harness) on GitHub.
 
-In addition an API reference for backchannels can be found here: http://aries-interop.info/api.html
+In addition an API reference for backchannels can be found [here](http://aries-interop.info/api.html)


### PR DESCRIPTION
Automatically download the `.xlsx` and `.csv` files from the Google sheet before generating (if no file path if passed to the script). Removes the manual export step and makes sure we always have the source files for the current generated files in the repo

Haven't updated the files yet as we first need to determine the correct source file to use.