### PR TITLE
fix: small error fixes for acapy-afgo interop

### DIFF
--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -46,8 +46,8 @@ jobs:
           TEST_SCOPE: "-t @RFC0023 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023"
           REPORT_PROJECT: acapy-b-afgo
         env:
-          EMIT-NEW-DIDCOMM-PREFIX: true
-          EMIT-NEW-DIDCOMM-MIME-TYPE: true
+          EMIT_NEW_DIDCOMM_PREFIX: true
+          EMIT_NEW_DIDCOMM_MIME_TYPE: true
         continue-on-error: true
       - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -236,11 +236,11 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             # if the tails server env is not set use the gov.bc TEST tails server.
             result.append(("--tails-server-base-url", "https://tails-server-test.pathfinder.gov.bc.ca"))
         
-        if AIP_CONFIG >= 20 or os.getenv('EMIT-NEW-DIDCOMM-PREFIX') is not None:
+        if AIP_CONFIG >= 20 or os.getenv('EMIT_NEW_DIDCOMM_PREFIX') is not None:
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-prefix"))
 
-        if AIP_CONFIG >= 20 or os.getenv('EMIT-NEW-DIDCOMM-MIME-TYPE') is not None:
+        if AIP_CONFIG >= 20 or os.getenv('EMIT_NEW_DIDCOMM_MIME_TYPE') is not None:
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-mime-type"))
 

--- a/aries-backchannels/afgo/afgo_backchannel.py
+++ b/aries-backchannels/afgo/afgo_backchannel.py
@@ -504,7 +504,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
     async def handle_did_exchange_POST(self, op, rec_id=None, data=None):
         operation = op["operation"]
-        agent_operation = "didexchange"
+        agent_operation = "/didexchange"
 
         if operation == "send-message":
             agent_operation = f"/connections/{rec_id}/accept-request"
@@ -620,7 +620,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
             # resp_text = json.dumps(did)
             # return (resp_status, resp_text)
-            return (411, {})
+            return (411, "")
 
         elif op["topic"] == "schema":
             schema_id = rec_id

--- a/aries-backchannels/python/utils.py
+++ b/aries-backchannels/python/utils.py
@@ -119,7 +119,7 @@ def output_reader(handle, callback, *args, **kwargs):
         return
         
     for line in iter(handle.readline, b""):
-        if not line:
+        if not line and line != "":
             break
         run_in_terminal(functools.partial(callback, line, *args))
 


### PR DESCRIPTION
- fixed some environment variables that had dashes
- add leading / to a path in afgo backchannel, so urls are constructed
  correctly
- return empty string instead of dict in a stub that should return a string
- don't skip processing empty strings in utils/output_reader

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>