### PR TITLE
Back-channels cleanup

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -3,28 +3,35 @@ import functools
 import json
 import logging
 import os
-import random
 import subprocess
 import sys
-import uuid
+
 from timeit import default_timer
-from time import sleep
-from operator import itemgetter
+from typing import Tuple
 
 from aiohttp import (
     web,
     ClientSession,
     ClientRequest,
-    ClientResponse,
     ClientError,
     ClientTimeout,
 )
 
-from python.agent_backchannel import AgentBackchannel, default_genesis_txns, RUN_MODE, START_TIMEOUT
-from python.utils import require_indy, flatten, log_json, log_msg, log_timer, output_reader, prompt_loop
-from python.storage import store_resource, get_resource, delete_resource, push_resource, pop_resource, pop_resource_latest
+from python.agent_backchannel import (
+    AgentBackchannel,
+    default_genesis_txns,
+    RUN_MODE,
+    START_TIMEOUT,
+)
+from python.utils import flatten, log_msg, output_reader, prompt_loop
+from python.storage import (
+    get_resource,
+    push_resource,
+    pop_resource,
+    pop_resource_latest,
+)
 
-#from helpers.jsonmapper.json_mapper import JsonMapper
+# from helpers.jsonmapper.json_mapper import JsonMapper
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,39 +55,33 @@ elif RUN_MODE == "pwd":
 
 class AcaPyAgentBackchannel(AgentBackchannel):
     def __init__(
-        self, 
+        self,
         ident: str,
         http_port: int,
         admin_port: int,
         genesis_data: str = None,
-        params: dict = {}
+        params: dict = {},
     ):
-        super().__init__(
-            ident,
-            http_port,
-            admin_port,
-            genesis_data,
-            params
-        )
+        super().__init__(ident, http_port, admin_port, genesis_data, params)
 
         # get aca-py version if available
         self.acapy_version = None
         try:
-            with open('./acapy-version.txt', 'r') as file:
+            with open("./acapy-version.txt", "r") as file:
                 self.acapy_version = file.readline()
-        except:
+        except Exception:
             # ignore errors
             pass
 
         # set the acapy AIP version, defaulting to AIP10
-        self.aip_version = "AIP10" 
+        self.aip_version = "AIP10"
 
         # Aca-py : RFC
         self.connectionStateTranslationDict = {
             "invitation": "invited",
             "request": "requested",
             "response": "responded",
-            "active": "complete"
+            "active": "complete",
         }
 
         # Aca-py : RFC
@@ -93,7 +94,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "request_received": "request-received",
             "credential_issued": "credential-issued",
             "credential_received": "credential-received",
-            "credential_acked": "done"
+            "credential_acked": "done",
         }
 
         # AATH API : Acapy Admin API
@@ -102,7 +103,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "send-offer": "send-offer",
             "send-request": "send-request",
             "issue": "issue",
-            "store": "store"
+            "store": "store",
         }
 
         # AATH API : Acapy Admin API
@@ -111,24 +112,21 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "send-presentation": "send-presentation",
             "send-request": "send-request",
             "verify-presentation": "verify-presentation",
-            "send-proposal": "send-proposal"
-        }        
+            "send-proposal": "send-proposal",
+        }
 
         # AATH API : Acapy Admin API
         self.TopicTranslationDict = {
             "issue-credential": "/issue-credential/",
             "issue-credential-v2": "/issue-credential-2.0/",
-            "proof-v2": "/present-proof-2.0/"
+            "proof-v2": "/present-proof-2.0/",
         }
 
-        self.credFormatFilterTranslationDict = {
-            "indy": "indy",
-            "json-ld": "ld_proof"
-        }
+        self.credFormatFilterTranslationDict = {"indy": "indy", "json-ld": "ld_proof"}
 
         self.proofTypeKeyTypeTranslationDict = {
             "Ed25519Signature2018": "ed25519",
-            "BbsBlsSignature2020": "bls12381g2"
+            "BbsBlsSignature2020": "bls12381g2",
         }
 
         # Aca-py : RFC
@@ -141,7 +139,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "presentation_received": "presentation-received",
             "reject_sent": "reject-sent",
             "verified": "done",
-            "presentation_acked": "done"
+            "presentation_acked": "done",
         }
 
         # Aca-py : RFC
@@ -149,19 +147,19 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "initial": "invitation-sent",
             "invitation": "invitation-received",
             "request": "request-received",
-            "response": "response-sent", 
+            "response": "response-sent",
             "?": "abandoned",
-            "active": "completed"
+            "active": "completed",
         }
 
         # Aca-py : RFC
         self.didExchangeRequesterStateTranslationDict = {
-            "initial": "invitation-sent", 
+            "initial": "invitation-sent",
             "invitation": "invitation-received",
-            "request": "request-sent", 
-            "response": "response-received", 
+            "request": "request-sent",
+            "response": "response-received",
             "?": "abandoned",
-            "active": "completed"
+            "active": "completed",
         }
 
     def get_acapy_version_as_float(self):
@@ -177,7 +175,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         descriptiveTrailer = "-"
         comparibleVersion = self.acapy_version
         if comparibleVersion.startswith("0"):
-            comparibleVersion = comparibleVersion[len("0"):]
+            comparibleVersion = comparibleVersion[len("0") :]
         if "." in comparibleVersion:
             stringParts = comparibleVersion.split(".")
             comparibleVersion = "".join(stringParts)
@@ -193,10 +191,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         result = [
             ("--endpoint", self.endpoint),
             ("--label", self.label),
-            #"--auto-ping-connection",
-            #"--auto-accept-invites", 
-            #"--auto-accept-requests", 
-            #"--auto-respond-messages",
+            # "--auto-ping-connection",
+            # "--auto-accept-invites",
+            # "--auto-accept-requests",
+            # "--auto-respond-messages",
             ("--inbound-transport", "http", "0.0.0.0", str(self.http_port)),
             ("--outbound-transport", "http"),
             ("--admin", "0.0.0.0", str(self.admin_port)),
@@ -226,32 +224,37 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             )
         if self.webhook_url:
             result.append(("--webhook-url", self.webhook_url))
-        
-        # This code for Tails Server is included here because aca-py does not support the env var directly yet. 
-        # when it does (and there is talk of supporting YAML) then this code can be removed. 
-        if os.getenv('TAILS_SERVER_URL') is not None:
+
+        # This code for Tails Server is included here because aca-py does not support the env var directly yet.
+        # when it does (and there is talk of supporting YAML) then this code can be removed.
+        if os.getenv("TAILS_SERVER_URL") is not None:
             # if the env var is set for tails server then use that.
-            result.append(("--tails-server-base-url", os.getenv('TAILS_SERVER_URL')))
+            result.append(("--tails-server-base-url", os.getenv("TAILS_SERVER_URL")))
         else:
             # if the tails server env is not set use the gov.bc TEST tails server.
-            result.append(("--tails-server-base-url", "https://tails-server-test.pathfinder.gov.bc.ca"))
-        
-        if AIP_CONFIG >= 20 or os.getenv('EMIT_NEW_DIDCOMM_PREFIX') is not None:
+            result.append(
+                (
+                    "--tails-server-base-url",
+                    "https://tails-server-test.pathfinder.gov.bc.ca",
+                )
+            )
+
+        if AIP_CONFIG >= 20 or os.getenv("EMIT_NEW_DIDCOMM_PREFIX") is not None:
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-prefix"))
 
-        if AIP_CONFIG >= 20 or os.getenv('EMIT_NEW_DIDCOMM_MIME_TYPE') is not None:
+        if AIP_CONFIG >= 20 or os.getenv("EMIT_NEW_DIDCOMM_MIME_TYPE") is not None:
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-mime-type"))
 
-        # This code for log level is included here because aca-py does not support the env var directly yet. 
-        # when it does (and there is talk of supporting YAML) then this code can be removed. 
-        if os.getenv('LOG_LEVEL') is not None:
-            result.append(("--log-level", os.getenv('LOG_LEVEL')))
+        # This code for log level is included here because aca-py does not support the env var directly yet.
+        # when it does (and there is talk of supporting YAML) then this code can be removed.
+        if os.getenv("LOG_LEVEL") is not None:
+            result.append(("--log-level", os.getenv("LOG_LEVEL")))
 
         # result.append(("--trace", "--trace-target", "log", "--trace-tag", "acapy.events", "--trace-label", "acapy",))
 
-        #if self.extra_args:
+        # if self.extra_args:
         #    result.extend(self.extra_args)
 
         return result
@@ -283,13 +286,13 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         if topic != "webhook":  # would recurse
             handler = f"handle_{topic}"
 
-            # Remove this handler change when bug is fixed. 
+            # Remove this handler change when bug is fixed.
             if handler == "handle_oob-invitation":
                 handler = "handle_oob_invitation"
 
             method = getattr(self, handler, None)
             # put a log message here
-            log_msg('Passing webhook payload to handler ' + handler)
+            log_msg("Passing webhook payload to handler " + handler)
             if method:
                 await method(payload)
             else:
@@ -299,7 +302,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     f"to handle webhook on topic {topic}"
                 )
         else:
-            log_msg('in webhook, topic is: ' + topic + ' payload is: ' + json.dumps(payload))
+            log_msg(
+                "in webhook, topic is: " + topic + " payload is: " + json.dumps(payload)
+            )
 
     async def handle_connections(self, message):
         if "request_id" in message:
@@ -314,51 +319,55 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             connection_id = message["connection_id"]
             push_resource(connection_id, "connection-msg", message)
         else:
-            raise Exception(f"Unknown message type in Connections Webhook: {json.dumps(message)}")
-        log_msg('Received a Connection Webhook message: ' + json.dumps(message))
+            raise Exception(
+                f"Unknown message type in Connections Webhook: {json.dumps(message)}"
+            )
+        log_msg("Received a Connection Webhook message: " + json.dumps(message))
 
     async def handle_issue_credential(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "credential-msg", message)
-        log_msg('Received Issue Credential Webhook message: ' + json.dumps(message)) 
-        if "revocation_id" in message: # also push as a revocation message 
+        log_msg("Received Issue Credential Webhook message: " + json.dumps(message))
+        if "revocation_id" in message:  # also push as a revocation message
             push_resource(thread_id, "revocation-registry-msg", message)
-            log_msg('Issue Credential Webhook message contains revocation info') 
+            log_msg("Issue Credential Webhook message contains revocation info")
 
     async def handle_issue_credential_v2_0(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "credential-msg", message)
-        log_msg('Received Issue Credential v2 Webhook message: ' + json.dumps(message)) 
-        if "revocation_id" in message: # also push as a revocation message 
+        log_msg("Received Issue Credential v2 Webhook message: " + json.dumps(message))
+        if "revocation_id" in message:  # also push as a revocation message
             push_resource(thread_id, "revocation-registry-msg", message)
-            log_msg('Issue Credential Webhook message contains revocation info') 
+            log_msg("Issue Credential Webhook message contains revocation info")
 
     async def handle_present_proof_v2_0(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "presentation-msg", message)
-        log_msg('Received a Present Proof v2 Webhook message: ' + json.dumps(message))
+        log_msg("Received a Present Proof v2 Webhook message: " + json.dumps(message))
 
     async def handle_present_proof(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "presentation-msg", message)
-        log_msg('Received a Present Proof Webhook message: ' + json.dumps(message))
+        log_msg("Received a Present Proof Webhook message: " + json.dumps(message))
 
     async def handle_revocation_registry(self, message):
         # No thread id in the webhook for revocation registry messages
         cred_def_id = message["cred_def_id"]
         push_resource(cred_def_id, "revocation-registry-msg", message)
-        log_msg('Received Revocation Registry Webhook message: ' + json.dumps(message)) 
+        log_msg("Received Revocation Registry Webhook message: " + json.dumps(message))
 
     async def handle_oob_invitation(self, message):
         # No thread id in the webhook for revocation registry messages
         invitation_id = message["invitation_id"]
         push_resource(invitation_id, "oob-inviation-msg", message)
-        log_msg('Received Out of Band Invitation Webhook message: ' + json.dumps(message)) 
+        log_msg(
+            "Received Out of Band Invitation Webhook message: " + json.dumps(message)
+        )
 
     async def handle_problem_report(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "problem-report-msg", message)
-        log_msg('Received Problem Report Webhook message: ' + json.dumps(message)) 
+        log_msg("Received Problem Report Webhook message: " + json.dumps(message))
 
     async def swap_thread_id_for_exchange_id(self, thread_id, data_type, id_txt):
         timeout = 0
@@ -372,7 +381,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 await asyncio.sleep(1)
                 timeout += 1
         if timeout == 20:
-            raise TimeoutError('Timeout waiting for web callback to retrieve the thread id based on the exchange id')
+            raise TimeoutError(
+                "Timeout waiting for web callback to retrieve the thread id based on the exchange id"
+            )
         return ex_id
 
     async def make_admin_request(
@@ -386,14 +397,14 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             resp_text = await resp.text()
             return (resp_status, resp_text)
 
-    async def admin_GET(self, path, text=False, params=None) -> (int, str):
+    async def admin_GET(self, path, text=False, params=None) -> Tuple[int, str]:
         try:
             return await self.make_admin_request("GET", path, None, text, params)
         except ClientError as e:
             self.log(f"Error during GET {path}: {str(e)}")
             raise
 
-    async def admin_DELETE(self, path, text=False, params=None) -> (int, str):
+    async def admin_DELETE(self, path, text=False, params=None) -> Tuple[int, str]:
         try:
             return await self.make_admin_request("DELETE", path, None, text, params)
         except ClientError as e:
@@ -402,7 +413,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
     async def admin_POST(
         self, path, data=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         try:
             return await self.make_admin_request("POST", path, data, text, params)
         except ClientError as e:
@@ -411,7 +422,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
     async def make_agent_POST_request(
         self, op, rec_id=None, data=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
 
         if op["topic"] == "connection":
             operation = op["operation"]
@@ -424,17 +435,26 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 invitation_resp = json.loads(resp_text)
                 resp_text = json.dumps(invitation_resp)
 
-                if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
+                if resp_status == 200:
+                    resp_text = self.agent_state_translation(
+                        op["topic"], operation, resp_text
+                    )
                 return (resp_status, resp_text)
 
             elif operation == "receive-invitation":
                 agent_operation = "/connections/" + operation
 
-                (resp_status, resp_text) = await self.admin_POST(agent_operation, data=data)
-                if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+                (resp_status, resp_text) = await self.admin_POST(
+                    agent_operation, data=data
+                )
+                if resp_status == 200:
+                    resp_text = self.agent_state_translation(
+                        op["topic"], None, resp_text
+                    )
                 return (resp_status, resp_text)
 
-            elif (operation == "accept-invitation" 
+            elif (
+                operation == "accept-invitation"
                 or operation == "accept-request"
                 or operation == "remove"
                 or operation == "start-introduction"
@@ -442,12 +462,15 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             ):
                 connection_id = rec_id
                 agent_operation = "/connections/" + connection_id + "/" + operation
-                log_msg('POST Request: ', agent_operation, data)
+                log_msg("POST Request: ", agent_operation, data)
 
                 (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
                 log_msg(resp_status, resp_text)
-                if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+                if resp_status == 200:
+                    resp_text = self.agent_state_translation(
+                        op["topic"], None, resp_text
+                    )
                 return (resp_status, resp_text)
 
         elif op["topic"] == "schema":
@@ -469,7 +492,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
             log_msg(resp_status, resp_text)
-            resp_text = self.move_field_to_top_level(resp_text, "credential_definition_id")
+            resp_text = self.move_field_to_top_level(
+                resp_text, "credential_definition_id"
+            )
             return (resp_status, resp_text)
 
         elif op["topic"] == "issue-credential":
@@ -480,57 +505,84 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             if rec_id is None:
                 agent_operation = acapy_topic + operation
             else:
-                if (operation == "send-offer" 
+                if (
+                    operation == "send-offer"
                     or operation == "send-request"
                     or operation == "issue"
                     or operation == "store"
                 ):
                     # swap thread id for cred ex id from the webhook
-                    cred_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "credential-msg", "credential_exchange_id")
-                    agent_operation = acapy_topic + "records/" + cred_ex_id + "/" + operation
+                    cred_ex_id = await self.swap_thread_id_for_exchange_id(
+                        rec_id, "credential-msg", "credential_exchange_id"
+                    )
+                    agent_operation = (
+                        acapy_topic + "records/" + cred_ex_id + "/" + operation
+                    )
                 # Make Special provisions for revoke since it is passing multiple query params not just one id.
-                elif (operation == "revoke"):
+                elif operation == "revoke":
                     cred_rev_id = rec_id
                     rev_reg_id = data["rev_registry_id"]
                     publish = data["publish_immediately"]
-                    agent_operation = acapy_topic + operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id + "&publish=" + str(publish).lower()
+                    agent_operation = (
+                        acapy_topic
+                        + operation
+                        + "?cred_rev_id="
+                        + cred_rev_id
+                        + "&rev_reg_id="
+                        + rev_reg_id
+                        + "&publish="
+                        + str(publish).lower()
+                    )
                     data = None
                 else:
                     agent_operation = acapy_topic + operation
-            
+
             log_msg(agent_operation, data)
-            
+
             (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
             log_msg(resp_status, resp_text)
-            if resp_status == 200 and self.aip_version != "AIP20": resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200 and self.aip_version != "AIP20":
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
-        # Handle issue credential v2 POST operations 
+        # Handle issue credential v2 POST operations
         elif op["topic"] == "issue-credential-v2":
-            (resp_status, resp_text) = await self.handle_issue_credential_v2_POST(op, rec_id=rec_id, data=data)
+            (resp_status, resp_text) = await self.handle_issue_credential_v2_POST(
+                op, rec_id=rec_id, data=data
+            )
             return (resp_status, resp_text)
 
-        # Handle issue credential v2 POST operations 
+        # Handle issue credential v2 POST operations
         elif op["topic"] == "proof-v2":
-            (resp_status, resp_text) = await self.handle_proof_v2_POST(op, rec_id=rec_id, data=data)
+            (resp_status, resp_text) = await self.handle_proof_v2_POST(
+                op, rec_id=rec_id, data=data
+            )
             return (resp_status, resp_text)
 
         elif op["topic"] == "revocation":
-            #set the acapyversion to master since work to set it is not complete. Remove when master report proper version
-            #self.acapy_version = "0.5.5-RC"
+            # set the acapyversion to master since work to set it is not complete. Remove when master report proper version
+            # self.acapy_version = "0.5.5-RC"
             operation = op["operation"]
-            agent_operation, admin_data = await self.get_agent_operation_acapy_version_based(op["topic"], operation, rec_id, data)
-            
+            (
+                agent_operation,
+                admin_data,
+            ) = await self.get_agent_operation_acapy_version_based(
+                op["topic"], operation, rec_id, data
+            )
+
             log_msg(agent_operation, admin_data)
-            
+
             if admin_data is None:
                 (resp_status, resp_text) = await self.admin_POST(agent_operation)
             else:
-                (resp_status, resp_text) = await self.admin_POST(agent_operation, admin_data)
+                (resp_status, resp_text) = await self.admin_POST(
+                    agent_operation, admin_data
+                )
 
             log_msg(resp_status, resp_text)
-            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200:
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
         elif op["topic"] == "proof":
@@ -540,79 +592,105 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             if rec_id is None:
                 agent_operation = "/present-proof/" + operation
             else:
-                if (operation == "send-presentation" 
+                if (
+                    operation == "send-presentation"
                     or operation == "send-request"
                     or operation == "verify-presentation"
                     or operation == "remove"
                 ):
-                    
-                    if (operation not in "send-presentation" or operation not in "send-request") and (data is None or "~service" not in data):
+
+                    if (
+                        operation not in "send-presentation"
+                        or operation not in "send-request"
+                    ) and (data is None or "~service" not in data):
                         # swap thread id for pres ex id from the webhook
-                        pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "presentation_exchange_id")
+                        pres_ex_id = await self.swap_thread_id_for_exchange_id(
+                            rec_id, "presentation-msg", "presentation_exchange_id"
+                        )
                     else:
                         # swap the thread id for the pres ex id in the service decorator (this is a connectionless proof)
                         pres_ex_id = data["~service"]["recipientKeys"][0]
-                    agent_operation = "/present-proof/records/" + pres_ex_id + "/" + operation
+                    agent_operation = (
+                        "/present-proof/records/" + pres_ex_id + "/" + operation
+                    )
 
                 else:
                     agent_operation = "/present-proof/" + operation
-            
+
             log_msg(agent_operation, data)
 
             if data is not None:
                 # Format the message data that came from the test, to what the Aca-py admin api expects.
-                data = self.map_test_json_to_admin_api_json(op["topic"], operation, data)
+                data = self.map_test_json_to_admin_api_json(
+                    op["topic"], operation, data
+                )
 
             (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
             log_msg(resp_status, resp_text)
-            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200:
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
-        
-        # Handle out of band POST operations 
+
+        # Handle out of band POST operations
         elif op["topic"] == "out-of-band":
             (resp_status, resp_text) = await self.handle_out_of_band_POST(op, data=data)
             return (resp_status, resp_text)
 
         # Handle did exchange POST operations
         elif op["topic"] == "did-exchange":
-            (resp_status, resp_text) = await self.handle_did_exchange_POST(op, rec_id=rec_id, data=data)
+            (resp_status, resp_text) = await self.handle_did_exchange_POST(
+                op, rec_id=rec_id, data=data
+            )
             return (resp_status, resp_text)
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
-
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     async def handle_out_of_band_POST(self, op, rec_id=None, data=None):
         operation = op["operation"]
         agent_operation = "/out-of-band/"
         if operation == "send-invitation-message":
-            #http://localhost:8022/out-of-band/create-invitation?auto_accept=false&multi_use=false
+            # http://localhost:8022/out-of-band/create-invitation?auto_accept=false&multi_use=false
             # TODO Check the data for auto_accept and multi_use. If it exists use those values then pop them out, otherwise false.
             auto_accept = "false"
             multi_use = "false"
-            agent_operation = agent_operation + "create-invitation" + "?auto_accept=" + auto_accept + "&multi_use=" + multi_use
+            agent_operation = (
+                agent_operation
+                + "create-invitation"
+                + "?auto_accept="
+                + auto_accept
+                + "&multi_use="
+                + multi_use
+            )
 
             # Add handshake protocols to message body
             admindata = {
                 "handshake_protocols": [
                     "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0"
                 ],
-                "use_public_did": data["use_public_did"]
+                "use_public_did": data["use_public_did"],
             }
             data = admindata
 
         elif operation == "receive-invitation":
             # TODO check for Alias and Auto_accept in data to add to the call (works without for now)
-            # TODO add use_existing_connection=false in data in the test to pass to here. 
+            # TODO add use_existing_connection=false in data in the test to pass to here.
             use_existing_connection = "false"
             auto_accept = "false"
-            agent_operation = agent_operation + "receive-invitation" + "?auto_accept=" + auto_accept + "&use_existing_connection=" + use_existing_connection
-            #agent_operation = "/didexchange/" + "receive-invitation"
-        
-        (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
-        if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
-        return (resp_status, resp_text)
+            agent_operation = (
+                agent_operation
+                + "receive-invitation"
+                + "?auto_accept="
+                + auto_accept
+                + "&use_existing_connection="
+                + use_existing_connection
+            )
+            # agent_operation = "/didexchange/" + "receive-invitation"
 
+        (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+        if resp_status == 200:
+            resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
+        return (resp_status, resp_text)
 
     async def handle_did_exchange_POST(self, op, rec_id=None, data=None):
         operation = op["operation"]
@@ -628,20 +706,25 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         elif operation == "create-request-resolvable-did":
             their_public_did = data["their_public_did"]
-            agent_operation = agent_operation + "create-request?their_public_did=" + their_public_did
+            agent_operation = (
+                agent_operation + "create-request?their_public_did=" + their_public_did
+            )
             data = None
 
         elif operation == "receive-request-resolvable-did":
             # as of PR 1182 in aries-cloudagent-python receive-request is no longer needed.
             # this is done automatically by the responder.
             # The test expects a connection_id returned so, return the last webhook message
-            #agent_operation = agent_operation + "receive-request"
-            
-            (wh_status, wh_text) = await self.make_agent_GET_request_response(op["topic"], rec_id=None, message_name="didexchange-msg")
+            # agent_operation = agent_operation + "receive-request"
+
+            (wh_status, wh_text) = await self.make_agent_GET_request_response(
+                op["topic"], rec_id=None, message_name="didexchange-msg"
+            )
             return (wh_status, wh_text)
 
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
-        if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
+        if resp_status == 200:
+            resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
         return (resp_status, resp_text)
 
     async def handle_issue_credential_v2_POST(self, op, rec_id=None, data=None):
@@ -652,10 +735,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             key_type = self.proofTypeKeyTypeTranslationDict[data["proof_type"]]
 
             # Retrieve matching dids
-            resp_status, resp_text = await self.admin_GET("/wallet/did", params={
-                "method": data["did_method"],
-                "key_type": key_type
-            })
+            resp_status, resp_text = await self.admin_GET(
+                "/wallet/did",
+                params={"method": data["did_method"], "key_type": key_type},
+            )
 
             did = None
             if resp_status == 200:
@@ -668,16 +751,14 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
             # If there was no matching did create a new one
             if not did:
-                (resp_status, resp_text) = await self.admin_POST("/wallet/did/create", {
-                    "method": data["did_method"],
-                    "options": {
-                        "key_type": key_type
-                    }
-                })
+                (resp_status, resp_text) = await self.admin_POST(
+                    "/wallet/did/create",
+                    {"method": data["did_method"], "options": {"key_type": key_type}},
+                )
                 if resp_status == 200:
                     resp_json = json.loads(resp_text)
                     did = resp_json["result"]["did"]
-            
+
             if did:
                 resp_text = json.dumps({"did": did})
 
@@ -685,19 +766,33 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             return (resp_status, resp_text)
 
         if rec_id is None:
-            agent_operation = self.TopicTranslationDict[topic] + self.issueCredentialv2OperationTranslationDict[operation]
+            agent_operation = (
+                self.TopicTranslationDict[topic]
+                + self.issueCredentialv2OperationTranslationDict[operation]
+            )
         else:
             # swap thread id for cred ex id from the webhook
-            cred_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "credential-msg", "cred_ex_id")
-            agent_operation = self.TopicTranslationDict[topic] + "records/" + cred_ex_id + "/" + self.issueCredentialv2OperationTranslationDict[operation]
-        
+            cred_ex_id = await self.swap_thread_id_for_exchange_id(
+                rec_id, "credential-msg", "cred_ex_id"
+            )
+            agent_operation = (
+                self.TopicTranslationDict[topic]
+                + "records/"
+                + cred_ex_id
+                + "/"
+                + self.issueCredentialv2OperationTranslationDict[operation]
+            )
+
         # Map AATH filter keys to ACA-Py filter keys
         # e.g. data.filters.json-ld becomes data.filters.ld_proof
         if data and "filter" in data:
-            data["filter"] = dict((self.credFormatFilterTranslationDict[name], val)for name, val in data["filter"].items())
+            data["filter"] = dict(
+                (self.credFormatFilterTranslationDict[name], val)
+                for name, val in data["filter"].items()
+            )
 
         log_msg(agent_operation, data)
-        
+
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
         if operation == "store":
@@ -709,13 +804,15 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             # Return less ACA-Py specific credential identifier key
             for key in resp_json:
                 if resp_json[key] and resp_json[key].get("cred_id_stored"):
-                    resp_json[key]["credential_id"] = resp_json[key].get("cred_id_stored")
+                    resp_json[key]["credential_id"] = resp_json[key].get(
+                        "cred_id_stored"
+                    )
 
             resp_text = json.dumps(resp_json)
 
         log_msg(resp_status, resp_text)
         # Looks like all v2 states are RFC states. Yah!
-        #if resp_status == 200: resp_text = self.agent_state_translation(topic], None, resp_text)
+        # if resp_status == 200: resp_text = self.agent_state_translation(topic], None, resp_text)
         resp_text = self.move_field_to_top_level(resp_text, "state")
         return (resp_status, resp_text)
 
@@ -724,17 +821,33 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         topic = op["topic"]
 
         if rec_id is None:
-            agent_operation = self.TopicTranslationDict[topic] + self.proofv2OperationTranslationDict[operation]
+            agent_operation = (
+                self.TopicTranslationDict[topic]
+                + self.proofv2OperationTranslationDict[operation]
+            )
         else:
             # swap thread id for cred ex id from the webhook
-            pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "pres_ex_id")
-            agent_operation = self.TopicTranslationDict[topic] + "records/" + pres_ex_id + "/" + self.proofv2OperationTranslationDict[operation]
-        
-        log_msg(f"Data passed to backchannel by test for operation: {agent_operation}", data)
+            pres_ex_id = await self.swap_thread_id_for_exchange_id(
+                rec_id, "presentation-msg", "pres_ex_id"
+            )
+            agent_operation = (
+                self.TopicTranslationDict[topic]
+                + "records/"
+                + pres_ex_id
+                + "/"
+                + self.proofv2OperationTranslationDict[operation]
+            )
+
+        log_msg(
+            f"Data passed to backchannel by test for operation: {agent_operation}", data
+        )
         if data is not None:
             # Format the message data that came from the test, to what the Aca-py admin api expects.
             data = self.map_test_json_to_admin_api_json("proof-v2", operation, data)
-        log_msg(f"Data translated by backchannel to send to agent for operation: {agent_operation}", data)
+        log_msg(
+            f"Data translated by backchannel to send to agent for operation: {agent_operation}",
+            data,
+        )
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
         log_msg(resp_status, resp_text)
@@ -759,21 +872,21 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
     async def make_agent_GET_request(
         self, op, rec_id=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
 
         if op["topic"] == "status":
             status = 200 if self.ACTIVE else 418
             status_msg = "Active" if self.ACTIVE else "Inactive"
             return (status, json.dumps({"status": status_msg}))
-        
+
         if op["topic"] == "version":
             if self.acapy_version is not None:
                 status = 200
-                #status_msg = json.dumps({"version": self.acapy_version})
+                # status_msg = json.dumps({"version": self.acapy_version})
                 status_msg = self.acapy_version
             else:
                 status = 404
-                #status_msg = json.dumps({"version": "not found"})
+                # status_msg = json.dumps({"version": "not found"})
                 status_msg = "not found"
             return (status, status_msg)
 
@@ -783,24 +896,32 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 agent_operation = "/connections/" + connection_id
             else:
                 agent_operation = "/connections"
-            
-            log_msg('GET Request agent operation: ', agent_operation)
+
+            log_msg("GET Request agent operation: ", agent_operation)
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
             if resp_status != 200:
                 return (resp_status, resp_text)
 
-            log_msg('GET Request response details: ', resp_status, resp_text)
+            log_msg("GET Request response details: ", resp_status, resp_text)
 
             resp_json = json.loads(resp_text)
             if rec_id:
-                connection_info = {"connection_id": resp_json["connection_id"], "state": resp_json["state"], "connection": resp_json}
+                connection_info = {
+                    "connection_id": resp_json["connection_id"],
+                    "state": resp_json["state"],
+                    "connection": resp_json,
+                }
                 resp_text = json.dumps(connection_info)
             else:
                 resp_json = resp_json["results"]
                 connection_infos = []
                 for connection in resp_json:
-                    connection_info = {"connection_id": connection["connection_id"], "state": connection["state"], "connection": connection}
+                    connection_info = {
+                        "connection_id": connection["connection_id"],
+                        "state": connection["state"],
+                        "connection": connection,
+                    }
                     connection_infos.append(connection_info)
                 resp_text = json.dumps(connection_infos)
             # translate the state from that the agent gave to what the tests expect
@@ -850,17 +971,26 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         elif op["topic"] == "issue-credential":
             # swap thread id for cred ex id from the webhook
-            cred_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "credential-msg", "credential_exchange_id")
-            agent_operation = self.TopicTranslationDict[op["topic"]] + "records/" + cred_ex_id
+            cred_ex_id = await self.swap_thread_id_for_exchange_id(
+                rec_id, "credential-msg", "credential_exchange_id"
+            )
+            agent_operation = (
+                self.TopicTranslationDict[op["topic"]] + "records/" + cred_ex_id
+            )
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
-            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200:
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
         elif op["topic"] == "issue-credential-v2":
             # swap thread id for cred ex id from the webhook
-            cred_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "credential-msg", "cred_ex_id")
-            agent_operation = self.TopicTranslationDict[op["topic"]] + "records/" + cred_ex_id
+            cred_ex_id = await self.swap_thread_id_for_exchange_id(
+                rec_id, "credential-msg", "cred_ex_id"
+            )
+            agent_operation = (
+                self.TopicTranslationDict[op["topic"]] + "records/" + cred_ex_id
+            )
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
             resp_text = self.move_field_to_top_level(resp_text, "state")
@@ -868,10 +998,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         elif op["topic"] == "credential":
             operation = op["operation"]
-            if operation == 'revoked':
+            if operation == "revoked":
                 agent_operation = "/credential/" + operation + "/" + rec_id
                 (resp_status, resp_text) = await self.admin_GET(agent_operation)
-                return (resp_status,  resp_text)
+                return (resp_status, resp_text)
             else:
                 # NOTE: We don't know what type of credential to fetch, so we first try an indy credential.
                 # Maybe it would be nice if the test harness passed the credential format that belonged to the
@@ -879,7 +1009,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 # First try indy credential
                 agent_operation = "/credential/" + rec_id
                 (resp_status, resp_text) = await self.admin_GET(agent_operation)
- 
+
                 # If not found try w3c credential
                 if resp_status == 404:
                     agent_operation = "/credential/w3c/" + rec_id
@@ -887,69 +1017,88 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
                     if resp_status == 200:
                         resp_json = json.loads(resp_text)
-                        return (resp_status, json.dumps({
-                            "credential_id": resp_json["record_id"], 
-                            "credential": resp_json["cred_value"]
-                        }))
+                        return (
+                            resp_status,
+                            json.dumps(
+                                {
+                                    "credential_id": resp_json["record_id"],
+                                    "credential": resp_json["cred_value"],
+                                }
+                            ),
+                        )
 
                 return (resp_status, resp_text)
 
         elif op["topic"] == "proof":
             # swap thread id for pres ex id from the webhook
-            pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "presentation_exchange_id")
+            pres_ex_id = await self.swap_thread_id_for_exchange_id(
+                rec_id, "presentation-msg", "presentation_exchange_id"
+            )
             agent_operation = "/present-proof/records/" + pres_ex_id
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
-            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200:
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
         elif op["topic"] == "proof-v2":
             # swap thread id for pres ex id from the webhook
-            pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "pres_ex_id")
-            agent_operation = self.TopicTranslationDict[op["topic"]] + "records/" + pres_ex_id
+            pres_ex_id = await self.swap_thread_id_for_exchange_id(
+                rec_id, "presentation-msg", "pres_ex_id"
+            )
+            agent_operation = (
+                self.TopicTranslationDict[op["topic"]] + "records/" + pres_ex_id
+            )
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
-            #if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            # if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
         elif op["topic"] == "revocation":
             operation = op["operation"]
-            agent_operation, admin_data = await self.get_agent_operation_acapy_version_based(op["topic"], operation, rec_id, data=None)
+            (
+                agent_operation,
+                admin_data,
+            ) = await self.get_agent_operation_acapy_version_based(
+                op["topic"], operation, rec_id, data=None
+            )
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
             return (resp_status, resp_text)
-        
+
         elif op["topic"] == "did-exchange":
-            
+
             connection_id = rec_id
             agent_operation = "/connections/" + connection_id
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation)
-            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200:
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     async def make_agent_DELETE_request(
         self, op, rec_id=None, data=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         if op["topic"] == "credential" and rec_id:
             # swap thread id for cred ex id from the webhook
             # cred_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "credential-msg","credential_exchange_id")
             agent_operation = "/credential/" + rec_id
-            #operation = op["operation"]
-            #agent_operation, admin_data = await self.get_agent_operation_acapy_version_based(op["topic"], operation, rec_id, data)
+            # operation = op["operation"]
+            # agent_operation, admin_data = await self.get_agent_operation_acapy_version_based(op["topic"], operation, rec_id, data)
             log_msg(agent_operation)
 
             (resp_status, resp_text) = await self.admin_DELETE(agent_operation)
-            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            if resp_status == 200:
+                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
             return (resp_status, resp_text)
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     async def make_agent_GET_request_response(
         self, topic, rec_id=None, text=False, params=None, message_name=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         if topic == "connection" and rec_id:
             connection_msg = pop_resource(rec_id, "connection-msg")
             i = 0
@@ -1037,7 +1186,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 resp_text = "{}"
 
             return (resp_status, resp_text)
-        
+
         elif topic == "proof" and rec_id:
             presentation_msg = pop_resource(rec_id, "presentation-msg")
             i = 0
@@ -1049,10 +1198,11 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             resp_status = 200
             if presentation_msg:
                 resp_text = json.dumps(presentation_msg)
-                if resp_status == 200: resp_text = self.agent_state_translation(topic, None, resp_text)
+                if resp_status == 200:
+                    resp_text = self.agent_state_translation(topic, None, resp_text)
             else:
                 resp_text = "{}"
-            
+
             return (resp_status, resp_text)
 
         elif topic == "revocation-registry" and rec_id:
@@ -1071,7 +1221,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
             return (resp_status, resp_text)
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     def _process(self, args, env, loop):
         proc = subprocess.Popen(
@@ -1094,20 +1244,22 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         return proc
 
     def get_process_args(self, bin_path: str = None):
-        #TODO aca-py needs to be in the path so no need to give it a cmd_path
+        # TODO aca-py needs to be in the path so no need to give it a cmd_path
         cmd_path = "aca-py"
         if bin_path is None:
             bin_path = DEFAULT_BIN_PATH
         if bin_path:
             cmd_path = os.path.join(bin_path, cmd_path)
-        print ('Location of ACA-Py: ' + cmd_path)
+        print("Location of ACA-Py: " + cmd_path)
         if self.get_acapy_version_as_float() > 56:
             return list(flatten(([cmd_path, "start"], self.get_agent_args())))
         else:
-            return list(flatten((["python3", cmd_path, "start"], self.get_agent_args())))
+            return list(
+                flatten((["python3", cmd_path, "start"], self.get_agent_args()))
+            )
 
     async def detect_process(self):
-        #text = None
+        # text = None
 
         async def fetch_swagger(url: str, timeout: float):
             text = None
@@ -1139,7 +1291,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             ok = isinstance(status, dict) and "version" in status
             if ok:
                 self.acapy_version = status["version"]
-                print("ACA-py Backchannel running with ACA-py version:", self.acapy_version)
+                print(
+                    "ACA-py Backchannel running with ACA-py version:",
+                    self.acapy_version,
+                )
         except json.JSONDecodeError:
             pass
         if not ok:
@@ -1190,11 +1345,11 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
     def map_test_json_to_admin_api_json(self, topic, operation, data):
         # If the translation of the json get complicated in the future we might want to consider a switch to JsonMapper or equivalent.
-        #json_mapper = JsonMapper()
+        # json_mapper = JsonMapper()
         # map_specification = {
         #     'name': ['person_name']
         # }
-        #JsonMapper(test_json).map(map_specification)
+        # JsonMapper(test_json).map(map_specification)
 
         if topic == "proof":
 
@@ -1205,32 +1360,72 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 else:
                     request_type = "proof_request"
                     attachment = "request_presentations~attach"
-                
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("requested_attributes") is None:
+
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("requested_attributes")
+                    is None
+                ):
                     requested_attributes = {}
                 else:
-                    requested_attributes = data["presentation_proposal"][attachment]["data"]["requested_attributes"]
+                    requested_attributes = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["requested_attributes"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("requested_predicates") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("requested_predicates")
+                    is None
+                ):
                     requested_predicates = {}
                 else:
-                    requested_predicates = data["presentation_proposal"][attachment]["data"]["requested_predicates"]
+                    requested_predicates = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["requested_predicates"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("name") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("name")
+                    is None
+                ):
                     proof_request_name = "test proof"
                 else:
-                    proof_request_name = data["presentation_proposal"][attachment]["data"]["name"]
+                    proof_request_name = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["name"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("version") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("version")
+                    is None
+                ):
                     proof_request_version = "1.0"
                 else:
-                    proof_request_version = data["presentation_proposal"][attachment]["data"]["version"]
+                    proof_request_version = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["version"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("non_revoked") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("non_revoked")
+                    is None
+                ):
                     non_revoked = None
                 else:
-                    non_revoked = data["presentation_proposal"][attachment]["data"]["non_revoked"]
-                
+                    non_revoked = data["presentation_proposal"][attachment]["data"][
+                        "non_revoked"
+                    ]
+
                 if "connection_id" in data:
                     admin_data = {
                         "comment": data["presentation_proposal"]["comment"],
@@ -1240,8 +1435,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                             "name": proof_request_name,
                             "version": proof_request_version,
                             "requested_attributes": requested_attributes,
-                            "requested_predicates": requested_predicates
-                        }
+                            "requested_predicates": requested_predicates,
+                        },
                     }
                 else:
                     admin_data = {
@@ -1251,8 +1446,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                             "name": proof_request_name,
                             "version": proof_request_version,
                             "requested_attributes": requested_attributes,
-                            "requested_predicates": requested_predicates
-                        }
+                            "requested_predicates": requested_predicates,
+                        },
                     }
                 if non_revoked is not None:
                     admin_data[request_type]["non_revoked"] = non_revoked
@@ -1262,32 +1457,42 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             elif operation == "send-proposal":
 
                 request_type = "presentation_proposal"
-                
-                if data.get("presentation_proposal", {}).get("requested_attributes") == None:
+
+                if (
+                    data.get("presentation_proposal", {}).get("requested_attributes")
+                    == None
+                ):
                     requested_attributes = []
                 else:
-                    requested_attributes = data["presentation_proposal"]["requested_attributes"]
+                    requested_attributes = data["presentation_proposal"][
+                        "requested_attributes"
+                    ]
 
-                if data.get("presentation_proposal", {}).get("requested_predicates") == None:
+                if (
+                    data.get("presentation_proposal", {}).get("requested_predicates")
+                    == None
+                ):
                     requested_predicates = []
                 else:
-                    requested_predicates = data["presentation_proposal"]["requested_predicates"]
-                
+                    requested_predicates = data["presentation_proposal"][
+                        "requested_predicates"
+                    ]
+
                 admin_data = {
-                        "comment": data["presentation_proposal"]["comment"],
-                        "trace": False,
-                        request_type: {
-                            "@type": data["presentation_proposal"]["@type"],
-                            "attributes": requested_attributes,
-                            "predicates": requested_predicates
-                        }
-                    }
+                    "comment": data["presentation_proposal"]["comment"],
+                    "trace": False,
+                    request_type: {
+                        "@type": data["presentation_proposal"]["@type"],
+                        "attributes": requested_attributes,
+                        "predicates": requested_predicates,
+                    },
+                }
 
                 if "connection_id" in data:
                     admin_data["connection_id"] = data["connection_id"]
 
             elif operation == "send-presentation":
-                
+
                 if data.get("requested_attributes") == None:
                     requested_attributes = {}
                 else:
@@ -1307,17 +1512,17 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     "comment": data["comment"],
                     "requested_attributes": requested_attributes,
                     "requested_predicates": requested_predicates,
-                    "self_attested_attributes": self_attested_attributes
+                    "self_attested_attributes": self_attested_attributes,
                 }
 
             else:
                 admin_data = data
 
             # Add on the service decorator if it exists.
-            if "~service" in data: 
+            if "~service" in data:
                 admin_data["~service"] = data["~service"]
 
-            return (admin_data)
+            return admin_data
 
         if topic == "proof-v2":
 
@@ -1327,12 +1532,16 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 presentation_proposal = data.get("presentation_proposal", {})
                 pres_proposal_data = presentation_proposal.get("data", {})
                 cred_format = presentation_proposal.get("format")
-                
+
                 if cred_format is None:
-                    raise Exception("Credential format not specified for presentation") 
+                    raise Exception("Credential format not specified for presentation")
                 elif cred_format == "indy":
-                    requested_attributes = pres_proposal_data.get("requested_attributes", {})
-                    requested_predicates = pres_proposal_data.get("requested_predicates", {})
+                    requested_attributes = pres_proposal_data.get(
+                        "requested_attributes", {}
+                    )
+                    requested_predicates = pres_proposal_data.get(
+                        "requested_predicates", {}
+                    )
                     proof_request_name = pres_proposal_data.get("name", "test proof")
                     proof_request_version = pres_proposal_data.get("version", "1.0")
                     non_revoked = pres_proposal_data.get("non_revoked")
@@ -1351,27 +1560,25 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
                 elif cred_format == "json-ld":
                     # We use DIF format for JSON-LD credentials
-                    presentation_request = {
-                        "dif": pres_proposal_data
-                    }
+                    presentation_request = {"dif": pres_proposal_data}
                 else:
                     raise Exception(f"Unknown credential format: {cred_format}")
-                
+
                 admin_data = {
                     "comment": presentation_proposal["comment"],
                     "trace": False,
-                    request_type: presentation_request
+                    request_type: presentation_request,
                 }
 
                 if "connection_id" in presentation_proposal:
-                    admin_data["connection_id"] = presentation_proposal["connection_id"] 
-            
+                    admin_data["connection_id"] = presentation_proposal["connection_id"]
+
             elif operation == "send-presentation":
 
                 cred_format = data.get("format")
-                
+
                 if cred_format is None:
-                    raise Exception("Credential format not specified for presentation") 
+                    raise Exception("Credential format not specified for presentation")
                 elif cred_format == "indy":
                     requested_attributes = data.get("requested_attributes", {})
                     requested_predicates = data.get("requested_predicates", {})
@@ -1381,16 +1588,14 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                         cred_format: {
                             "requested_attributes": requested_attributes,
                             "requested_predicates": requested_predicates,
-                            "self_attested_attributes": self_attested_attributes
+                            "self_attested_attributes": self_attested_attributes,
                         }
                     }
                 elif cred_format == "json-ld":
                     presentation = data.copy()
                     presentation.pop("format")
 
-                    presentation_data = {
-                        "dif": presentation
-                    }
+                    presentation_data = {"dif": presentation}
 
                 else:
                     raise Exception(f"Unknown credential format: {cred_format}")
@@ -1404,78 +1609,108 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 admin_data = data
 
             # Add on the service decorator if it exists.
-            if "~service" in data: 
+            if "~service" in data:
                 admin_data["~service"] = data["~service"]
 
-            return (admin_data)
+            return admin_data
 
     def agent_state_translation(self, topic, operation, data):
-            # This method is used to translate the agent states passes back in the responses of operations into the states the 
-            # test harness expects. The test harness expects states to be as they are written in the Protocol's RFC.
-            # the following is what the tests/rfc expect vs what aca-py communicates
-            # Connection Protocol:
-            # Tests/RFC         |   Aca-py
-            # invited           |   invitation
-            # requested         |   request
-            # responded         |   response
-            # complete          |   active
-            #
-            # Issue Credential Protocol:
-            # Tests/RFC         |   Aca-py
-            # proposal-sent     |   proposal_sent
-            # proposal-received |   proposal_received
-            # offer-sent        |   offer_sent
-            # offer_received    |   offer_received
-            # request-sent      |   request_sent
-            # request-received  |   request_received
-            # credential-issued |   issued
-            # credential-received | credential_received
-            # done              |   credential_acked
-            #
-            # Present Proof Protocol:
-            # Tests/RFC         |   Aca-py
+        # This method is used to translate the agent states passes back in the responses of operations into the states the
+        # test harness expects. The test harness expects states to be as they are written in the Protocol's RFC.
+        # the following is what the tests/rfc expect vs what aca-py communicates
+        # Connection Protocol:
+        # Tests/RFC         |   Aca-py
+        # invited           |   invitation
+        # requested         |   request
+        # responded         |   response
+        # complete          |   active
+        #
+        # Issue Credential Protocol:
+        # Tests/RFC         |   Aca-py
+        # proposal-sent     |   proposal_sent
+        # proposal-received |   proposal_received
+        # offer-sent        |   offer_sent
+        # offer_received    |   offer_received
+        # request-sent      |   request_sent
+        # request-received  |   request_received
+        # credential-issued |   issued
+        # credential-received | credential_received
+        # done              |   credential_acked
+        #
+        # Present Proof Protocol:
+        # Tests/RFC         |   Aca-py
 
-            resp_json = json.loads(data)
-            # Check to see if state is in the json
-            if "state" in resp_json:
-                agent_state = resp_json["state"]
+        resp_json = json.loads(data)
+        # Check to see if state is in the json
+        if "state" in resp_json:
+            agent_state = resp_json["state"]
 
-                # if "did_exchange" in topic:
-                #     if "rfc23_state" in resp_json:
-                #         rfc_state = resp_json["rfc23_state"]
-                #     else:
-                #         rfc_state = resp_json["connection"]["rfc23_state"]
-                #     data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + rfc_state + '"')
-                # else:
-                # Check the thier_role property in the data and set the calling method to swap states to the correct role for DID Exchange
-                if "their_role" in data:
-                    #if resp_json["connection"]["their_role"] == "invitee":
-                    if "invitee" in data:
-                        de_state_trans_method = self.didExchangeResponderStateTranslationDict
-                    elif "inviter" in data:
-                        de_state_trans_method = self.didExchangeRequesterStateTranslationDict
+            # if "did_exchange" in topic:
+            #     if "rfc23_state" in resp_json:
+            #         rfc_state = resp_json["rfc23_state"]
+            #     else:
+            #         rfc_state = resp_json["connection"]["rfc23_state"]
+            #     data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + rfc_state + '"')
+            # else:
+            # Check the thier_role property in the data and set the calling method to swap states to the correct role for DID Exchange
+            if "their_role" in data:
+                # if resp_json["connection"]["their_role"] == "invitee":
+                if "invitee" in data:
+                    de_state_trans_method = (
+                        self.didExchangeResponderStateTranslationDict
+                    )
+                elif "inviter" in data:
+                    de_state_trans_method = (
+                        self.didExchangeRequesterStateTranslationDict
+                    )
+            else:
+                # make the trans method any one, since it doesn't matter. It's probably Out of Band.
+                de_state_trans_method = self.didExchangeResponderStateTranslationDict
+
+            if topic == "connection":
+                # if the response contains didexchange/1.0, swap out the connection states for the did exchange states
+                # if "didexchange/1.0" in resp_json["connection_protocol"]:
+                if "didexchange/1.0" in data:
+                    data = data.replace(
+                        '"state"' + ": " + '"' + agent_state + '"',
+                        '"state"'
+                        + ": "
+                        + '"'
+                        + de_state_trans_method[agent_state]
+                        + '"',
+                    )
                 else:
-                    # make the trans method any one, since it doesn't matter. It's probably Out of Band.
-                    de_state_trans_method = self.didExchangeResponderStateTranslationDict
+                    data = data.replace(
+                        agent_state, self.connectionStateTranslationDict[agent_state]
+                    )
+            elif topic == "issue-credential":
+                data = data.replace(
+                    agent_state, self.issueCredentialStateTranslationDict[agent_state]
+                )
+            elif topic == "proof":
+                data = data.replace(
+                    '"state"' + ": " + '"' + agent_state + '"',
+                    '"state"'
+                    + ": "
+                    + '"'
+                    + self.presentProofStateTranslationDict[agent_state]
+                    + '"',
+                )
+            elif topic == "out-of-band":
+                data = data.replace(
+                    '"state"' + ": " + '"' + agent_state + '"',
+                    '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"',
+                )
+            elif topic == "did-exchange":
+                data = data.replace(
+                    '"state"' + ": " + '"' + agent_state + '"',
+                    '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"',
+                )
+        return data
 
-                if topic == "connection":
-                    # if the response contains didexchange/1.0, swap out the connection states for the did exchange states
-                    #if "didexchange/1.0" in resp_json["connection_protocol"]:
-                    if "didexchange/1.0" in data:
-                         data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"')
-                    else:
-                        data = data.replace(agent_state, self.connectionStateTranslationDict[agent_state])
-                elif topic == "issue-credential":
-                    data = data.replace(agent_state, self.issueCredentialStateTranslationDict[agent_state])
-                elif topic == "proof":
-                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + self.presentProofStateTranslationDict[agent_state] + '"')
-                elif topic == "out-of-band":
-                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"')
-                elif topic == "did-exchange":
-                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"')
-            return (data)
-
-    async def get_agent_operation_acapy_version_based(self, topic, operation, rec_id=None, data=None):
+    async def get_agent_operation_acapy_version_based(
+        self, topic, operation, rec_id=None, data=None
+    ):
         # Admin api calls may change with acapy releases. For example revocation related calls change
         # between 0.5.4 and 0.5.5. To be able to handle this the backchannel is made aware of the acapy version
         # and constructs the calls based off that version
@@ -1483,7 +1718,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         # construct some number to compare to with > or < instead of listing out the version number
         comparibleVersion = self.get_acapy_version_as_float()
 
-        if (topic == "revocation"):
+        if topic == "revocation":
             if operation == "revoke":
                 if comparibleVersion > 54:
                     agent_operation = "/revocation/" + operation
@@ -1501,26 +1736,43 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 else:
                     agent_operation = "/issue-credential/" + operation
 
-                    if (data is not None): # Data should be included with 0.5.4 or lower acapy. Then it takes them as inline parameters.
+                    if (
+                        data is not None
+                    ):  # Data should be included with 0.5.4 or lower acapy. Then it takes them as inline parameters.
                         cred_rev_id = data["cred_rev_id"]
                         rev_reg_id = data["rev_registry_id"]
                         publish = data["publish_immediately"]
-                        agent_operation = agent_operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id + "&publish=" + rev_reg_id + str(publish).lower()
+                        agent_operation = (
+                            agent_operation
+                            + "?cred_rev_id="
+                            + cred_rev_id
+                            + "&rev_reg_id="
+                            + rev_reg_id
+                            + "&publish="
+                            + rev_reg_id
+                            + str(publish).lower()
+                        )
                         data = None
             elif operation == "credential-record":
-                    agent_operation = "/revocation/" + operation
-                    if "cred_ex_id" in data:
-                        cred_ex_id = data["cred_ex_id"]
-                        agent_operation = agent_operation + "?cred_ex_id=" + cred_ex_id
-                    else:
-                        cred_rev_id = data["cred_rev_id"]
-                        rev_reg_id = data["rev_registry_id"]
-                        agent_operation = agent_operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id
-                        data = None
-        #elif (topic == "credential"):
-
+                agent_operation = "/revocation/" + operation
+                if "cred_ex_id" in data:
+                    cred_ex_id = data["cred_ex_id"]
+                    agent_operation = agent_operation + "?cred_ex_id=" + cred_ex_id
+                else:
+                    cred_rev_id = data["cred_rev_id"]
+                    rev_reg_id = data["rev_registry_id"]
+                    agent_operation = (
+                        agent_operation
+                        + "?cred_rev_id="
+                        + cred_rev_id
+                        + "&rev_reg_id="
+                        + rev_reg_id
+                    )
+                    data = None
+        # elif (topic == "credential"):
 
         return agent_operation, data
+
 
 async def main(start_port: int, show_timing: bool = False, interactive: bool = True):
 
@@ -1533,14 +1785,14 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
 
     try:
         agent = AcaPyAgentBackchannel(
-            "aca-py." + AGENT_NAME, start_port+1, start_port+2, genesis_data=genesis
+            "aca-py." + AGENT_NAME, start_port + 1, start_port + 2, genesis_data=genesis
         )
 
         # start backchannel (common across all types of agents)
         await agent.listen_backchannel(start_port)
 
         # start aca-py agent sub-process and listen for web hooks
-        await agent.listen_webhooks(start_port+3)
+        await agent.listen_webhooks(start_port + 3)
         await agent.register_did()
 
         await agent.start_process()
@@ -1548,9 +1800,7 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
 
         # now wait ...
         if interactive:
-            async for option in prompt_loop(
-                "(X) Exit? [X] "
-            ):
+            async for option in prompt_loop("(X) Exit? [X] "):
                 if option is None or option in "xX":
                     break
         else:
@@ -1572,15 +1822,17 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
     if not terminated:
         os._exit(1)
 
+
 def str2bool(v):
     if isinstance(v, bool):
-       return v
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
         return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+    elif v.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
+        raise argparse.ArgumentTypeError("Boolean value expected.")
+
 
 if __name__ == "__main__":
     import argparse
@@ -1604,9 +1856,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    require_indy()
-
     try:
-        asyncio.get_event_loop().run_until_complete(main(start_port=args.port, interactive=args.interactive))
+        asyncio.get_event_loop().run_until_complete(
+            main(start_port=args.port, interactive=args.interactive)
+        )
     except KeyboardInterrupt:
         os._exit(1)

--- a/aries-backchannels/mobile/mobile_backchannel.py
+++ b/aries-backchannels/mobile/mobile_backchannel.py
@@ -1,32 +1,32 @@
 import asyncio
-import functools
+import base64
 import json
 import logging
 import os
-import random
-import subprocess
-import sys
-import uuid
-from timeit import default_timer
+
 from time import sleep
-from operator import itemgetter
-from qrcode import QRCode
-import base64
+from typing import Tuple
 
 from aiohttp import (
     web,
-    ClientSession,
     ClientRequest,
-    ClientResponse,
-    ClientError,
-    ClientTimeout,
+)
+from qrcode import QRCode
+
+from python.agent_backchannel import (
+    AgentBackchannel,
+    RUN_MODE,
+)
+from python.utils import (
+    log_msg,
+    prompt_loop,
+)
+from python.storage import (
+    push_resource,
+    pop_resource,
 )
 
-from python.agent_backchannel import AgentBackchannel, default_genesis_txns, RUN_MODE, START_TIMEOUT
-from python.utils import require_indy, flatten, log_json, log_msg, log_timer, output_reader, prompt_loop
-from python.storage import store_resource, get_resource, delete_resource, push_resource, pop_resource, pop_resource_latest
-
-#from helpers.jsonmapper.json_mapper import JsonMapper
+# from helpers.jsonmapper.json_mapper import JsonMapper
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,32 +42,27 @@ elif RUN_MODE == "pwd":
     DEFAULT_BIN_PATH = "./bin"
     DEFAULT_PYTHON_PATH = "."
 
+
 class MobileAgentBackchannel(AgentBackchannel):
     def __init__(
-        self, 
+        self,
         ident: str,
         http_port: int,
         admin_port: int,
         genesis_data: str = None,
-        params: dict = {}
+        params: dict = {},
     ):
-        super().__init__(
-            ident,
-            http_port,
-            admin_port,
-            genesis_data,
-            params
-        )
+        super().__init__(ident, http_port, admin_port, genesis_data, params)
         self.connection_state = "n/a"
 
     def get_agent_args(self):
         result = [
             ("--endpoint", self.endpoint),
             ("--label", self.label),
-            #"--auto-ping-connection",
-            #"--auto-accept-invites", 
-            #"--auto-accept-requests", 
-            #"--auto-respond-messages",
+            # "--auto-ping-connection",
+            # "--auto-accept-invites",
+            # "--auto-accept-requests",
+            # "--auto-respond-messages",
             ("--inbound-transport", "http", "0.0.0.0", str(self.http_port)),
             ("--outbound-transport", "http"),
             ("--admin", "0.0.0.0", str(self.admin_port)),
@@ -97,30 +92,35 @@ class MobileAgentBackchannel(AgentBackchannel):
             )
         if self.webhook_url:
             result.append(("--webhook-url", self.webhook_url))
-        
-        # This code for Tails Server is included here because aca-py does not support the env var directly yet. 
-        # when it does (and there is talk of supporting YAML) then this code can be removed. 
-        if os.getenv('TAILS_SERVER_URL') is not None:
+
+        # This code for Tails Server is included here because aca-py does not support the env var directly yet.
+        # when it does (and there is talk of supporting YAML) then this code can be removed.
+        if os.getenv("TAILS_SERVER_URL") is not None:
             # if the env var is set for tails server then use that.
-            result.append(("--tails-server-base-url", os.getenv('TAILS_SERVER_URL')))
+            result.append(("--tails-server-base-url", os.getenv("TAILS_SERVER_URL")))
         else:
             # if the tails server env is not set use the gov.bc TEST tails server.
-            result.append(("--tails-server-base-url", "https://tails-server-test.pathfinder.gov.bc.ca"))
-        
-        if os.getenv('EMIT-NEW-DIDCOMM-PREFIX') is not None:
+            result.append(
+                (
+                    "--tails-server-base-url",
+                    "https://tails-server-test.pathfinder.gov.bc.ca",
+                )
+            )
+
+        if os.getenv("EMIT-NEW-DIDCOMM-PREFIX") is not None:
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-prefix"))
 
-        if os.getenv('EMIT-NEW-DIDCOMM-MIME-TYPE') is not None:
+        if os.getenv("EMIT-NEW-DIDCOMM-MIME-TYPE") is not None:
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-mime-type"))
 
-        # This code for log level is included here because aca-py does not support the env var directly yet. 
-        # when it does (and there is talk of supporting YAML) then this code can be removed. 
-        if os.getenv('LOG_LEVEL') is not None:
-            result.append(("--log-level", os.getenv('LOG_LEVEL')))
+        # This code for log level is included here because aca-py does not support the env var directly yet.
+        # when it does (and there is talk of supporting YAML) then this code can be removed.
+        if os.getenv("LOG_LEVEL") is not None:
+            result.append(("--log-level", os.getenv("LOG_LEVEL")))
 
-        #if self.extra_args:
+        # if self.extra_args:
         #    result.extend(self.extra_args)
 
         return result
@@ -152,13 +152,13 @@ class MobileAgentBackchannel(AgentBackchannel):
         if topic != "webhook":  # would recurse
             handler = f"handle_{topic}"
 
-            # Remove this handler change when bug is fixed. 
+            # Remove this handler change when bug is fixed.
             if handler == "handle_oob-invitation":
                 handler = "handle_oob_invitation"
 
             method = getattr(self, handler, None)
             # put a log message here
-            log_msg('Passing webhook payload to handler ' + handler)
+            log_msg("Passing webhook payload to handler " + handler)
             if method:
                 await method(payload)
             else:
@@ -168,7 +168,9 @@ class MobileAgentBackchannel(AgentBackchannel):
                     f"to handle webhook on topic {topic}"
                 )
         else:
-            log_msg('in webhook, topic is: ' + topic + ' payload is: ' + json.dumps(payload))
+            log_msg(
+                "in webhook, topic is: " + topic + " payload is: " + json.dumps(payload)
+            )
 
     async def handle_connections(self, message):
         if "invitation_msg_id" in message:
@@ -182,37 +184,39 @@ class MobileAgentBackchannel(AgentBackchannel):
         else:
             connection_id = message["connection_id"]
             push_resource(connection_id, "connection-msg", message)
-        log_msg('Received a Connection Webhook message: ' + json.dumps(message))
+        log_msg("Received a Connection Webhook message: " + json.dumps(message))
 
     async def handle_issue_credential(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "credential-msg", message)
-        log_msg('Received Issue Credential Webhook message: ' + json.dumps(message)) 
-        if "revocation_id" in message: # also push as a revocation message 
+        log_msg("Received Issue Credential Webhook message: " + json.dumps(message))
+        if "revocation_id" in message:  # also push as a revocation message
             push_resource(thread_id, "revocation-registry-msg", message)
-            log_msg('Issue Credential Webhook message contains revocation info') 
+            log_msg("Issue Credential Webhook message contains revocation info")
 
     async def handle_present_proof(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "presentation-msg", message)
-        log_msg('Received a Present Proof Webhook message: ' + json.dumps(message))
+        log_msg("Received a Present Proof Webhook message: " + json.dumps(message))
 
     async def handle_revocation_registry(self, message):
         # No thread id in the webhook for revocation registry messages
         cred_def_id = message["cred_def_id"]
         push_resource(cred_def_id, "revocation-registry-msg", message)
-        log_msg('Received Revocation Registry Webhook message: ' + json.dumps(message)) 
+        log_msg("Received Revocation Registry Webhook message: " + json.dumps(message))
 
     async def handle_oob_invitation(self, message):
         # No thread id in the webhook for revocation registry messages
         invitation_id = message["invitation_id"]
         push_resource(invitation_id, "oob-inviation-msg", message)
-        log_msg('Received Out of Band Invitation Webhook message: ' + json.dumps(message)) 
+        log_msg(
+            "Received Out of Band Invitation Webhook message: " + json.dumps(message)
+        )
 
     async def handle_problem_report(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "problem-report-msg", message)
-        log_msg('Received Problem Report Webhook message: ' + json.dumps(message)) 
+        log_msg("Received Problem Report Webhook message: " + json.dumps(message))
 
     async def make_agent_POST_request(
         self, op, rec_id=None, data=None, text=False, params=None
@@ -223,11 +227,13 @@ class MobileAgentBackchannel(AgentBackchannel):
             operation = op["operation"]
             if operation == "receive-invitation":
                 self.connection_state = "invited"
-                print("=================================================================")
+                print(
+                    "================================================================="
+                )
 
-                message_bytes = json.dumps(data).encode('ascii')
+                message_bytes = json.dumps(data).encode("ascii")
                 base64_bytes = base64.b64encode(message_bytes)
-                base64_message = base64_bytes.decode('ascii')
+                base64_message = base64_bytes.decode("ascii")
                 invitation_url = data["serviceEndpoint"] + "?c_i=" + base64_message
 
                 qr = QRCode(border=1)
@@ -236,55 +242,82 @@ class MobileAgentBackchannel(AgentBackchannel):
                     "Use the following JSON to accept the invite from another demo agent."
                     " Or use the QR code to connect from a mobile agent."
                 )
-                log_msg(
-                    json.dumps(data), label="Invitation Data:", color=None
-                )
+                log_msg(json.dumps(data), label="Invitation Data:", color=None)
                 qr.print_ascii(invert=True)
-                log_msg(
-                    "If you can't scan the QR code here is the url."
-                )
+                log_msg("If you can't scan the QR code here is the url.")
                 print("Invitation url:", invitation_url)
-                print("=================================================================")
+                print(
+                    "================================================================="
+                )
 
-                return (200, '{"result": "ok", "connection_id": "1", "state": "' + self.connection_state + '"}')
+                return (
+                    200,
+                    '{"result": "ok", "connection_id": "1", "state": "'
+                    + self.connection_state
+                    + '"}',
+                )
 
-            elif (operation == "accept-invitation" 
+            elif (
+                operation == "accept-invitation"
                 or operation == "accept-request"
                 or operation == "remove"
                 or operation == "start-introduction"
                 or operation == "send-ping"
             ):
                 self.connection_state = "requested"
-                return (200, '{"result": "ok", "connection_id": "1", "state": "' + self.connection_state + '"}')
+                return (
+                    200,
+                    '{"result": "ok", "connection_id": "1", "state": "'
+                    + self.connection_state
+                    + '"}',
+                )
 
         elif op["topic"] == "issue-credential":
             operation = op["operation"]
             if operation == "send-request":
-                print("=================================================================")
+                print(
+                    "================================================================="
+                )
                 print("Please respond to the Credential Offer!")
-                print("=================================================================")
-                return (200, '{"result": "ok", "thread_id": "1", "state": "request-sent"}')
+                print(
+                    "================================================================="
+                )
+                return (
+                    200,
+                    '{"result": "ok", "thread_id": "1", "state": "request-sent"}',
+                )
             elif operation == "store":
-                return (200, '{"result": "ok", "thread_id": "1", "credential_id": "' + rec_id + '", "state": "done"}')
+                return (
+                    200,
+                    '{"result": "ok", "thread_id": "1", "credential_id": "'
+                    + rec_id
+                    + '", "state": "done"}',
+                )
             else:
                 return (200, '{"result": "ok", "thread_id": "1", "state": "N/A"}')
 
         elif op["topic"] == "proof":
             operation = op["operation"]
             if operation == "send-presentation":
-                print("=================================================================")
+                print(
+                    "================================================================="
+                )
                 print("Please respond to the Proof Request!")
-                print("=================================================================")
-                return (200, '{"result": "ok", "thread_id": "1", "state": "presentation-sent"}')
+                print(
+                    "================================================================="
+                )
+                return (
+                    200,
+                    '{"result": "ok", "thread_id": "1", "state": "presentation-sent"}',
+                )
             else:
                 return (200, '{"result": "ok", "thread_id": "1", "state": "N/A"}')
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
-
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     async def make_agent_GET_request(
         self, op, rec_id=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         print("make_agent_GET_request:", op)
         if op["topic"] == "status":
             status = 200 if self.ACTIVE else 418
@@ -295,28 +328,37 @@ class MobileAgentBackchannel(AgentBackchannel):
             return (200, '{"result": "ok", "connection_id": "1", "state": "N/A"}')
 
         elif op["topic"] == "issue-credential":
-            return (200, '{"result": "ok", "credential_id": "' + rec_id + '", "state": "N/A"}')
+            return (
+                200,
+                '{"result": "ok", "credential_id": "' + rec_id + '", "state": "N/A"}',
+            )
 
         elif op["topic"] == "credential":
-            return (200, '{"result": "ok", "credential_id": "' + rec_id + '", "state": "N/A"}')
+            return (
+                200,
+                '{"result": "ok", "credential_id": "' + rec_id + '", "state": "N/A"}',
+            )
 
         elif op["topic"] == "proof":
-            return (200, '{"result": "ok", "thread_id": "' + rec_id + '", "state": "N/A"}')
+            return (
+                200,
+                '{"result": "ok", "thread_id": "' + rec_id + '", "state": "N/A"}',
+            )
 
         if op["topic"] == "version":
             return (200, '{"result": "ok"}')
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     async def make_agent_DELETE_request(
         self, op, rec_id=None, data=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     async def make_agent_GET_request_response(
         self, topic, rec_id=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         if topic == "connection" and rec_id:
             connection_msg = pop_resource(rec_id, "connection-msg")
             i = 0
@@ -333,15 +375,15 @@ class MobileAgentBackchannel(AgentBackchannel):
 
             return (resp_status, resp_text)
 
-        return (501, '501: Not Implemented\n\n'.encode('utf8'))
+        return (501, "501: Not Implemented\n\n".encode("utf8"))
 
     def map_test_json_to_admin_api_json(self, topic, operation, data):
         # If the translation of the json get complicated in the future we might want to consider a switch to JsonMapper or equivalent.
-        #json_mapper = JsonMapper()
+        # json_mapper = JsonMapper()
         # map_specification = {
         #     'name': ['person_name']
         # }
-        #JsonMapper(test_json).map(map_specification)
+        # JsonMapper(test_json).map(map_specification)
 
         if topic == "proof":
 
@@ -352,32 +394,72 @@ class MobileAgentBackchannel(AgentBackchannel):
                 else:
                     request_type = "proof_request"
                     attachment = "request_presentations~attach"
-                
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("requested_attributes") is None:
+
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("requested_attributes")
+                    is None
+                ):
                     requested_attributes = {}
                 else:
-                    requested_attributes = data["presentation_proposal"][attachment]["data"]["requested_attributes"]
+                    requested_attributes = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["requested_attributes"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("requested_predicates") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("requested_predicates")
+                    is None
+                ):
                     requested_predicates = {}
                 else:
-                    requested_predicates = data["presentation_proposal"][attachment]["data"]["requested_predicates"]
+                    requested_predicates = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["requested_predicates"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("name") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("name")
+                    is None
+                ):
                     proof_request_name = "test proof"
                 else:
-                    proof_request_name = data["presentation_proposal"][attachment]["data"]["name"]
+                    proof_request_name = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["name"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("version") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("version")
+                    is None
+                ):
                     proof_request_version = "1.0"
                 else:
-                    proof_request_version = data["presentation_proposal"][attachment]["data"]["version"]
+                    proof_request_version = data["presentation_proposal"][attachment][
+                        "data"
+                    ]["version"]
 
-                if data.get("presentation_proposal", {}).get(attachment, {}).get("data", {}).get("non_revoked") is None:
+                if (
+                    data.get("presentation_proposal", {})
+                    .get(attachment, {})
+                    .get("data", {})
+                    .get("non_revoked")
+                    is None
+                ):
                     non_revoked = None
                 else:
-                    non_revoked = data["presentation_proposal"][attachment]["data"]["non_revoked"]
-                
+                    non_revoked = data["presentation_proposal"][attachment]["data"][
+                        "non_revoked"
+                    ]
+
                 if "connection_id" in data:
                     admin_data = {
                         "comment": data["presentation_proposal"]["comment"],
@@ -387,8 +469,8 @@ class MobileAgentBackchannel(AgentBackchannel):
                             "name": proof_request_name,
                             "version": proof_request_version,
                             "requested_attributes": requested_attributes,
-                            "requested_predicates": requested_predicates
-                        }
+                            "requested_predicates": requested_predicates,
+                        },
                     }
                 else:
                     admin_data = {
@@ -398,8 +480,8 @@ class MobileAgentBackchannel(AgentBackchannel):
                             "name": proof_request_name,
                             "version": proof_request_version,
                             "requested_attributes": requested_attributes,
-                            "requested_predicates": requested_predicates
-                        }
+                            "requested_predicates": requested_predicates,
+                        },
                     }
                 if non_revoked is not None:
                     admin_data[request_type]["non_revoked"] = non_revoked
@@ -409,32 +491,42 @@ class MobileAgentBackchannel(AgentBackchannel):
             elif operation == "send-proposal":
 
                 request_type = "presentation_proposal"
-                
-                if data.get("presentation_proposal", {}).get("requested_attributes") == None:
+
+                if (
+                    data.get("presentation_proposal", {}).get("requested_attributes")
+                    == None
+                ):
                     requested_attributes = []
                 else:
-                    requested_attributes = data["presentation_proposal"]["requested_attributes"]
+                    requested_attributes = data["presentation_proposal"][
+                        "requested_attributes"
+                    ]
 
-                if data.get("presentation_proposal", {}).get("requested_predicates") == None:
+                if (
+                    data.get("presentation_proposal", {}).get("requested_predicates")
+                    == None
+                ):
                     requested_predicates = []
                 else:
-                    requested_predicates = data["presentation_proposal"]["requested_predicates"]
-                
+                    requested_predicates = data["presentation_proposal"][
+                        "requested_predicates"
+                    ]
+
                 admin_data = {
-                        "comment": data["presentation_proposal"]["comment"],
-                        "trace": False,
-                        request_type: {
-                            "@type": data["presentation_proposal"]["@type"],
-                            "attributes": requested_attributes,
-                            "predicates": requested_predicates
-                        }
-                    }
+                    "comment": data["presentation_proposal"]["comment"],
+                    "trace": False,
+                    request_type: {
+                        "@type": data["presentation_proposal"]["@type"],
+                        "attributes": requested_attributes,
+                        "predicates": requested_predicates,
+                    },
+                }
 
                 if "connection_id" in data:
                     admin_data["connection_id"] = data["connection_id"]
 
             elif operation == "send-presentation":
-                
+
                 if data.get("requested_attributes") == None:
                     requested_attributes = {}
                 else:
@@ -454,84 +546,114 @@ class MobileAgentBackchannel(AgentBackchannel):
                     "comment": data["comment"],
                     "requested_attributes": requested_attributes,
                     "requested_predicates": requested_predicates,
-                    "self_attested_attributes": self_attested_attributes
+                    "self_attested_attributes": self_attested_attributes,
                 }
 
             else:
                 admin_data = data
 
             # Add on the service decorator if it exists.
-            if "~service" in data: 
+            if "~service" in data:
                 admin_data["~service"] = data["~service"]
 
-            return (admin_data)
+            return admin_data
 
     def agent_state_translation(self, topic, operation, data):
-            # This method is used to translate the agent states passes back in the responses of operations into the states the 
-            # test harness expects. The test harness expects states to be as they are written in the Protocol's RFC.
-            # the following is what the tests/rfc expect vs what aca-py communicates
-            # Connection Protocol:
-            # Tests/RFC         |   Aca-py
-            # invited           |   invitation
-            # requested         |   request
-            # responded         |   response
-            # complete          |   active
-            #
-            # Issue Credential Protocol:
-            # Tests/RFC         |   Aca-py
-            # proposal-sent     |   proposal_sent
-            # proposal-received |   proposal_received
-            # offer-sent        |   offer_sent
-            # offer_received    |   offer_received
-            # request-sent      |   request_sent
-            # request-received  |   request_received
-            # credential-issued |   issued
-            # credential-received | credential_received
-            # done              |   credential_acked
-            #
-            # Present Proof Protocol:
-            # Tests/RFC         |   Aca-py
+        # This method is used to translate the agent states passes back in the responses of operations into the states the
+        # test harness expects. The test harness expects states to be as they are written in the Protocol's RFC.
+        # the following is what the tests/rfc expect vs what aca-py communicates
+        # Connection Protocol:
+        # Tests/RFC         |   Aca-py
+        # invited           |   invitation
+        # requested         |   request
+        # responded         |   response
+        # complete          |   active
+        #
+        # Issue Credential Protocol:
+        # Tests/RFC         |   Aca-py
+        # proposal-sent     |   proposal_sent
+        # proposal-received |   proposal_received
+        # offer-sent        |   offer_sent
+        # offer_received    |   offer_received
+        # request-sent      |   request_sent
+        # request-received  |   request_received
+        # credential-issued |   issued
+        # credential-received | credential_received
+        # done              |   credential_acked
+        #
+        # Present Proof Protocol:
+        # Tests/RFC         |   Aca-py
 
-            resp_json = json.loads(data)
-            # Check to see if state is in the json
-            if "state" in resp_json:
-                agent_state = resp_json["state"]
+        resp_json = json.loads(data)
+        # Check to see if state is in the json
+        if "state" in resp_json:
+            agent_state = resp_json["state"]
 
-                # if "did_exchange" in topic:
-                #     if "rfc23_state" in resp_json:
-                #         rfc_state = resp_json["rfc23_state"]
-                #     else:
-                #         rfc_state = resp_json["connection"]["rfc23_state"]
-                #     data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + rfc_state + '"')
-                # else:
-                # Check the thier_role property in the data and set the calling method to swap states to the correct role for DID Exchange
-                if "their_role" in data:
-                    #if resp_json["connection"]["their_role"] == "invitee":
-                    if "invitee" in data:
-                        de_state_trans_method = self.didExchangeResponderStateTranslationDict
-                    elif "inviter" in data:
-                        de_state_trans_method = self.didExchangeRequesterStateTranslationDict
+            # if "did_exchange" in topic:
+            #     if "rfc23_state" in resp_json:
+            #         rfc_state = resp_json["rfc23_state"]
+            #     else:
+            #         rfc_state = resp_json["connection"]["rfc23_state"]
+            #     data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + rfc_state + '"')
+            # else:
+            # Check the thier_role property in the data and set the calling method to swap states to the correct role for DID Exchange
+            if "their_role" in data:
+                # if resp_json["connection"]["their_role"] == "invitee":
+                if "invitee" in data:
+                    de_state_trans_method = (
+                        self.didExchangeResponderStateTranslationDict
+                    )
+                elif "inviter" in data:
+                    de_state_trans_method = (
+                        self.didExchangeRequesterStateTranslationDict
+                    )
+            else:
+                # make the trans method any one, since it doesn't matter. It's probably Out of Band.
+                de_state_trans_method = self.didExchangeResponderStateTranslationDict
+
+            if topic == "connection":
+                # if the response contains invitation id, swap out the connection states for the did exchange states
+                if "invitation_msg_id" in data:
+                    data = data.replace(
+                        '"state"' + ": " + '"' + agent_state + '"',
+                        '"state"'
+                        + ": "
+                        + '"'
+                        + de_state_trans_method[agent_state]
+                        + '"',
+                    )
                 else:
-                    # make the trans method any one, since it doesn't matter. It's probably Out of Band.
-                    de_state_trans_method = self.didExchangeResponderStateTranslationDict
+                    data = data.replace(
+                        agent_state, self.connectionStateTranslationDict[agent_state]
+                    )
+            elif topic == "issue-credential":
+                data = data.replace(
+                    agent_state, self.issueCredentialStateTranslationDict[agent_state]
+                )
+            elif topic == "proof":
+                data = data.replace(
+                    '"state"' + ": " + '"' + agent_state + '"',
+                    '"state"'
+                    + ": "
+                    + '"'
+                    + self.presentProofStateTranslationDict[agent_state]
+                    + '"',
+                )
+            elif topic == "out-of-band":
+                data = data.replace(
+                    '"state"' + ": " + '"' + agent_state + '"',
+                    '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"',
+                )
+            elif topic == "did-exchange":
+                data = data.replace(
+                    '"state"' + ": " + '"' + agent_state + '"',
+                    '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"',
+                )
+        return data
 
-                if topic == "connection":
-                    # if the response contains invitation id, swap out the connection states for the did exchange states
-                    if "invitation_msg_id" in data:
-                        data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"')
-                    else:
-                        data = data.replace(agent_state, self.connectionStateTranslationDict[agent_state])
-                elif topic == "issue-credential":
-                    data = data.replace(agent_state, self.issueCredentialStateTranslationDict[agent_state])
-                elif topic == "proof":
-                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + self.presentProofStateTranslationDict[agent_state] + '"')
-                elif topic == "out-of-band":
-                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"')
-                elif topic == "did-exchange":
-                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + de_state_trans_method[agent_state] + '"')
-            return (data)
-
-    async def get_agent_operation_acapy_version_based(self, topic, operation, rec_id=None, data=None):
+    async def get_agent_operation_acapy_version_based(
+        self, topic, operation, rec_id=None, data=None
+    ):
         # Admin api calls may change with acapy releases. For example revocation related calls change
         # between 0.5.4 and 0.5.5. To be able to handle this the backchannel is made aware of the acapy version
         # and constructs the calls based off that version
@@ -539,7 +661,7 @@ class MobileAgentBackchannel(AgentBackchannel):
         # construct some number to compare to with > or < instead of listing out the version number
         comparibleVersion = self.get_acapy_version_as_float()
 
-        if (topic == "revocation"):
+        if topic == "revocation":
             if operation == "revoke":
                 if comparibleVersion > 54:
                     agent_operation = "/revocation/" + operation
@@ -557,26 +679,43 @@ class MobileAgentBackchannel(AgentBackchannel):
                 else:
                     agent_operation = "/issue-credential/" + operation
 
-                    if (data is not None): # Data should be included with 0.5.4 or lower acapy. Then it takes them as inline parameters.
+                    if (
+                        data is not None
+                    ):  # Data should be included with 0.5.4 or lower acapy. Then it takes them as inline parameters.
                         cred_rev_id = data["cred_rev_id"]
                         rev_reg_id = data["rev_registry_id"]
                         publish = data["publish_immediately"]
-                        agent_operation = agent_operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id + "&publish=" + rev_reg_id + str(publish).lower()
+                        agent_operation = (
+                            agent_operation
+                            + "?cred_rev_id="
+                            + cred_rev_id
+                            + "&rev_reg_id="
+                            + rev_reg_id
+                            + "&publish="
+                            + rev_reg_id
+                            + str(publish).lower()
+                        )
                         data = None
             elif operation == "credential-record":
-                    agent_operation = "/revocation/" + operation
-                    if "cred_ex_id" in data:
-                        cred_ex_id = data["cred_ex_id"]
-                        agent_operation = agent_operation + "?cred_ex_id=" + cred_ex_id
-                    else:
-                        cred_rev_id = data["cred_rev_id"]
-                        rev_reg_id = data["rev_registry_id"]
-                        agent_operation = agent_operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id
-                        data = None
-        #elif (topic == "credential"):
-
+                agent_operation = "/revocation/" + operation
+                if "cred_ex_id" in data:
+                    cred_ex_id = data["cred_ex_id"]
+                    agent_operation = agent_operation + "?cred_ex_id=" + cred_ex_id
+                else:
+                    cred_rev_id = data["cred_rev_id"]
+                    rev_reg_id = data["rev_registry_id"]
+                    agent_operation = (
+                        agent_operation
+                        + "?cred_rev_id="
+                        + cred_rev_id
+                        + "&rev_reg_id="
+                        + rev_reg_id
+                    )
+                    data = None
+        # elif (topic == "credential"):
 
         return agent_operation, data
+
 
 async def main(start_port: int, show_timing: bool = False, interactive: bool = True):
 
@@ -586,7 +725,7 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
     try:
         print("Starting mobile backchannel ...")
         agent = MobileAgentBackchannel(
-            "mobile", start_port+1, start_port+2, genesis_data=genesis
+            "mobile", start_port + 1, start_port + 2, genesis_data=genesis
         )
 
         # start backchannel (common across all types of agents)
@@ -596,9 +735,7 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
 
         # now wait ...
         if interactive:
-            async for option in prompt_loop(
-                "(X) Exit? [X] "
-            ):
+            async for option in prompt_loop("(X) Exit? [X] "):
                 if option is None or option in "xX":
                     break
         else:
@@ -620,15 +757,17 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
     if not terminated:
         os._exit(1)
 
+
 def str2bool(v):
     if isinstance(v, bool):
-       return v
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
         return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+    elif v.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
+        raise argparse.ArgumentTypeError("Boolean value expected.")
+
 
 if __name__ == "__main__":
     import argparse
@@ -653,6 +792,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        asyncio.get_event_loop().run_until_complete(main(start_port=args.port, interactive=args.interactive))
+        asyncio.get_event_loop().run_until_complete(
+            main(start_port=args.port, interactive=args.interactive)
+        )
     except KeyboardInterrupt:
         os._exit(1)

--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -1,36 +1,20 @@
-import asyncio
-import functools
 import json
 import logging
 import os
 import traceback
 import random
-import subprocess
-import sys
-import prompt_toolkit
-from prompt_toolkit.application import run_in_terminal
-from prompt_toolkit.eventloop.defaults import use_asyncio_event_loop
-from prompt_toolkit.patch_stdout import patch_stdout
-from timeit import default_timer
 
-import pygments
-from pygments.filter import Filter
-from pygments.lexer import Lexer
-from pygments.lexers.data import JsonLdLexer
-from prompt_toolkit.formatted_text import FormattedText, PygmentsTokens
+from typing import Tuple
 
 from aiohttp import (
     web,
     ClientSession,
     ClientRequest,
-    ClientResponse,
-    ClientError,
-    ClientTimeout,
 )
-
-from python.utils import require_indy, flatten, log_json, log_msg, log_timer, output_reader, prompt_loop, read_operations
-
 import ptvsd
+
+from .utils import log_msg, read_operations
+
 ptvsd.enable_attach()
 
 LOGGER = logging.getLogger(__name__)
@@ -54,12 +38,7 @@ elif RUN_MODE == "pwd":
 
 
 def get_ledger_url(ledger_url: str = None):
-    if not ledger_url:
-        ledger_url = LEDGER_URL
-    if not ledger_url:
-        ledger_url = f"http://{self.external_host}:9000"
-
-    return ledger_url
+    return ledger_url or LEDGER_URL
 
 
 async def default_genesis_txns():
@@ -74,9 +53,7 @@ async def default_genesis_txns():
             async with ClientSession() as session:
                 ledger_url = get_ledger_url()
                 print("From ledger_url:", f"{ledger_url}/genesis")
-                async with session.get(
-                    f"{ledger_url}/genesis"
-                ) as resp:
+                async with session.get(f"{ledger_url}/genesis") as resp:
                     genesis = await resp.text()
         else:
             print("With local file:", "../local-genesis.txt")
@@ -89,18 +66,20 @@ async def default_genesis_txns():
 
 class AgentBackchannel:
     """
-    Base class for building Aries agent backchannel adapters for integration into the interoperability test suite.
+    Base class for building Aries agent backchannel adapters for integration
+    into the interoperability test suite.
 
-    Extend this base class and implement hooks to communicate with a specific agent.
+    Extend this base class and implement hooks to communicate with a specific
+    agent.
     """
 
     def __init__(
-        self, 
+        self,
         ident: str,
         http_port: int,
         admin_port: int,
         genesis_data: str = None,
-        params: dict = {}
+        params: dict = {},
     ):
         self.ACTIVE = False
 
@@ -141,7 +120,7 @@ class AgentBackchannel:
         self.ACTIVE = active
 
     async def listen_backchannel(self, backchannel_port):
-        """ 
+        """
         Setup the routes to allow the test harness to send commands to and get replies
         from the Agent under test.
 
@@ -167,28 +146,87 @@ class AgentBackchannel:
         Operations for each topic are in the backchannel_operations.csv file, generated from
         the Google sheet at https://bit.ly/AriesTestHarnessScenarios
         """
-        #operations_file = "../backchannel_operations.txt"
-        #self.operations = read_operations(file_name=operations_file, parser="pipe")
+        # operations_file = "../backchannel_operations.txt"
+        # self.operations = read_operations(file_name=operations_file, parser="pipe")
         operations_file = "./backchannel_operations.csv"
         self.operations = read_operations(file_name=operations_file)
 
         app = web.Application()
-        app.add_routes([web.post("/agent/command/{topic}/", self._post_command_backchannel)])
-        app.add_routes([web.post("/agent/command/{topic}", self._post_command_backchannel)])
-        app.add_routes([web.post("/agent/command/{topic}/{operation}/", self._post_command_backchannel)])
-        app.add_routes([web.post("/agent/command/{topic}/{operation}", self._post_command_backchannel)])
-        app.add_routes([web.get("/agent/command/{topic}/", self._get_command_backchannel)])
-        app.add_routes([web.get("/agent/command/{topic}", self._get_command_backchannel)])
-        app.add_routes([web.get("/agent/command/{topic}/{id}/", self._get_command_backchannel)])
-        app.add_routes([web.get("/agent/command/{topic}/{id}", self._get_command_backchannel)])
-        app.add_routes([web.get("/agent/command/{topic}/{operation}/{id}/", self._get_command_backchannel)])
-        app.add_routes([web.get("/agent/command/{topic}/{operation}/{id}", self._get_command_backchannel)])
-        app.add_routes([web.delete("/agent/command/{topic}/{id}/", self._delete_command_backchannel)])
-        app.add_routes([web.delete("/agent/command/{topic}/{id}", self._delete_command_backchannel)])
-        app.add_routes([web.get("/agent/response/{topic}/", self._get_response_backchannel)])
-        app.add_routes([web.get("/agent/response/{topic}", self._get_response_backchannel)])
-        app.add_routes([web.get("/agent/response/{topic}/{id}/", self._get_response_backchannel)])
-        app.add_routes([web.get("/agent/response/{topic}/{id}", self._get_response_backchannel)])
+        app.add_routes(
+            [web.post("/agent/command/{topic}/", self._post_command_backchannel)]
+        )
+        app.add_routes(
+            [web.post("/agent/command/{topic}", self._post_command_backchannel)]
+        )
+        app.add_routes(
+            [
+                web.post(
+                    "/agent/command/{topic}/{operation}/",
+                    self._post_command_backchannel,
+                )
+            ]
+        )
+        app.add_routes(
+            [
+                web.post(
+                    "/agent/command/{topic}/{operation}", self._post_command_backchannel
+                )
+            ]
+        )
+        app.add_routes(
+            [web.get("/agent/command/{topic}/", self._get_command_backchannel)]
+        )
+        app.add_routes(
+            [web.get("/agent/command/{topic}", self._get_command_backchannel)]
+        )
+        app.add_routes(
+            [web.get("/agent/command/{topic}/{id}/", self._get_command_backchannel)]
+        )
+        app.add_routes(
+            [web.get("/agent/command/{topic}/{id}", self._get_command_backchannel)]
+        )
+        app.add_routes(
+            [
+                web.get(
+                    "/agent/command/{topic}/{operation}/{id}/",
+                    self._get_command_backchannel,
+                )
+            ]
+        )
+        app.add_routes(
+            [
+                web.get(
+                    "/agent/command/{topic}/{operation}/{id}",
+                    self._get_command_backchannel,
+                )
+            ]
+        )
+        app.add_routes(
+            [
+                web.delete(
+                    "/agent/command/{topic}/{id}/", self._delete_command_backchannel
+                )
+            ]
+        )
+        app.add_routes(
+            [
+                web.delete(
+                    "/agent/command/{topic}/{id}", self._delete_command_backchannel
+                )
+            ]
+        )
+        app.add_routes(
+            [web.get("/agent/response/{topic}/", self._get_response_backchannel)]
+        )
+        app.add_routes(
+            [web.get("/agent/response/{topic}", self._get_response_backchannel)]
+        )
+        app.add_routes(
+            [web.get("/agent/response/{topic}/{id}/", self._get_response_backchannel)]
+        )
+        app.add_routes(
+            [web.get("/agent/response/{topic}/{id}", self._get_response_backchannel)]
+        )
         runner = web.AppRunner(app)
         await runner.setup()
         self.backchannel_site = web.TCPSite(runner, "0.0.0.0", backchannel_port)
@@ -209,18 +247,26 @@ class AgentBackchannel:
                 data = payload["data"]
         for op in self.operations:
             if operation is not None:
-                if (op["topic"] == topic and op["method"] == method and
-                    ((rec_id and op["id"] == "Y") or (rec_id is None)) and
-                    ((operation and op["operation"] == operation)) and
-                    ((data and op["data"] == "Y") or (data is None))
+                if (
+                    op["topic"] == topic
+                    and op["method"] == method
+                    and ((rec_id and op["id"] == "Y") or (rec_id is None))
+                    and ((operation and op["operation"] == operation))
+                    and ((data and op["data"] == "Y") or (data is None))
                 ):
                     print("Matched operation:", op)
                     return op
             else:
-                if (op["topic"] == topic and op["method"] == method and
-                    ((rec_id and op["id"] == "Y") or (rec_id is None)) and
-                    ((method == "GET") or (operation and op["operation"] == operation) or (operation is None)) and
-                    ((data and op["data"] == "Y") or (data is None))
+                if (
+                    op["topic"] == topic
+                    and op["method"] == method
+                    and ((rec_id and op["id"] == "Y") or (rec_id is None))
+                    and (
+                        (method == "GET")
+                        or (operation and op["operation"] == operation)
+                        or (operation is None)
+                    )
+                    and ((data and op["data"] == "Y") or (data is None))
                 ):
                     print("Matched operation:", op)
                     return op
@@ -229,29 +275,35 @@ class AgentBackchannel:
 
     def not_found_response(self, request):
         resp_text = "404 not found: " + str(request)
-        return web.Response(body=resp_text.encode('utf8'), status=404)
+        return web.Response(body=resp_text.encode("utf8"), status=404)
 
     def not_implemented_response(self, operation):
         resp_text = "501 not implemented: " + str(operation)
-        return web.Response(body=resp_text.encode('utf8'), status=501)
+        return web.Response(body=resp_text.encode("utf8"), status=501)
 
     async def _post_command_backchannel(self, request: ClientRequest):
         """
         Post a POST command to the agent.
         """
         topic = request.match_info["topic"]
-        topic_operation = request.match_info["operation"] if "operation" in request.match_info else None
+        topic_operation = (
+            request.match_info["operation"]
+            if "operation" in request.match_info
+            else None
+        )
         payload = await request.json()
 
         try:
-            operation = self.match_operation(topic, "POST", payload=payload, operation=topic_operation)
+            operation = self.match_operation(
+                topic, "POST", payload=payload, operation=topic_operation
+            )
             if operation:
                 try:
                     if "data" in payload:
                         data = payload["data"]
                     else:
                         data = None
-                        
+
                     if "id" in payload:
                         rec_id = payload["id"]
                     elif "cred_ex_id" in payload:
@@ -259,7 +311,9 @@ class AgentBackchannel:
                     else:
                         rec_id = None
 
-                    (resp_status, resp_text) = await self.make_agent_POST_request(operation, rec_id=rec_id, data=data)
+                    (resp_status, resp_text) = await self.make_agent_POST_request(
+                        operation, rec_id=rec_id, data=data
+                    )
 
                     if resp_status == 200:
                         return web.Response(text=resp_text, status=resp_status)
@@ -269,7 +323,7 @@ class AgentBackchannel:
                         return self.not_implemented_response(json.dumps(operation))
                     else:
                         return web.Response(body=resp_text, status=resp_status)
-                except NotImplementedError as ni_e:
+                except NotImplementedError:
                     return self.not_implemented_response(json.dumps(operation))
 
             return self.not_found_response(topic + " " + topic_operation)
@@ -284,19 +338,26 @@ class AgentBackchannel:
         Post a GET command to the agent.
         """
         topic = request.match_info["topic"]
-        topic_operation = request.match_info["operation"] if "operation" in request.match_info else None
-
+        topic_operation = (
+            request.match_info["operation"]
+            if "operation" in request.match_info
+            else None
+        )
 
         if "id" in request.match_info:
             rec_id = request.match_info["id"]
         else:
             rec_id = None
-        
+
         try:
-            operation = self.match_operation(topic, "GET", operation=topic_operation, rec_id=rec_id)
+            operation = self.match_operation(
+                topic, "GET", operation=topic_operation, rec_id=rec_id
+            )
             if operation:
                 try:
-                    (resp_status, resp_text) = await self.make_agent_GET_request(operation, rec_id=rec_id)
+                    (resp_status, resp_text) = await self.make_agent_GET_request(
+                        operation, rec_id=rec_id
+                    )
 
                     if resp_status == 200:
                         return web.Response(text=resp_text, status=resp_status)
@@ -306,7 +367,7 @@ class AgentBackchannel:
                         return self.not_implemented_response(json.dumps(operation))
                     else:
                         return web.Response(body=resp_text, status=resp_status)
-                except NotImplementedError as ni_e:
+                except NotImplementedError:
                     return self.not_implemented_response(json.dumps(operation))
 
             return self.not_found_response(topic)
@@ -317,39 +378,41 @@ class AgentBackchannel:
             return web.Response(body=str(e), status=500)
 
     async def _delete_command_backchannel(self, request: ClientRequest):
-            """
-            Post a DELETE command to the agent.
-            """
-            topic = request.match_info["topic"]
+        """
+        Post a DELETE command to the agent.
+        """
+        topic = request.match_info["topic"]
 
-            if "id" in request.match_info:
-                rec_id = request.match_info["id"]
-            else:
-                rec_id = None
+        if "id" in request.match_info:
+            rec_id = request.match_info["id"]
+        else:
+            rec_id = None
 
-            try:
-                operation = self.match_operation(topic, "DELETE", rec_id=rec_id)
-                if operation:
-                    try:
-                        (resp_status, resp_text) = await self.make_agent_DELETE_request(operation, rec_id=rec_id)
+        try:
+            operation = self.match_operation(topic, "DELETE", rec_id=rec_id)
+            if operation:
+                try:
+                    (resp_status, resp_text) = await self.make_agent_DELETE_request(
+                        operation, rec_id=rec_id
+                    )
 
-                        if resp_status == 200:
-                            return web.Response(text=resp_text, status=resp_status)
-                        elif resp_status == 404:
-                            return self.not_found_response(json.dumps(operation))
-                        elif resp_status == 501:
-                            return self.not_implemented_response(json.dumps(operation))
-                        else:
-                            return web.Response(body=resp_text, status=resp_status)
-                    except NotImplementedError as ni_e:
+                    if resp_status == 200:
+                        return web.Response(text=resp_text, status=resp_status)
+                    elif resp_status == 404:
+                        return self.not_found_response(json.dumps(operation))
+                    elif resp_status == 501:
                         return self.not_implemented_response(json.dumps(operation))
+                    else:
+                        return web.Response(body=resp_text, status=resp_status)
+                except NotImplementedError:
+                    return self.not_implemented_response(json.dumps(operation))
 
-                return self.not_found_response(topic)
+            return self.not_found_response(topic)
 
-            except Exception as e:
-                print("Exception:", e)
-                traceback.print_exc()
-                return web.Response(body=str(e), status=500)
+        except Exception as e:
+            print("Exception:", e)
+            traceback.print_exc()
+            return web.Response(body=str(e), status=500)
 
     async def _get_response_backchannel(self, request: ClientRequest):
         """
@@ -362,7 +425,9 @@ class AgentBackchannel:
             rec_id = None
 
         try:
-            (resp_status, resp_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id)
+            (resp_status, resp_text) = await self.make_agent_GET_request_response(
+                topic, rec_id=rec_id
+            )
 
             if resp_status == 200:
                 return web.Response(text=resp_text, status=resp_status)
@@ -373,7 +438,7 @@ class AgentBackchannel:
             else:
                 return web.Response(body=resp_text, status=resp_status)
 
-        except NotImplementedError as ni_e:
+        except NotImplementedError:
             return self.not_implemented_response(topic)
         except Exception as e:
             print("Exception:", e)
@@ -382,7 +447,7 @@ class AgentBackchannel:
 
     async def make_agent_POST_request(
         self, op, rec_id=None, data=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         """
         Override with agent-specific behaviour
         """
@@ -390,7 +455,7 @@ class AgentBackchannel:
 
     async def make_agent_GET_request(
         self, op, rec_id=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         """
         Override with agent-specific behaviour
         """
@@ -398,7 +463,7 @@ class AgentBackchannel:
 
     async def make_agent_GET_request_response(
         self, topic, rec_id=None, text=False, params=None
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         """
         Override with agent-specific behaviour
         """
@@ -428,4 +493,3 @@ class AgentBackchannel:
             nym_info = await resp.json()
             self.did = nym_info["did"]
         self.log(f"Got DID: {self.did}")
-

--- a/aries-backchannels/python/storage.py
+++ b/aries-backchannels/python/storage.py
@@ -8,7 +8,7 @@ storage_lock = threading.Lock()
 def store_resource(data_id, data_type, data):
     storage_lock.acquire()
     try:
-        if not data_id in storage:
+        if data_id not in storage:
             storage[data_id] = {}
         storage[data_id][data_type] = data
         return data
@@ -26,13 +26,14 @@ def get_resource(data_id, data_type):
     finally:
         storage_lock.release()
 
+
 def get_resource_latest(data_type):
     storage_lock.acquire()
     try:
         data_ids = list(storage.keys())
         data_id = data_ids[-1]
-        #data_type_keys = list(storage[data_id].keys())
-        #data_type = data_type_keys[-1]
+        # data_type_keys = list(storage[data_id].keys())
+        # data_type = data_type_keys[-1]
         data = storage[data_id][data_type][-1]
         return data
     finally:
@@ -67,9 +68,9 @@ def delete_resource(data_id, data_type):
 def push_resource(data_id, data_type, data):
     storage_lock.acquire()
     try:
-        if not data_id in storage:
+        if data_id not in storage:
             storage[data_id] = {}
-        if not data_type in storage[data_id]:
+        if data_type not in storage[data_id]:
             storage[data_id][data_type] = []
         storage[data_id][data_type].append(data)
         return data
@@ -89,6 +90,7 @@ def pop_resource(data_id, data_type):
         return None
     finally:
         storage_lock.release()
+
 
 def pop_resource_latest(data_type):
     storage_lock.acquire()

--- a/aries-backchannels/python/utils.py
+++ b/aries-backchannels/python/utils.py
@@ -115,9 +115,9 @@ def print_ext(
 
 
 def output_reader(handle, callback, *args, **kwargs):
-    if handle == None:
+    if handle is None:
         return
-        
+
     for line in iter(handle.readline, b""):
         if not line and line != "":
             break
@@ -242,29 +242,20 @@ def progress(*args, **kwargs):
     return ProgressBar(*args, **kwargs)
 
 
-def require_indy():
-    try:
-        from indy.libindy import _cdll
-
-        _cdll()
-    except ImportError:
-        print("python3-indy module not installed")
-        sys.exit(1)
-    except OSError:
-        print("libindy shared library could not be loaded")
-        sys.exit(1)
-
-
 def pipe_parser(str_data):
     data = io.StringIO(str_data)
-    csv.register_dialect('piper', delimiter='|', quoting=csv.QUOTE_NONE, skipinitialspace=True)
-    reader = csv.reader(data, dialect='piper')
+    csv.register_dialect(
+        "piper", delimiter="|", quoting=csv.QUOTE_NONE, skipinitialspace=True
+    )
+    reader = csv.reader(data, dialect="piper")
     return [[x.strip() for x in row] for row in reader]
+
 
 def csv_parser(str_data):
     data = io.StringIO(str_data)
     reader = csv.reader(data)
     return [[x.strip() for x in row] for row in reader]
+
 
 def read_operations(str_data=None, file_name=None, parser=None):
     # either str_data or an input file must be provided
@@ -293,12 +284,13 @@ def read_operations(str_data=None, file_name=None, parser=None):
     return operations
 
 
-EXTENSION = {"darwin": ".dylib", "linux": ".so", "win32": ".dll", 'windows': '.dll'}
+EXTENSION = {"darwin": ".dylib", "linux": ".so", "win32": ".dll", "windows": ".dll"}
 
 
 def file_ext():
     your_platform = platform.system().lower()
-    return EXTENSION[your_platform] if (your_platform in EXTENSION) else '.so'
+    return EXTENSION[your_platform] if (your_platform in EXTENSION) else ".so"
+
 
 def create_uuid():
     return str(uuid.uuid4())

--- a/manage
+++ b/manage
@@ -221,11 +221,14 @@ buildImages() {
     echo Backchannel Folder: ${BACKCHANNEL_FOLDER}
     if [ -e "${BACKCHANNEL_FOLDER}/Dockerfile.${agent}" ]; then
       echo "Building ${agent}-agent-backchannel ..."
-      docker build \
+      if ! docker build \
         ${args} \
         $(initDockerBuildArgs) \
         -t "${agent}-agent-backchannel" \
-        -f "${BACKCHANNEL_FOLDER}/Dockerfile.${agent}" "aries-backchannels/"
+        -f "${BACKCHANNEL_FOLDER}/Dockerfile.${agent}" "aries-backchannels/"; then
+          echo "Docker image build failed."
+          exit 1
+      fi
     else
       echo "Unable to find Dockerfile to build agent: ${agent}"
       echo "Must be one one of: ${VALID_AGENTS}"
@@ -233,11 +236,14 @@ buildImages() {
   done
 
   echo "Building aries-test-harness ..."
-  docker build \
+  if ! docker build \
     ${args} \
     $(initDockerBuildArgs) \
     -t 'aries-test-harness' \
-    -f 'aries-test-harness/Dockerfile.harness' 'aries-test-harness/'
+    -f 'aries-test-harness/Dockerfile.harness' 'aries-test-harness/'; then
+      echo "Docker image build failed."
+      exit 1
+  fi
 }
 
 pingLedger(){
@@ -379,8 +385,8 @@ startAgent() {
       export NGROK_NAME=
     fi
     echo "Starting ${NAME} Agent using ${IMAGE_NAME} ..."
-    #echo "docker run -d -it --name \"${CONTAINER_NAME}\" --expose \"${PORT_RANGE}\" -p \"${PORT_RANGE}:${PORT_RANGE}\" ${ENV_FILE_ARG} -e \"NGROK_NAME=${NGROK_NAME}\" -e \"DOCKERHOST=${DOCKERHOST}\" -e \"AGENT_NAME=${NAME}\" -e \"LEDGER_URL=${LEDGER_URL_INTERNAL}\" -e \"TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}\" -e \"AIP_CONFIG=${AIP_CONFIG}\" \"${IMAGE_NAME}\" -p \"${BACKCHANNEL_PORT}\" -i false"
-    local container_id=$(docker run -d -it --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${ENV_FILE_ARG} -e "NGROK_NAME=${NGROK_NAME}" -e "DOCKERHOST=${DOCKERHOST}" -e "AGENT_NAME=${NAME}" -e "LEDGER_URL=${LEDGER_URL_INTERNAL}" -e "TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}" -e "AIP_CONFIG=${AIP_CONFIG}" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
+    #echo 'docker run -dt --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${ENV_FILE_ARG} -e "NGROK_NAME=${NGROK_NAME}" -e "DOCKERHOST=${DOCKERHOST}" -e "AGENT_NAME=${NAME}" -e "LEDGER_URL=${LEDGER_URL_INTERNAL}" -e "TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}" -e "AIP_CONFIG=${AIP_CONFIG}" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false'
+    local container_id=$(docker run -dt --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${ENV_FILE_ARG} -e "NGROK_NAME=${NGROK_NAME}" -e "DOCKERHOST=${DOCKERHOST}" -e "AGENT_NAME=${NAME}" -e "LEDGER_URL=${LEDGER_URL_INTERNAL}" -e "TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}" -e "AIP_CONFIG=${AIP_CONFIG}" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
     sleep 1
     if [[ "${USE_NGROK}" = "true" ]]; then
       docker network connect aath_network "${CONTAINER_NAME}"
@@ -633,7 +639,7 @@ stopHarness(){
 
   cleanupNetwork
 
-  if [ ! "${docker_result}" == "0" ]; then
+  if [ -n "${docker_result}" ] && [ ! "${docker_result}" = "0" ]; then
     echo "Exit with error code ${docker_result}"
     exit ${docker_result}
   fi


### PR DESCRIPTION
This PR applies Black formatting to the back channel implementations, fixes a bunch of Python warnings and removes unused imports. It also removes the checks for the indy-sdk Python library which were inherited from the demo agents, but aren't necessary here (if it's needed but not installed, then the tests will fail anyway).

It also fixes a failure when running `manage stop` on my system by adjusting the check for `docker_result`, and aborts `manage build` if a docker build fails.