### PR TITLE
fix: afj and dotnet interop issues

### DIFF
--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -11,9 +11,9 @@ name: test-harness-acapy-javascript
 # notably those that involve revocation.
 #
 # Current
-# 
+#
 # Most of the tests are running. The tests not passing are being investigated.
-# 
+#
 # *Status Note Updated: 2021.03.18*
 #
 # End
@@ -45,7 +45,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a javascript"
           TEST_AGENTS: "-d acapy-main -b javascript"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@ProofProposal"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip"
           REPORT_PROJECT: acapy-b-javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-afj-acapy.yml
+++ b/.github/workflows/test-harness-afj-acapy.yml
@@ -7,14 +7,12 @@ name: test-harness-javascript-acapy
 #
 # This runset uses the current master branch of Aries Framework JavaScript for all of the agents except Bob (holder),
 # which uses the main branch of ACA-Py. The runset covers all of the AIP 1.0 tests
-# except those that are known **not** to work with the Aries Framework JavaScript,
-# notably those that involve proof proposals.
+# except those that are known **not** to work with the Aries Framework JavaScript
 #
 # Current
-# 
-# All AIP10 tests are currently running, except for the tests with the holder proposing a proof, 
-# as that feature is not supported in AFJ.
-# 
+#
+# All AIP10 tests are currently running.
+#
 # *Status Note Updated: 2021.03.17*
 #
 # End
@@ -46,7 +44,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a javascript -a acapy-main"
           TEST_AGENTS: "-d javascript -b acapy-main"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@ProofProposal"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10"
           REPORT_PROJECT: javascript-b-acapy
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-afj.yml
+++ b/.github/workflows/test-harness-afj.yml
@@ -9,9 +9,9 @@ name: test-harness-javascript-javascript
 # that are expected to pass given the current state of the framework's support for AIP 1. Tests related to revocation (Indy HIPE 0011) are not included.
 #
 # Current
-# 
+#
 # All of the tests being executed in this runset are passing.
-# 
+#
 # *Status Note Updated: 2021.03.05*
 #
 # End
@@ -43,7 +43,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a javascript"
           TEST_AGENTS: "-d javascript"
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@revocation -t ~@RFC0023 -t ~@DIDExchangeConnection"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10"
           REPORT_PROJECT: javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -8,7 +8,9 @@ using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Models.Events;
 using Microsoft.Extensions.Caching.Memory;
 using Hyperledger.Aries.Contracts;
+using System.Linq;
 using System.Reactive.Linq;
+
 using System;
 
 namespace DotNet.Backchannel.Controllers
@@ -84,7 +86,7 @@ namespace DotNet.Backchannel.Controllers
             _connectionCache.Set(connection.Id, testHarnessConnection);
 
             // Listen for connection request to update the state
-            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Requested, _ => _.MessageType == MessageTypes.ConnectionRequest && _.RecordId == connection.Id);
+            UpdateStateOnMessage(testHarnessConnection, TestHarnessConnectionState.Requested, _ => new[] { MessageTypes.ConnectionRequest, MessageTypesHttps.ConnectionRequest }.Contains(_.MessageType) && _.RecordId == connection.Id);
 
             return Ok(new { connection_id = testHarnessConnection.ConnectionId, state = testHarnessConnection.State, invitation });
         }
@@ -124,7 +126,7 @@ namespace DotNet.Backchannel.Controllers
             catch { return NotFound(); }
 
             // Listen for connection response to update the state
-            UpdateStateOnMessage(THConnection, TestHarnessConnectionState.Responded, _ => _.MessageType == MessageTypes.ConnectionResponse && _.RecordId == connection.Id);
+            UpdateStateOnMessage(THConnection, TestHarnessConnectionState.Responded, _ => new[] { MessageTypes.ConnectionResponse, MessageTypesHttps.ConnectionResponse }.Contains(_.MessageType) && _.RecordId == connection.Id);
 
             await _messageService.SendAsync(context, THConnection.Request, connection);
 

--- a/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
@@ -128,7 +128,7 @@ namespace DotNet.Backchannel.Controllers
             _credentialCache.Set(THCredentialExchange.ThreadId, THCredentialExchange);
 
             // Listen for credential offer to update the state
-            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.OfferReceived, _ => _.MessageType == MessageTypes.IssueCredentialNames.OfferCredential && _.ThreadId == THCredentialExchange.ThreadId);
+            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.OfferReceived, _ => new[] { MessageTypes.IssueCredentialNames.OfferCredential, MessageTypesHttps.IssueCredentialNames.OfferCredential }.Contains(_.MessageType) && _.ThreadId == THCredentialExchange.ThreadId);
 
             await _messageService.SendAsync(context, credentialProposeMessage, connection);
 
@@ -220,7 +220,7 @@ namespace DotNet.Backchannel.Controllers
             var connection = await _connectionService.GetAsync(context, connectionId);
 
             // Listen for credential request to update the state
-            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.RequestReceived, _ => _.MessageType == MessageTypes.IssueCredentialNames.RequestCredential && _.ThreadId == THCredentialExchange.ThreadId);
+            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.RequestReceived, _ => new[] { MessageTypes.IssueCredentialNames.RequestCredential, MessageTypesHttps.IssueCredentialNames.RequestCredential, }.Contains(_.MessageType) && _.ThreadId == THCredentialExchange.ThreadId);
 
             await _messageService.SendAsync(context, credentialOffer, connection);
 
@@ -239,7 +239,7 @@ namespace DotNet.Backchannel.Controllers
             THCredentialExchange.State = TestHarnessCredentialExchangeState.RequestSent;
 
             // Listen for issue credential to update the state
-            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.CredentialReceived, _ => _.MessageType == MessageTypes.IssueCredentialNames.IssueCredential && _.ThreadId == THCredentialExchange.ThreadId);
+            UpdateStateOnMessage(THCredentialExchange, TestHarnessCredentialExchangeState.CredentialReceived, _ => new[] { MessageTypes.IssueCredentialNames.IssueCredential, MessageTypesHttps.IssueCredentialNames.IssueCredential }.Contains(_.MessageType) && _.ThreadId == THCredentialExchange.ThreadId);
 
             var connection = await _connectionService.GetAsync(context, credentialRecord.ConnectionId);
             await _messageService.SendAsync(context, credentialRequest, connection);

--- a/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Hyperledger.Aries.Utils;
 using Hyperledger.Aries.Models.Events;
 using System.Reactive.Linq;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using Hyperledger.Indy.AnonCredsApi;
@@ -124,7 +125,7 @@ namespace DotNet.Backchannel.Controllers
             };
             _proofCache.Set(THPresentationExchange.ThreadId, THPresentationExchange);
 
-            UpdateStateOnMessage(THPresentationExchange, TestHarnessPresentationExchangeState.PresentationReceived, _ => _.MessageType == MessageTypes.PresentProofNames.Presentation && _.ThreadId == THPresentationExchange.ThreadId);
+            UpdateStateOnMessage(THPresentationExchange, TestHarnessPresentationExchangeState.PresentationReceived, _ => new[] { MessageTypes.PresentProofNames.Presentation, MessageTypesHttps.PresentProofNames.Presentation }.Contains(_.MessageType) && _.ThreadId == THPresentationExchange.ThreadId);
 
             _logger.LogDebug("Send Presentation Request {requestPresentationMessage}", requestPresentationMessage.ToJson());
 
@@ -144,7 +145,7 @@ namespace DotNet.Backchannel.Controllers
 
             var requestedCredentials = requestedCredentialsJson.ToObject<RequestedCredentials>();
 
-            _logger.LogInformation("SendProofPresentation {requestedCredentials}", requestedCredentials.ToJson());
+            _logger.LogInformation("SendProofPresentation {id} {requestedCredentials}", THPresentationExchange.RecordId, requestedCredentials.ToJson());
 
             var (presentationMessage, proofRecord) = await _proofService.CreatePresentationAsync(context, THPresentationExchange.RecordId, requestedCredentials);
 

--- a/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
+++ b/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hyperledger.Aries" Version="1.3.3" />
-    <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.3.3" />
+    <PackageReference Include="Hyperledger.Aries" Version="1.6.1" />
+    <PackageReference Include="Hyperledger.Aries.AspNetCore" Version="1.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
     <PackageReference Include="NLog.Config" Version="4.6.5" />

--- a/aries-backchannels/dotnet/server/Handlers/CredentialHandler.cs
+++ b/aries-backchannels/dotnet/server/Handlers/CredentialHandler.cs
@@ -62,6 +62,11 @@ namespace DotNet.Backchannel.Handlers
             MessageTypes.IssueCredentialNames.OfferCredential,
             MessageTypes.IssueCredentialNames.RequestCredential,
             MessageTypes.IssueCredentialNames.IssueCredential,
+            MessageTypesHttps.IssueCredentialNames.ProposeCredential,
+            MessageTypesHttps.IssueCredentialNames.OfferCredential,
+            MessageTypesHttps.IssueCredentialNames.RequestCredential,
+            MessageTypesHttps.IssueCredentialNames.IssueCredential,
+
         };
 
         /// <summary>
@@ -76,6 +81,7 @@ namespace DotNet.Backchannel.Handlers
             switch (messageContext.GetMessageType())
             {
                 case MessageTypes.IssueCredentialNames.ProposeCredential:
+                case MessageTypesHttps.IssueCredentialNames.ProposeCredential:
                     {
                         var credentialProposal = messageContext.GetMessage<CustomCredentialProposeMessage>();
 
@@ -144,6 +150,7 @@ namespace DotNet.Backchannel.Handlers
                         return null;
                     }
                 case MessageTypes.IssueCredentialNames.OfferCredential:
+                case MessageTypesHttps.IssueCredentialNames.OfferCredential:
                     {
                         var offer = messageContext.GetMessage<CredentialOfferMessage>();
                         var recordId = await this.ProcessOfferAsync(
@@ -154,6 +161,7 @@ namespace DotNet.Backchannel.Handlers
                         return null;
                     }
                 case MessageTypes.IssueCredentialNames.RequestCredential:
+                case MessageTypesHttps.IssueCredentialNames.RequestCredential:
                     {
                         var request = messageContext.GetMessage<CredentialRequestMessage>();
                         var recordId = await _credentialService.ProcessCredentialRequestAsync(
@@ -174,6 +182,7 @@ namespace DotNet.Backchannel.Handlers
                     }
 
                 case MessageTypes.IssueCredentialNames.IssueCredential:
+                case MessageTypesHttps.IssueCredentialNames.IssueCredential:
                     {
                         var credential = messageContext.GetMessage<CredentialIssueMessage>();
                         var recordId = await _credentialService.ProcessCredentialAsync(

--- a/aries-backchannels/dotnet/server/Handlers/PresentationAckHandler.cs
+++ b/aries-backchannels/dotnet/server/Handlers/PresentationAckHandler.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
-using Hyperledger.Aries.Features.IssueCredential;
 using Hyperledger.Aries;
 using DotNet.Backchannel.Messages;
 using DotNet.Backchannel.Models;
@@ -30,7 +29,8 @@ namespace DotNet.Backchannel.Handlers
         /// </value>
         public IEnumerable<MessageType> SupportedMessageTypes => new MessageType[]
         {
-           CustomMessageTypes.AckPresentation
+           CustomMessageTypes.AckPresentation,
+           CustomMessageTypes.AckPresentationHttps
         };
 
         /// <summary>
@@ -45,6 +45,7 @@ namespace DotNet.Backchannel.Handlers
             switch (messageContext.GetMessageType())
             {
                 case CustomMessageTypes.AckPresentation:
+                case CustomMessageTypes.AckPresentationHttps:
                     {
                         var presentationAck = messageContext.GetMessage<AckPresentationMessage>();
 

--- a/aries-backchannels/dotnet/server/Messages/CustomMessageTypes.cs
+++ b/aries-backchannels/dotnet/server/Messages/CustomMessageTypes.cs
@@ -3,5 +3,6 @@ namespace DotNet.Backchannel.Messages
     public static class CustomMessageTypes
     {
         public const string AckPresentation = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/ack";
+        public const string AckPresentationHttps = "https://didcomm.org/present-proof/1.0/ack";
     }
 }

--- a/aries-backchannels/javascript/server/package.json
+++ b/aries-backchannels/javascript/server/package.json
@@ -10,8 +10,8 @@
     "start:prod": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
-    "@aries-framework/core": "^0.1.0-alpha.230",
-    "@aries-framework/node": "^0.1.0-alpha.230",
+    "@aries-framework/core": "^0.1.0-alpha.233",
+    "@aries-framework/node": "^0.1.0-alpha.233",
     "@tsed/common": "6.25.2",
     "@tsed/core": "6.25.2",
     "@tsed/di": "6.25.2",

--- a/aries-backchannels/javascript/server/src/TestAgent.ts
+++ b/aries-backchannels/javascript/server/src/TestAgent.ts
@@ -14,13 +14,13 @@ export async function createAgent({
   endpoint,
   publicDidSeed,
   genesisPath,
-  agentName
+  agentName,
 }: {
   port: number;
   endpoint: string;
   publicDidSeed: string;
   genesisPath: string;
-  agentName: string
+  agentName: string;
 }) {
   // TODO: Public did does not seem to be registered
   // TODO: Schema is prob already registered
@@ -32,11 +32,7 @@ export async function createAgent({
     endpoint,
     publicDidSeed,
     genesisPath,
-    logger: new TsedLogger({
-      logLevel: LogLevel.debug,
-      logger: $log,
-      name: agentName,
-    }),
+    logger: new TsedLogger($log),
   };
 
   const agent = new Agent(agentConfig, agentDependencies);

--- a/aries-backchannels/javascript/server/src/TsedLogger.ts
+++ b/aries-backchannels/javascript/server/src/TsedLogger.ts
@@ -16,21 +16,9 @@ export class TsedLogger extends BaseLogger {
     [LogLevel.fatal]: "fatal",
   } as const;
 
-  public constructor({
-    logger,
-    logLevel,
-    name,
-  }: {
-    logger: Logger;
-    logLevel: LogLevel;
-    name?: string;
-  }) {
-    super(logLevel);
-    this.logger = logger ?? new Logger(name);
-
-    if (this.logLevel !== LogLevel.off) {
-      this.logger.level = this.tsedLogLevelMap[this.logLevel];
-    }
+  public constructor(logger: Logger) {
+    super(LogLevel.test);
+    this.logger = logger;
   }
 
   private log(
@@ -39,8 +27,6 @@ export class TsedLogger extends BaseLogger {
     data?: Record<string, any>
   ): void {
     const tsedLogLevel = this.tsedLogLevelMap[level];
-
-    if (this.logLevel === LogLevel.off) return;
 
     if (data) {
       this.logger[tsedLogLevel](message, data);

--- a/aries-backchannels/javascript/server/src/controllers/PresentProofController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/PresentProofController.ts
@@ -49,11 +49,23 @@ export class PresentProofController {
     @BodyParams("data")
     data: {
       connection_id: string;
-      presentation_proposal: any;
+      presentation_proposal: {
+        comment?: string;
+        requested_attributes: any;
+        requested_predicates: any;
+      };
     }
   ) {
+    const { requested_attributes, requested_predicates, ...restProposal } =
+      data.presentation_proposal;
+
+    const newPresentationProposal = {
+      ...restProposal,
+      attributes: requested_attributes,
+      predicates: requested_predicates,
+    };
     const presentationProposal = JsonTransformer.fromJSON(
-      data.presentation_proposal,
+      newPresentationProposal,
       PresentationPreview
     );
 
@@ -127,7 +139,11 @@ export class PresentProofController {
     );
 
     this.logger.info("Created requested credentials ", {
-      requestedCredentials: JSON.stringify(requestedCredentials.toJSON(), null, 2),
+      requestedCredentials: JSON.stringify(
+        requestedCredentials.toJSON(),
+        null,
+        2
+      ),
     });
 
     const credentialUtils = new CredentialUtils(this.agent);

--- a/aries-backchannels/javascript/server/yarn.lock
+++ b/aries-backchannels/javascript/server/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@aries-framework/core@0.1.0-alpha.230+69684bc", "@aries-framework/core@^0.1.0-alpha.230":
-  version "0.1.0-alpha.230"
-  resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.1.0-alpha.230.tgz#6042c86f447bcb60ac9f994e66179e241e57a4c2"
-  integrity sha512-srjKbMsSX5kXMafqIyacsSgJcaM9Bt5xsq8iaFJ8rBXi8at6oQBCVqf8qiyvwppFUfFTPlOuN+gY94x9AaKXpw==
+"@aries-framework/core@0.1.0-alpha.233+cdf2edd", "@aries-framework/core@^0.1.0-alpha.233":
+  version "0.1.0-alpha.233"
+  resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.1.0-alpha.233.tgz#5cb3bc5187c03218606253c986c7b2286d30927d"
+  integrity sha512-JfXoSurnPS6iLcqJdXWYtXcv4P3KshZ+wK2/kAXWzV+A3jy5M1xAKcoH/F0lMCeY88T/EzrEizo/suqjJdRCaA==
   dependencies:
     "@types/indy-sdk" "^1.16.5"
     abort-controller "^3.0.0"
@@ -24,12 +24,12 @@
     tsyringe "^4.5.0"
     uuid "^8.3.2"
 
-"@aries-framework/node@^0.1.0-alpha.230":
-  version "0.1.0-alpha.230"
-  resolved "https://registry.yarnpkg.com/@aries-framework/node/-/node-0.1.0-alpha.230.tgz#5a5d317d7d4737ea5823a4411a968841463648e0"
-  integrity sha512-YdW9lhClz1RTaZu6HmlT6vi5vh8M8ebEUPPVhiHaC7Ragoqedr0N0N962pY4u/nPeUwZoeNLo96ZdhCgCPVYhg==
+"@aries-framework/node@^0.1.0-alpha.233":
+  version "0.1.0-alpha.233"
+  resolved "https://registry.yarnpkg.com/@aries-framework/node/-/node-0.1.0-alpha.233.tgz#f25660ef599e29b2e16fd655ba04f5a77814bf69"
+  integrity sha512-O6wNZ2dXZeF+/2Kb8Kho00pY62LXh+HF4ItaeF3qXWQMchvT0RLl3V8YF89+QFvoFpyi1hjUESlRMzgIo9fMUg==
   dependencies:
-    "@aries-framework/core" "0.1.0-alpha.230+69684bc"
+    "@aries-framework/core" "0.1.0-alpha.233+cdf2edd"
     express "^4.17.1"
     indy-sdk "^1.16.0-dev-1634"
     node-fetch "^2.6.1"


### PR DESCRIPTION
AFJ had a lot of changes that were not updated in AATH. 4 issues:

1. AFJ sends https messages by default. Although .NET supports https, the backchannel did not -> Updated .NET backchannel to support https messages
2. AFJ includes both the `IndyAgent` and `did-communication` services in a did doc. .NET errors if other services than `IndyAgent` are present. As I don't suspect AF.NET to be updated in the near future I'v made a PR to AFJ: https://github.com/hyperledger/aries-framework-javascript/pull/402. We will wait with sending this until we support did exchange.
3. .NET crashes if no `mime-type` is present ([optional according to the RFC](https://github.com/hyperledger/aries-rfcs/blob/master/features/0036-issue-credential/README.md#mime-type-and-value)). AFJ doesn't send a mime-type if it is not explicitly set -> Updated AFJ to emit `mime-type` value of `text/plain` if not set
4. AFJ didn't take the presentation preview property quirk (as described [here](https://github.com/hyperledger/aries-agent-test-harness/issues/259#issuecomment-884553477)) into account. -> fixed.

This PR should be merged after https://github.com/hyperledger/aries-framework-javascript/pull/402 is merged and I had the chance to update the dependency in here.

afj-dotnet and acapy-dotnet-javascript fully passing now