### PR TITLE
fix: acapy-backchannel not having curl

### DIFF
--- a/aries-backchannels/acapy/Dockerfile.acapy
+++ b/aries-backchannels/acapy/Dockerfile.acapy
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 
 RUN apt-get update \
-   && apt-get install -y git gnupg2 software-properties-common \
+   && apt-get install -y git gnupg2 software-properties-common curl \
    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
    && add-apt-repository 'deb https://repo.sovrin.org/sdk/deb bionic stable' \
    && apt-get update \

--- a/aries-backchannels/acapy/Dockerfile.acapy-main
+++ b/aries-backchannels/acapy/Dockerfile.acapy-main
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 
 RUN apt-get update \
-   && apt-get install -y git gnupg2 software-properties-common \
+   && apt-get install -y git gnupg2 software-properties-common curl \
    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
    && add-apt-repository 'deb https://repo.sovrin.org/sdk/deb bionic stable' \
    && apt-get update \

--- a/manage
+++ b/manage
@@ -390,7 +390,7 @@ startAgent() {
   local DATA_VOLUME_ARG=
   # optional data volume folder
   if [[ -n DATA_VOLUME_PATH  ]]; then
-    DATA_VOLUME_ARG="-v $(pwd)/$DATA_VOLUME_PATH:/data-mount"
+    DATA_VOLUME_ARG="-v $(pwd)/$DATA_VOLUME_PATH:/data-mount:z"
   fi
 
   if [ ! "$(docker ps -q -f name=$CONTAINER_NAME)" ]; then


### PR DESCRIPTION
Running this locally, the tests were failing after being unable to detect if the agents had been started. Upon inspection of the logs for the agents (which had actually started), the following was repeatedly printed until it timed out:

```
acapy/ngrok-wait.sh: line 12: curl: command not found
ngrok not ready, sleeping 5 seconds....
```

So I added curl to both of the acapy backchannel docker files which seemed to fix things. Not sure how this wasn't breaking things outside of my environment though :thinking: 

The other small tweak I've included is just a RHEL based system compatibility thing for mapping SELinux context.