### PR TITLE
Auto response state handling

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -159,6 +159,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "response": "response-sent",
             "?": "abandoned",
             "active": "completed",
+            "completed": "completed",
         }
 
         # Aca-py : RFC
@@ -677,8 +678,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             agent_operation = (
                 agent_operation
                 + "create-invitation"
-                # + "?auto_accept="
-                # + auto_accept
                 + "?multi_use="
                 + multi_use
             )
@@ -700,8 +699,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             agent_operation = (
                 agent_operation
                 + "receive-invitation"
-                # + "?auto_accept="
-                # + auto_accept
                 + "?use_existing_connection="
                 + use_existing_connection
             )

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -677,9 +677,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             agent_operation = (
                 agent_operation
                 + "create-invitation"
-                + "?auto_accept="
-                + auto_accept
-                + "&multi_use="
+                # + "?auto_accept="
+                # + auto_accept
+                + "?multi_use="
                 + multi_use
             )
 
@@ -700,9 +700,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             agent_operation = (
                 agent_operation
                 + "receive-invitation"
-                + "?auto_accept="
-                + auto_accept
-                + "&use_existing_connection="
+                # + "?auto_accept="
+                # + auto_accept
+                + "?use_existing_connection="
                 + use_existing_connection
             )
             # agent_operation = "/didexchange/" + "receive-invitation"

--- a/aries-test-harness/features/0023-did-exchange.feature
+++ b/aries-test-harness/features/0023-did-exchange.feature
@@ -95,6 +95,8 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Bob" sends complete to "Acme"
       Then "Bob" and "Acme" have a connection
 
+   # This test will give an expected failure when running with Aca-py with the --auto-accept-requests & --auto-respond-messages options.
+   # Do not run this test with those flags on. It may also fail for other agents that do auto_responding depending on how the backchannel is implmented.
    @T007-RFC0023 @normal @AcceptanceTest @NegativeTest @ExceptionTest
    Scenario: Establish a connection with DID Exchange between two agents with attempt to continue after protocol is completed
       Given we have "2" agents


### PR DESCRIPTION
Fixed the acapy backchannel removing the auto_accept on OOB calls so it defaults to the configuration. This only matters if acapy is started with the auto respond and auto accept options. 