### PR TITLE
Cred id bypass invite create

### DIFF
--- a/aries-test-harness/features/steps/0160-connection.py
+++ b/aries-test-harness/features/steps/0160-connection.py
@@ -133,7 +133,11 @@ def step_impl(context, invitee):
         # This means the connection id was not retreived for the inviter in the create invitation step
         # The assumption made at this point is that both the inviter and invitee share the same connection_id
         # Add the connection id from the reponse invitee receive invitation as the initer connection id.
-        context.connection_id_dict[context.inviter_name][invitee] = resp_json["connection_id"]
+        #context.connection_id_dict[context.inviter_name][invitee] = resp_json["connection_id"]
+        (alt_resp_status, alt_resp_text) = agent_backchannel_GET(context.inviter_url + "/agent/response/", "conection", id=context.inviter_invitation["@id"])
+        assert alt_resp_status == 200, f'resp_status {alt_resp_status} is not 200; {alt_resp_text}'
+        alt_resp_json = json.loads(alt_resp_text)
+        context.connection_id_dict[context.inviter_name][invitee] = alt_resp_json["connection_id"]
 
     # Check to see if the invitee_name exists in context. If not, another suite is using it so set the invitee name and url
     if not hasattr(context, 'invitee_name'):

--- a/aries-test-harness/features/steps/0160-connection.py
+++ b/aries-test-harness/features/steps/0160-connection.py
@@ -131,13 +131,12 @@ def step_impl(context, invitee):
             context.temp_connection_id_dict.clear()
     else:
         # This means the connection id was not retreived for the inviter in the create invitation step
-        # The assumption made at this point is that both the inviter and invitee share the same connection_id
-        # Add the connection id from the reponse invitee receive invitation as the initer connection id.
-        #context.connection_id_dict[context.inviter_name][invitee] = resp_json["connection_id"]
+        # Get the connection id for the inviter given the invitation_id
+        #context.connection_id_dict[context.inviter_name] = {invitee:  resp_json["connection_id"]}
         (alt_resp_status, alt_resp_text) = agent_backchannel_GET(context.inviter_url + "/agent/response/", "conection", id=context.inviter_invitation["@id"])
         assert alt_resp_status == 200, f'resp_status {alt_resp_status} is not 200; {alt_resp_text}'
         alt_resp_json = json.loads(alt_resp_text)
-        context.connection_id_dict[context.inviter_name][invitee] = alt_resp_json["connection_id"]
+        context.connection_id_dict[context.inviter_name] = {invitee: alt_resp_json["connection_id"]}
 
     # Check to see if the invitee_name exists in context. If not, another suite is using it so set the invitee name and url
     if not hasattr(context, 'invitee_name'):


### PR DESCRIPTION
This PR updates the secondary get of the inviter's connection_id at the point the invitee accepts the invitation in the 160 Connection Protocol tests. There is now a call to get the connection id based on the invitation id. 