### PR TITLE
removal of all role reversal tests

### DIFF
--- a/aries-test-harness/features/0023-did-exchange.feature
+++ b/aries-test-harness/features/0023-did-exchange.feature
@@ -20,20 +20,8 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Acme" sends complete to "Bob"
       Then "Acme" and "Bob" have a connection
 
-   @T002-RFC0023 @critical @AcceptanceTest
-   Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with role reversal
-      Given we have "2" agents
-         | name | role      |
-         | Acme | responder |
-         | Bob  | requester |
-      When "Acme" sends an explicit invitation
-      And "Bob" receives the invitation
-      And "Bob" sends the request to "Acme"
-      And "Acme" receives the request
-      And "Acme" sends a response to "Bob"
-      And "Bob" receives the response
-      And "Bob" sends complete to "Acme"
-      Then "Bob" and "Acme" have a connection
+   #@T002-RFC0023 @critical @AcceptanceTest @Deprecated
+   #Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with role reversal
 
    @T003-RFC0023 @normal @AcceptanceTest
    Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with a public DID
@@ -50,20 +38,8 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Acme" sends complete to "Bob"
       Then "Acme" and "Bob" have a connection
 
-   @T004-RFC0023 @normal @AcceptanceTest
-   Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with a public DID with role reversal
-      Given we have "2" agents
-         | name | role      |
-         | Acme | responder |
-         | Bob  | requester |
-      When "Acme" sends an explicit invitation with a public DID
-      And "Bob" receives the invitation
-      And "Bob" sends the request to "Acme"
-      And "Acme" receives the request
-      And "Acme" sends a response to "Bob"
-      And "Bob" receives the response
-      And "Bob" sends complete to "Acme"
-      Then "Bob" and "Acme" have a connection
+   #@T004-RFC0023 @normal @AcceptanceTest @Deprecated
+   #Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with a public DID with role reversal
 
    @T005-RFC0023 @critical @AcceptanceTest
    Scenario: Establish a connection with DID Exchange between two agents with an implicit invitation
@@ -80,7 +56,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Acme" sends complete to "Bob"
       Then "Acme" and "Bob" have a connection
 
-   @T006-RFC0023 @critical @AcceptanceTest
+   @T006-RFC0023 @critical @AcceptanceTest @Deprecated
    Scenario: Establish a connection with DID Exchange between two agents with an implicit invitation with role reversal
       Given we have "2" agents
          | name | role      |

--- a/aries-test-harness/features/0023-did-exchange.feature
+++ b/aries-test-harness/features/0023-did-exchange.feature
@@ -56,20 +56,8 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Acme" sends complete to "Bob"
       Then "Acme" and "Bob" have a connection
 
-   @T006-RFC0023 @critical @AcceptanceTest @Deprecated
-   Scenario: Establish a connection with DID Exchange between two agents with an implicit invitation with role reversal
-      Given we have "2" agents
-         | name | role      |
-         | Acme | responder |
-         | Bob  | requester |
-      And "Acme" has a resolvable DID
-      And "Bob" aquires the resolvable DID
-      When "Bob" sends the request to "Acme" with the public DID
-      And "Acme" receives the request with their public DID
-      And "Acme" sends a response to "Bob"
-      And "Bob" receives the response
-      And "Bob" sends complete to "Acme"
-      Then "Bob" and "Acme" have a connection
+   #@T006-RFC0023 @critical @AcceptanceTest @Deprecated
+   #Scenario: Establish a connection with DID Exchange between two agents with an implicit invitation with role reversal
 
    # This test will give an expected failure when running with Aca-py with the --auto-accept-requests & --auto-respond-messages options.
    # Do not run this test with those flags on. It may also fail for other agents that do auto_responding depending on how the backchannel is implmented.

--- a/aries-test-harness/features/0160-connection.feature
+++ b/aries-test-harness/features/0160-connection.feature
@@ -23,28 +23,8 @@ Feature: RFC 0160 Aries agent connection functions
                         # implemented trustping which is not part of the AIP 1.0. The acks is removed here in favor of trustping until the RFC is changed or
                         # the agents under test implement acks.
 
-   @T001.2-RFC0160 @critical @AcceptanceTest
-   Scenario Outline: establish a connection between two agents with role reversal
-      Given we have "2" agents
-         | name  | role    |
-         | Acme | invitee |
-         | Bob   | inviter |
-      When "Bob" generates a connection invitation
-      And "Acme" receives the connection invitation
-      And "Acme" sends a connection request to "Bob"
-      And "Bob" receives the connection request
-      And "Bob" sends a connection response to "Acme"
-      And "Acme" receives the connection response
-      And "Acme" sends <message> to "Bob"
-      Then "Bob" and "Acme" have a connection
-
-      Examples:
-         | message   |
-         | trustping |
-         # | acks      | *Note* in RFC 0302: Aries Interop Profile, it states that Acknowledgements are part of AIP 1.0, however, agents under test have
-                        # implemented trustping which is not part of the AIP 1.0. The acks is removed here in favor of trustping until the RFC is changed or
-                        # the agents under test implement acks.
-
+   #@T001.2-RFC0160 @critical @AcceptanceTest @Deprecated
+   #Scenario Outline: establish a connection between two agents with role reversal
 
    @T002-RFC0160 @critical @AcceptanceTest
    Scenario Outline: Connection established between two agents but inviter sends next message to establish full connection state


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR removes any role reversal tests. This creates a strict adherence to the role assignments to the names used in the agents. IE. Acme is an issuer, Bob is a Holder, etc. Tests will no longer swap these roles, like Acme as a Holder or Bob as an Issuer. When assigning an agent in the run command to Acme `-a`, you can be sure that the agent will play the issuer role in all tests. 