### PR TITLE
Proposed change to test parametrization

### DIFF
--- a/aries-test-harness/allure/allure-results/environment.properties
+++ b/aries-test-harness/allure/allure-results/environment.properties
@@ -1,8 +1,8 @@
-role.acme=acapy-klump-agent-backchannel
+role.acme=acapy-main-agent-backchannel
 acme.agent.version=0.6.0
-role.bob=acapy-klump-agent-backchannel
+role.bob=acapy-main-agent-backchannel
 bob.agent.version=0.6.0
-role.faber=acapy-klump-agent-backchannel
+role.faber=acapy-main-agent-backchannel
 faber.agent.version=0.6.0
-role.mallory=acapy-klump-agent-backchannel
+role.mallory=acapy-main-agent-backchannel
 mallory.agent.version=0.6.0

--- a/aries-test-harness/features/0453-issue-credential-v2.feature
+++ b/aries-test-harness/features/0453-issue-credential-v2.feature
@@ -1,14 +1,13 @@
 @RFC0453 @AIP20
 Feature: RFC 0453 Aries Agent Issue Credential v2
 
-  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_Indy @Schema_DriversLicense_v2
-  Scenario Outline: Issue a Indy credential with the Holder beginning with a proposal
+  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @DIDExchangeConnection @Schema_DriversLicense_v2
+  Scenario Outline: Issue a Credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
       | Acme | issuer |
       | Bob  | holder |
-    Given "Acme" has a public did
-    And "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
+    Given "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
     And "Acme" and "Bob" have an existing connection
     When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
     And "Acme" offers the "<credential_format>" credential
@@ -17,45 +16,17 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
     And "Bob" acknowledges the "<credential_format>" credential issue
     Then "Bob" has the "<credential_format>" credential issued
 
-    Examples:
+    @CredFormat_Indy
+    Examples: Indy
       | credential_data   | credential_format | signature_suite | did_method |
       | Data_DL_MaxValues | indy              | n/a             | sov        |
 
-  @T001.1-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2
-  Scenario Outline: Issue a JSON-LD Ed25519Signature2018 credential with the Holder beginning with a proposal
-    Given "2" agents
-      | name | role   |
-      | Acme | issuer |
-      | Bob  | holder |
-    And "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
-    And "Acme" and "Bob" have an existing connection
-    When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
-    And "Acme" offers the "<credential_format>" credential
-    And "Bob" requests the "<credential_format>" credential
-    And "Acme" issues the "<credential_format>" credential
-    And "Bob" acknowledges the "<credential_format>" credential issue
-    Then "Bob" has the "<credential_format>" credential issued
-
-    Examples:
+    @CredFormat_JSON-LD
+    Examples: Json-LD
       | credential_data   | credential_format | signature_suite      | did_method |
       | Data_DL_MaxValues | json-ld           | Ed25519Signature2018 | key        |
 
-  @T001.2-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2
-  Scenario Outline: Issue a JSON-LD BbsBlsSignature2020 credential with the Holder beginning with a proposal
-    Given "2" agents
-      | name | role   |
-      | Acme | issuer |
-      | Bob  | holder |
-    And "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
-    And "Acme" and "Bob" have an existing connection
-    When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
-    And "Acme" offers the "<credential_format>" credential
-    And "Bob" requests the "<credential_format>" credential
-    And "Acme" issues the "<credential_format>" credential
-    And "Bob" acknowledges the "<credential_format>" credential issue
-    Then "Bob" has the "<credential_format>" credential issued
-
-    Examples:
+    @CredFormat_JSON-BBS
       | credential_data   | credential_format | signature_suite      | did_method |
       | Data_DL_MaxValues | json-ld           | BbsBlsSignature2020  | key        |
 

--- a/aries-test-harness/features/0453-issue-credential-v2.feature
+++ b/aries-test-harness/features/0453-issue-credential-v2.feature
@@ -8,56 +8,56 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
       | Acme | issuer |
       | Bob  | holder |
     Given "Acme" has a public did
-    And "Acme" is ready to issue a credential
+    And "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
     And "Acme" and "Bob" have an existing connection
-    When "Bob" proposes a "indy" credential to "Acme" with <credential_data>
-    And "Acme" offers the "indy" credential
-    And "Bob" requests the "indy" credential
-    And "Acme" issues the "indy" credential
-    And "Bob" acknowledges the "indy" credential issue
-    Then "Bob" has the "indy" credential issued
+    When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
+    And "Acme" offers the "<credential_format>" credential
+    And "Bob" requests the "<credential_format>" credential
+    And "Acme" issues the "<credential_format>" credential
+    And "Bob" acknowledges the "<credential_format>" credential issue
+    Then "Bob" has the "<credential_format>" credential issued
 
     Examples:
-      | credential_data   |
-      | Data_DL_MaxValues |
+      | credential_data   | credential_format | signature_suite | did_method |
+      | Data_DL_MaxValues | indy              | n/a             | sov        |
 
-  @T001.1-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2 @ProofType_Ed25519Signature2018 @DidMethod_key
+  @T001.1-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2
   Scenario Outline: Issue a JSON-LD Ed25519Signature2018 credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
       | Acme | issuer |
       | Bob  | holder |
-    And "Acme" is ready to issue a "json-ld" credential
+    And "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
     And "Acme" and "Bob" have an existing connection
-    When "Bob" proposes a "json-ld" credential to "Acme" with <credential_data>
-    And "Acme" offers the "json-ld" credential
-    And "Bob" requests the "json-ld" credential
-    And "Acme" issues the "json-ld" credential
-    And "Bob" acknowledges the "json-ld" credential issue
-    Then "Bob" has the "json-ld" credential issued
+    When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
+    And "Acme" offers the "<credential_format>" credential
+    And "Bob" requests the "<credential_format>" credential
+    And "Acme" issues the "<credential_format>" credential
+    And "Bob" acknowledges the "<credential_format>" credential issue
+    Then "Bob" has the "<credential_format>" credential issued
 
     Examples:
-      | credential_data   |
-      | Data_DL_MaxValues |
+      | credential_data   | credential_format | signature_suite      | did_method |
+      | Data_DL_MaxValues | json-ld           | Ed25519Signature2018 | key        |
 
-  @T001.2-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2 @ProofType_BbsBlsSignature2020 @DidMethod_key
+  @T001.2-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2
   Scenario Outline: Issue a JSON-LD BbsBlsSignature2020 credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
       | Acme | issuer |
       | Bob  | holder |
-    And "Acme" is ready to issue a "json-ld" credential
+    And "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
     And "Acme" and "Bob" have an existing connection
-    When "Bob" proposes a "json-ld" credential to "Acme" with <credential_data>
-    And "Acme" offers the "json-ld" credential
-    And "Bob" requests the "json-ld" credential
-    And "Acme" issues the "json-ld" credential
-    And "Bob" acknowledges the "json-ld" credential issue
-    Then "Bob" has the "json-ld" credential issued
+    When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
+    And "Acme" offers the "<credential_format>" credential
+    And "Bob" requests the "<credential_format>" credential
+    And "Acme" issues the "<credential_format>" credential
+    And "Bob" acknowledges the "<credential_format>" credential issue
+    Then "Bob" has the "<credential_format>" credential issued
 
     Examples:
-      | credential_data   |
-      | Data_DL_MaxValues |
+      | credential_data   | credential_format | signature_suite      | did_method |
+      | Data_DL_MaxValues | json-ld           | BbsBlsSignature2020  | key        |
 
 
   @T002-RFC0453 @normal @wip @AcceptanceTest @DIDExchangeConnection @CredFormat_Indy @Schema_DriversLicense_v2

--- a/aries-test-harness/features/0453-issue-credential-v2.feature
+++ b/aries-test-harness/features/0453-issue-credential-v2.feature
@@ -1,13 +1,13 @@
 @RFC0453 @AIP20
 Feature: RFC 0453 Aries Agent Issue Credential v2
 
-  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @DIDExchangeConnection @Schema_DriversLicense_v2
+  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @DIDExchangeConnection
   Scenario Outline: Issue a Credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
       | Acme | issuer |
       | Bob  | holder |
-    Given "Acme" is ready to issue a "<credential_format>" credential using signature suite "<signature_suite>" and did method "<did_method>"
+    Given "Acme" is ready to issue a "<credential_format>" credential
     And "Acme" and "Bob" have an existing connection
     When "Bob" proposes a "<credential_format>" credential to "Acme" with <credential_data>
     And "Acme" offers the "<credential_format>" credential
@@ -16,19 +16,20 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
     And "Bob" acknowledges the "<credential_format>" credential issue
     Then "Bob" has the "<credential_format>" credential issued
 
-    @CredFormat_Indy
+    @CredFormat_Indy @Schema_DriversLicense_v2 @DidMethod_sov
     Examples: Indy
-      | credential_data   | credential_format | signature_suite | did_method |
-      | Data_DL_MaxValues | indy              | n/a             | sov        |
+      | credential_data   | credential_format |
+      | Data_DL_MaxValues | indy              |
 
-    @CredFormat_JSON-LD
+    @CredFormat_JSON-LD @Schema_DriversLicense_v2 @ProofType_Ed25519Signature2018 @DidMethod_key
     Examples: Json-LD
-      | credential_data   | credential_format | signature_suite      | did_method |
-      | Data_DL_MaxValues | json-ld           | Ed25519Signature2018 | key        |
+      | credential_data   | credential_format |
+      | Data_DL_MaxValues | json-ld           |
 
-    @CredFormat_JSON-BBS
-      | credential_data   | credential_format | signature_suite      | did_method |
-      | Data_DL_MaxValues | json-ld           | BbsBlsSignature2020  | key        |
+    @CredFormat_JSON-LD @Schema_DriversLicense_v2 @ProofType_BbsBlsSignature2020 @DidMethod_key
+    Examples: Json-LD-BBS
+      | credential_data   | credential_format |
+      | Data_DL_MaxValues | json-ld           |
 
 
   @T002-RFC0453 @normal @wip @AcceptanceTest @DIDExchangeConnection @CredFormat_Indy @Schema_DriversLicense_v2

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -7,12 +7,13 @@ from time import sleep
 CRED_FORMAT_INDY = "indy"
 CRED_FORMAT_JSON_LD = "json-ld"
 
-@given('"{issuer}" is ready to issue a "{cred_format}" credential')
+@given('"{issuer}" is ready to issue a "{cred_format}" credential using signature suite "<signature_suite>" and did method "<did_method>"')
 def step_impl(context, issuer: str, cred_format: str = CRED_FORMAT_INDY):
     if cred_format == CRED_FORMAT_INDY:
         # Call legacy indy ready to issue credential step
         context.execute_steps(f'''
-            Given '"{issuer}" is ready to issue a credential'
+            Given '"{issuer}" has a public did'
+            And '"{issuer}" is ready to issue a credential'
         ''')
     elif cred_format == CRED_FORMAT_JSON_LD:
         issuer_url = context.config.userdata.get(issuer)

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -7,13 +7,13 @@ from time import sleep
 CRED_FORMAT_INDY = "indy"
 CRED_FORMAT_JSON_LD = "json-ld"
 
-@given('"{issuer}" is ready to issue a "{cred_format}" credential using signature suite "<signature_suite>" and did method "<did_method>"')
+@given('"{issuer}" is ready to issue a "{cred_format}" credential')
 def step_impl(context, issuer: str, cred_format: str = CRED_FORMAT_INDY):
     if cred_format == CRED_FORMAT_INDY:
         # Call legacy indy ready to issue credential step
         context.execute_steps(f'''
-            Given '"{issuer}" has a public did'
-            And '"{issuer}" is ready to issue a credential'
+            Given "{issuer}" has a public did
+            And "{issuer}" is ready to issue a credential
         ''')
     elif cred_format == CRED_FORMAT_JSON_LD:
         issuer_url = context.config.userdata.get(issuer)


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

We're currently using a combination of "example" parameters and tags to configure the tests.

I propose to use only the example parameters, not the tags, to provide the configuration options for each test.  (IMHO tags should describe the tests but not configure them.  I find the mixed approach confusing, maybe it's just me!)

Looking for feedback before I make any changes - in this draft PR I updated the feature file for @T001-RFC0453, as well as the *.1 and *.2 version of this test.  With this change, the 3 scenarios can be collapsed into 1, with 3 sets of "example" parameters.  (Note I didn't collapse it yet in this PR, but you can see that all the steps are exactly the same.)

Thoughts?