### PR TITLE
comment out line that causes agent start problem

### DIFF
--- a/manage
+++ b/manage
@@ -379,7 +379,7 @@ startAgent() {
     echo "Starting ${NAME} Agent using ${IMAGE_NAME} ..."
     local container_id=$(docker run -d -it --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${ENV_FILE_ARG} -e "NGROK_NAME=${NGROK_NAME}" -e "DOCKERHOST=${DOCKERHOST}" -e "AGENT_NAME=${NAME}" -e "LEDGER_URL=${LEDGER_URL_INTERNAL}" -e "TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}" -e "AIP_CONFIG=${AIP_CONFIG}" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
     sleep 1
-    docker network connect aath_network "${CONTAINER_NAME}"
+    #docker network connect aath_network "${CONTAINER_NAME}"
     if [[ "${IMAGE_NAME}" = "mobile-agent-backchannel" ]]; then
       echo "Tail-ing log files for ${NAME} agent in ${container_id}"
       docker logs -f ${container_id} &


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>
A recent PR for that adds support for auxiliary services #244 is continuing to cause acapy agent startup issues. I've commented out the line that causes the problem in the manage script.
 
@Moopli  further investigation is needed to determine why this problem exists. Multiple people are continually hitting this issue and it is slowing down velocity. 