### PR TITLE
Auto respond handling for Issue Credential/Proof 

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -208,13 +208,13 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             ("--label", self.label),
             # "--auto-ping-connection",
             # "--auto-accept-invites",
-            "--auto-accept-requests",
-            "--auto-respond-messages",
-            "--auto-respond-credential-proposal",
-            "--auto-respond-credential-offer",
-            "--auto-respond-credential-request",
-            "--auto-respond-presentation-proposal",
-            "--auto-respond-presentation-request",
+            #"--auto-accept-requests",
+            #"--auto-respond-messages",
+            #"--auto-respond-credential-proposal",
+            #"--auto-respond-credential-offer",
+            #"--auto-respond-credential-request",
+            #"--auto-respond-presentation-proposal",
+            #"--auto-respond-presentation-request",
             ("--inbound-transport", "http", "0.0.0.0", str(self.http_port)),
             ("--outbound-transport", "http"),
             ("--admin", "0.0.0.0", str(self.admin_port)),
@@ -395,6 +395,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         cred_def_id = message["cred_def_id"]
         push_resource(cred_def_id, "revocation-registry-msg", message)
         log_msg("Received Revocation Registry Webhook message: " + json.dumps(message))
+
+    # TODO Handle handle_issuer_cred_rev (this must be newer than the revocation tests?)
+    # TODO Handle handle_issue_credential_v2_0_indy
 
     async def handle_oob_invitation(self, message):
         # No thread id in the webhook for revocation registry messages

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -500,8 +500,12 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
                 # wait for the connection to be in "requested" status
                 if operation == "accept-request":
+                    # if self.auto_accept_requests:
+                    #     if not await self.expected_agent_state("/connections/" + connection_id, "response", wait_time=60.0):
+                    #         raise Exception(f"Expected state responded but not received")
+                    # else:
                     if not await self.expected_agent_state("/connections/" + connection_id, "request", wait_time=60.0):
-                        raise Exception(f"Expected state request but note recevied")
+                        raise Exception(f"Expected state request but not received")
 
                 agent_operation = "/connections/" + connection_id + "/" + operation
                 log_msg("POST Request: ", agent_operation, data)

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -84,6 +84,11 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         # set the auto response/request flags
         self.auto_accept_requests = False
         self.auto_respond_messages = False
+        self.auto_respond_credential_proposal = False
+        self.auto_respond_credential_offer = False
+        self.auto_respond_credential_request = False
+        self.auto_respond_presentation_proposal = False
+        self.auto_respond_presentation_request = False
 
         # Aca-py : RFC
         self.connectionStateTranslationDict = {
@@ -203,8 +208,13 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             ("--label", self.label),
             # "--auto-ping-connection",
             # "--auto-accept-invites",
-            #"--auto-accept-requests",
-            #"--auto-respond-messages",
+            "--auto-accept-requests",
+            "--auto-respond-messages",
+            "--auto-respond-credential-proposal",
+            "--auto-respond-credential-offer",
+            "--auto-respond-credential-request",
+            "--auto-respond-presentation-proposal",
+            "--auto-respond-presentation-request",
             ("--inbound-transport", "http", "0.0.0.0", str(self.http_port)),
             ("--outbound-transport", "http"),
             ("--admin", "0.0.0.0", str(self.admin_port)),
@@ -221,6 +231,16 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             self.auto_accept_requests = True
         if "--auto-respond-messages" in result:
             self.auto_respond_messages = True
+        if "--auto-respond-credential-proposal" in result:
+            self.auto_respond_credential_proposal = True
+        if "--auto-respond-credential-offer" in result:
+            self.auto_respond_credential_offer = True
+        if "--auto-respond-credential-request" in result:
+            self.auto_respond_credential_request = True
+        if "--auto-respond-presentation-proposal" in result:
+            self.auto_respond_presentation_proposal = True
+        if "--auto-respond-presentation-request" in result:
+            self.auto_respond_presentation_request = True
 
         if self.get_acapy_version_as_float() > 56:
             result.append(("--auto-provision", "--recreate-wallet"))
@@ -504,8 +524,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     #     if not await self.expected_agent_state("/connections/" + connection_id, "response", wait_time=60.0):
                     #         raise Exception(f"Expected state responded but not received")
                     # else:
-                    if not await self.expected_agent_state("/connections/" + connection_id, "request", wait_time=60.0):
-                        raise Exception(f"Expected state request but not received")
+                    if not self.auto_accept_requests:
+                        if not await self.expected_agent_state("/connections/" + connection_id, "request", wait_time=60.0):
+                            raise Exception(f"Expected state request but not received")
 
                 agent_operation = "/connections/" + connection_id + "/" + operation
                 log_msg("POST Request: ", agent_operation, data)
@@ -552,49 +573,67 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
             acapy_topic = "/issue-credential/"
 
-            if rec_id is None:
-                agent_operation = acapy_topic + operation
+            if self.auto_respond_credential_proposal and operation == "send-offer" and rec_id:
+                resp_status = 200
+                resp_text = '{"message": "Aca-py agent in auto respond mode for proposal. send-offer operation not called."}'
+                return (resp_status, resp_text)
+            elif self.auto_respond_credential_offer and operation == "send-request":
+                resp_status = 200
+                resp_text = '{"message": "Aca-py agent in auto respond mode for offer. send-request operation not called."}'
+                return (resp_status, resp_text)
+            elif self.auto_respond_credential_request and operation == "issue":
+                resp_status = 200
+                resp_text = '{"message": "Aca-py agent in auto respond mode for request. issue operation not called."}'
+                return (resp_status, resp_text)
             else:
-                if (
-                    operation == "send-offer"
-                    or operation == "send-request"
-                    or operation == "issue"
-                    or operation == "store"
-                ):
-                    # swap thread id for cred ex id from the webhook
-                    cred_ex_id = await self.swap_thread_id_for_exchange_id(
-                        rec_id, "credential-msg", "credential_exchange_id"
-                    )
-                    agent_operation = (
-                        acapy_topic + "records/" + cred_ex_id + "/" + operation
-                    )
-                # Make Special provisions for revoke since it is passing multiple query params not just one id.
-                elif operation == "revoke":
-                    cred_rev_id = rec_id
-                    rev_reg_id = data["rev_registry_id"]
-                    publish = data["publish_immediately"]
-                    agent_operation = (
-                        acapy_topic
-                        + operation
-                        + "?cred_rev_id="
-                        + cred_rev_id
-                        + "&rev_reg_id="
-                        + rev_reg_id
-                        + "&publish="
-                        + str(publish).lower()
-                    )
-                    data = None
-                else:
+                if rec_id is None:
                     agent_operation = acapy_topic + operation
+                else:
+                    if (
+                        operation == "send-offer"
+                        or operation == "send-request"
+                        or operation == "issue"
+                        or operation == "store"
+                    ):
+                            
+                        # swap thread id for cred ex id from the webhook
+                        cred_ex_id = await self.swap_thread_id_for_exchange_id(
+                            rec_id, "credential-msg", "credential_exchange_id"
+                        )
+                        agent_operation = (
+                            acapy_topic + "records/" + cred_ex_id + "/" + operation
+                        )
+                    # Make Special provisions for revoke since it is passing multiple query params not just one id.
+                    elif operation == "revoke":
+                        cred_rev_id = rec_id
+                        rev_reg_id = data["rev_registry_id"]
+                        publish = data["publish_immediately"]
+                        agent_operation = (
+                            acapy_topic
+                            + operation
+                            + "?cred_rev_id="
+                            + cred_rev_id
+                            + "&rev_reg_id="
+                            + rev_reg_id
+                            + "&publish="
+                            + str(publish).lower()
+                        )
+                        data = None
+                    else:
+                        agent_operation = acapy_topic + operation
 
-            log_msg(agent_operation, data)
+                log_msg(agent_operation, data)
 
-            (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+                # As of adding the Auto Accept and Auto Respond support and not taking time to check interim states
+                # it seems a sleep is required here,
+                # or sometimes the agent isn't in the correct state to accept the operation. Not sure why...
+                await asyncio.sleep(1)
+                (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
-            log_msg(resp_status, resp_text)
-            if resp_status == 200 and self.aip_version != "AIP20":
-                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
-            return (resp_status, resp_text)
+                log_msg(resp_status, resp_text)
+                if resp_status == 200 and self.aip_version != "AIP20":
+                    resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+                return (resp_status, resp_text)
 
         # Handle issue credential v2 POST operations
         elif op["topic"] == "issue-credential-v2":
@@ -603,7 +642,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             )
             return (resp_status, resp_text)
 
-        # Handle issue credential v2 POST operations
+        # Handle proof v2 POST operations
         elif op["topic"] == "proof-v2":
             (resp_status, resp_text) = await self.handle_proof_v2_POST(
                 op, rec_id=rec_id, data=data
@@ -639,48 +678,64 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             operation = op["operation"]
             if operation == "create-send-connectionless-request":
                 operation = "create-request"
-            if rec_id is None:
-                agent_operation = "/present-proof/" + operation
-            else:
-                if (
-                    operation == "send-presentation"
-                    or operation == "send-request"
-                    or operation == "verify-presentation"
-                    or operation == "remove"
-                ):
 
+            if self.auto_respond_presentation_proposal and operation == "send-request" and rec_id:
+                resp_status = 200
+                resp_text = '{"message": "Aca-py agent in auto respond mode for presentation proposal. send-request operation not called."}'
+                log_msg("Aca-py agent in auto respond mode for presentation proposal. send-request operation not called.")
+                return (resp_status, resp_text)
+            elif self.auto_respond_presentation_request and operation == "send-presentation":
+                resp_status = 200
+                resp_text = '{"message": "Aca-py agent in auto respond mode for presentation request. send-presentation operation not called."}'
+                log_msg("Aca-py agent in auto respond mode for presentation request. send-presentation operation not called.")
+                return (resp_status, resp_text)
+            else:
+                if rec_id is None:
+                    agent_operation = "/present-proof/" + operation
+                else:
                     if (
-                        operation not in "send-presentation"
-                        or operation not in "send-request"
-                    ) and (data is None or "~service" not in data):
-                        # swap thread id for pres ex id from the webhook
-                        pres_ex_id = await self.swap_thread_id_for_exchange_id(
-                            rec_id, "presentation-msg", "presentation_exchange_id"
+                        operation == "send-presentation"
+                        or operation == "send-request"
+                        or operation == "verify-presentation"
+                        or operation == "remove"
+                    ):
+
+                        if (
+                            operation not in "send-presentation"
+                            or operation not in "send-request"
+                        ) and (data is None or "~service" not in data):
+                            # swap thread id for pres ex id from the webhook
+                            pres_ex_id = await self.swap_thread_id_for_exchange_id(
+                                rec_id, "presentation-msg", "presentation_exchange_id"
+                            )
+                        else:
+                            # swap the thread id for the pres ex id in the service decorator (this is a connectionless proof)
+                            pres_ex_id = data["~service"]["recipientKeys"][0]
+                        agent_operation = (
+                            "/present-proof/records/" + pres_ex_id + "/" + operation
                         )
+
                     else:
-                        # swap the thread id for the pres ex id in the service decorator (this is a connectionless proof)
-                        pres_ex_id = data["~service"]["recipientKeys"][0]
-                    agent_operation = (
-                        "/present-proof/records/" + pres_ex_id + "/" + operation
+                        agent_operation = "/present-proof/" + operation
+
+                log_msg(agent_operation, data)
+
+                if data is not None:
+                    # Format the message data that came from the test, to what the Aca-py admin api expects.
+                    data = self.map_test_json_to_admin_api_json(
+                        op["topic"], operation, data
                     )
 
-                else:
-                    agent_operation = "/present-proof/" + operation
+                # As of adding the Auto Accept and Auto Respond support and not taking time to check interim states
+                # it seems a sleep is required here,
+                # or sometimes the agent isn't in the correct state to accept the operation. Not sure why...
+                await asyncio.sleep(1)
+                (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
-            log_msg(agent_operation, data)
-
-            if data is not None:
-                # Format the message data that came from the test, to what the Aca-py admin api expects.
-                data = self.map_test_json_to_admin_api_json(
-                    op["topic"], operation, data
-                )
-
-            (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
-
-            log_msg(resp_status, resp_text)
-            if resp_status == 200:
-                resp_text = self.agent_state_translation(op["topic"], None, resp_text)
-            return (resp_status, resp_text)
+                log_msg(resp_status, resp_text)
+                if resp_status == 200:
+                    resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+                return (resp_status, resp_text)
 
         # Handle out of band POST operations
         elif op["topic"] == "out-of-band":
@@ -795,128 +850,154 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         operation = op["operation"]
         topic = op["topic"]
 
-        if operation == "prepare-json-ld":
-            key_type = self.proofTypeKeyTypeTranslationDict[data["proof_type"]]
+        if self.auto_respond_credential_proposal and operation == "send-offer" and rec_id:
+            resp_status = 200
+            resp_text = '{"message": "Aca-py agent in auto respond mode for proposal. send-offer operation not called."}'
+            return (resp_status, resp_text)
+        elif self.auto_respond_credential_offer and operation == "send-request":
+            resp_status = 200
+            resp_text = '{"message": "Aca-py agent in auto respond mode for offer. send-request operation not called."}'
+            return (resp_status, resp_text)
+        elif self.auto_respond_credential_request and operation == "issue":
+            resp_status = 200
+            resp_text = '{"message": "Aca-py agent in auto respond mode for request. issue operation not called."}'
+            return (resp_status, resp_text)
+        else:
 
-            # Retrieve matching dids
-            resp_status, resp_text = await self.admin_GET(
-                "/wallet/did",
-                params={"method": data["did_method"], "key_type": key_type},
-            )
+            if operation == "prepare-json-ld":
+                key_type = self.proofTypeKeyTypeTranslationDict[data["proof_type"]]
 
-            did = None
-            if resp_status == 200:
-                resp_json = json.loads(resp_text)
-
-                # If there is a matching did use it
-                if len(resp_json["results"]) > 0:
-                    # Get first matching did
-                    did = resp_json["results"][0]["did"]
-
-            # If there was no matching did create a new one
-            if not did:
-                (resp_status, resp_text) = await self.admin_POST(
-                    "/wallet/did/create",
-                    {"method": data["did_method"], "options": {"key_type": key_type}},
+                # Retrieve matching dids
+                resp_status, resp_text = await self.admin_GET(
+                    "/wallet/did",
+                    params={"method": data["did_method"], "key_type": key_type},
                 )
+
+                did = None
                 if resp_status == 200:
                     resp_json = json.loads(resp_text)
-                    did = resp_json["result"]["did"]
 
-            if did:
-                resp_text = json.dumps({"did": did})
+                    # If there is a matching did use it
+                    if len(resp_json["results"]) > 0:
+                        # Get first matching did
+                        did = resp_json["results"][0]["did"]
+
+                # If there was no matching did create a new one
+                if not did:
+                    (resp_status, resp_text) = await self.admin_POST(
+                        "/wallet/did/create",
+                        {"method": data["did_method"], "options": {"key_type": key_type}},
+                    )
+                    if resp_status == 200:
+                        resp_json = json.loads(resp_text)
+                        did = resp_json["result"]["did"]
+
+                if did:
+                    resp_text = json.dumps({"did": did})
+
+                log_msg(resp_status, resp_text)
+                return (resp_status, resp_text)
+
+            if rec_id is None:
+                agent_operation = (
+                    self.TopicTranslationDict[topic]
+                    + self.issueCredentialv2OperationTranslationDict[operation]
+                )
+            else:
+                # swap thread id for cred ex id from the webhook
+                cred_ex_id = await self.swap_thread_id_for_exchange_id(
+                    rec_id, "credential-msg", "cred_ex_id"
+                )
+                agent_operation = (
+                    self.TopicTranslationDict[topic]
+                    + "records/"
+                    + cred_ex_id
+                    + "/"
+                    + self.issueCredentialv2OperationTranslationDict[operation]
+                )
+
+            # Map AATH filter keys to ACA-Py filter keys
+            # e.g. data.filters.json-ld becomes data.filters.ld_proof
+            if data and "filter" in data:
+                data["filter"] = dict(
+                    (self.credFormatFilterTranslationDict[name], val)
+                    for name, val in data["filter"].items()
+                )
+
+            log_msg(agent_operation, data)
+            await asyncio.sleep(1)
+            (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+
+            if operation == "store":
+                resp_json = json.loads(resp_text)
+
+                if resp_json["ld_proof"]:
+                    resp_json["json-ld"] = resp_json.pop("ld_proof")
+
+                # Return less ACA-Py specific credential identifier key
+                for key in resp_json:
+                    if resp_json[key] and resp_json[key].get("cred_id_stored"):
+                        resp_json[key]["credential_id"] = resp_json[key].get(
+                            "cred_id_stored"
+                        )
+
+                resp_text = json.dumps(resp_json)
 
             log_msg(resp_status, resp_text)
+            # Looks like all v2 states are RFC states. Yah!
+            # if resp_status == 200: resp_text = self.agent_state_translation(topic], None, resp_text)
+            resp_text = self.move_field_to_top_level(resp_text, "state")
             return (resp_status, resp_text)
-
-        if rec_id is None:
-            agent_operation = (
-                self.TopicTranslationDict[topic]
-                + self.issueCredentialv2OperationTranslationDict[operation]
-            )
-        else:
-            # swap thread id for cred ex id from the webhook
-            cred_ex_id = await self.swap_thread_id_for_exchange_id(
-                rec_id, "credential-msg", "cred_ex_id"
-            )
-            agent_operation = (
-                self.TopicTranslationDict[topic]
-                + "records/"
-                + cred_ex_id
-                + "/"
-                + self.issueCredentialv2OperationTranslationDict[operation]
-            )
-
-        # Map AATH filter keys to ACA-Py filter keys
-        # e.g. data.filters.json-ld becomes data.filters.ld_proof
-        if data and "filter" in data:
-            data["filter"] = dict(
-                (self.credFormatFilterTranslationDict[name], val)
-                for name, val in data["filter"].items()
-            )
-
-        log_msg(agent_operation, data)
-
-        (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
-
-        if operation == "store":
-            resp_json = json.loads(resp_text)
-
-            if resp_json["ld_proof"]:
-                resp_json["json-ld"] = resp_json.pop("ld_proof")
-
-            # Return less ACA-Py specific credential identifier key
-            for key in resp_json:
-                if resp_json[key] and resp_json[key].get("cred_id_stored"):
-                    resp_json[key]["credential_id"] = resp_json[key].get(
-                        "cred_id_stored"
-                    )
-
-            resp_text = json.dumps(resp_json)
-
-        log_msg(resp_status, resp_text)
-        # Looks like all v2 states are RFC states. Yah!
-        # if resp_status == 200: resp_text = self.agent_state_translation(topic], None, resp_text)
-        resp_text = self.move_field_to_top_level(resp_text, "state")
-        return (resp_status, resp_text)
 
     async def handle_proof_v2_POST(self, op, rec_id=None, data=None):
         operation = op["operation"]
         topic = op["topic"]
 
-        if rec_id is None:
-            agent_operation = (
-                self.TopicTranslationDict[topic]
-                + self.proofv2OperationTranslationDict[operation]
-            )
+        if self.auto_respond_presentation_proposal and operation == "send-request" and rec_id:
+            resp_status = 200
+            resp_text = '{"message": "Aca-py agent in auto respond mode for presentation proposal. send-request operation not called."}'
+            log_msg("Aca-py agent in auto respond mode for presentation proposal. send-request operation not called.")
+            return (resp_status, resp_text)
+        elif self.auto_respond_presentation_request and operation == "send-presentation":
+            resp_status = 200
+            resp_text = '{"message": "Aca-py agent in auto respond mode for presentation request. send-presentation operation not called."}'
+            log_msg("Aca-py agent in auto respond mode for presentation request. send-presentation operation not called.")
+            return (resp_status, resp_text)
         else:
-            # swap thread id for cred ex id from the webhook
-            pres_ex_id = await self.swap_thread_id_for_exchange_id(
-                rec_id, "presentation-msg", "pres_ex_id"
-            )
-            agent_operation = (
-                self.TopicTranslationDict[topic]
-                + "records/"
-                + pres_ex_id
-                + "/"
-                + self.proofv2OperationTranslationDict[operation]
-            )
+            if rec_id is None:
+                agent_operation = (
+                    self.TopicTranslationDict[topic]
+                    + self.proofv2OperationTranslationDict[operation]
+                )
+            else:
+                # swap thread id for cred ex id from the webhook
+                pres_ex_id = await self.swap_thread_id_for_exchange_id(
+                    rec_id, "presentation-msg", "pres_ex_id"
+                )
+                agent_operation = (
+                    self.TopicTranslationDict[topic]
+                    + "records/"
+                    + pres_ex_id
+                    + "/"
+                    + self.proofv2OperationTranslationDict[operation]
+                )
 
-        log_msg(
-            f"Data passed to backchannel by test for operation: {agent_operation}", data
-        )
-        if data is not None:
-            # Format the message data that came from the test, to what the Aca-py admin api expects.
-            data = self.map_test_json_to_admin_api_json("proof-v2", operation, data)
-        log_msg(
-            f"Data translated by backchannel to send to agent for operation: {agent_operation}",
-            data,
-        )
-        (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+            log_msg(
+                f"Data passed to backchannel by test for operation: {agent_operation}", data
+            )
+            if data is not None:
+                # Format the message data that came from the test, to what the Aca-py admin api expects.
+                data = self.map_test_json_to_admin_api_json("proof-v2", operation, data)
+            log_msg(
+                f"Data translated by backchannel to send to agent for operation: {agent_operation}",
+                data,
+            )
+            await asyncio.sleep(1)
+            (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
-        log_msg(resp_status, resp_text)
-        resp_text = self.move_field_to_top_level(resp_text, "state")
-        return (resp_status, resp_text)
+            log_msg(resp_status, resp_text)
+            resp_text = self.move_field_to_top_level(resp_text, "state")
+            return (resp_status, resp_text)
 
     def move_field_to_top_level(self, resp_text, field_to_move):
         # Some reponses have been changed to nest fields that were once at top level.

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -253,7 +253,7 @@ def step_impl(context, responder):
             # else:
             #     assert False, f'Could not retreive responders connection_id'
 
-    responder_connection_id = context.connection_id_dict[responder][context.requester_name]
+    #responder_connection_id = context.connection_id_dict[responder][context.requester_name]
 
     # responder already recieved the connection request in the send-request call so get connection and verify status.
     #assert expected_agent_state(responder_url, "did-exchange", responder_connection_id, "request-received")

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -248,10 +248,6 @@ def step_impl(context, issuer):
         # If context has the credential thread id then the proposal was done. 
         (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential", operation="send-offer", id=context.cred_thread_id)
         assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-        ##resp_json = json.loads(resp_text)
-        
-    # Check the issuers State
-    ##assert resp_json["state"] == "offer-sent"
 
     # Check the state of the holder after issuers call of send-offer
     # TODO Removing this line causes too many failures in Acapy-Dotnet Acapy-Afgo. 
@@ -279,11 +275,6 @@ def step_impl(context, holder):
     # If the protocol starts with a request we need a thread_id to call the issue command
     if "cred_thread_id" not in context:
             context.cred_thread_id = resp_json["thread_id"]
-
-    ##assert resp_json["state"] == "request-sent"
-
-    # Verify issuer status
-    ##assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "request-received", wait_time=60.0)
 
 
 @when('"{issuer}" issues the credential')

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -203,7 +203,6 @@ def step_impl(context, holder, issuer):
         "schema_id": context.issuer_schema_dict[context.schema['schema_name']]["id"],
     }
 
-    #(resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential", operation="send-proposal", id=holder_connection_id, data=credential_offer)
     (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential", operation="send-proposal", data=credential_offer)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
@@ -276,10 +275,10 @@ def step_impl(context, holder):
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    assert resp_json["state"] == "request-sent"
+    #assert resp_json["state"] == "request-sent"
 
     # Verify issuer status
-    assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "request-received", wait_time=60.0)
+    #assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "request-received", wait_time=60.0)
 
 
 @when('"{issuer}" issues the credential')
@@ -304,11 +303,11 @@ def step_impl(context, issuer):
     (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential", operation="issue", id=context.cred_thread_id, data=credential_preview)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    assert resp_json["state"] == "credential-issued"
+    #assert resp_json["state"] == "credential-issued"
 
     # Verify holder status
     #sleep(1.0)
-    assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "credential-received")
+    #assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "credential-received")
 
 
 @when('"{holder}" acknowledges the credential issue')

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -254,7 +254,8 @@ def step_impl(context, issuer):
     ##assert resp_json["state"] == "offer-sent"
 
     # Check the state of the holder after issuers call of send-offer
-    ##assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
+    # TODO Removing this line causes too many failures in Acapy-Dotnet Acapy-Afgo. 
+    assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
 
     
 @when('"{holder}" requests the credential')

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -240,20 +240,21 @@ def step_impl(context, issuer):
         (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential", operation="send-offer", data=credential_offer)
         assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
         resp_json = json.loads(resp_text)
-        context.cred_thread_id = resp_json["thread_id"]
+        if "thread_id" in resp_json:
+            context.cred_thread_id = resp_json["thread_id"]
 
     else:
 
         # If context has the credential thread id then the proposal was done. 
         (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential", operation="send-offer", id=context.cred_thread_id)
         assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-        resp_json = json.loads(resp_text)
+        ##resp_json = json.loads(resp_text)
         
     # Check the issuers State
-    assert resp_json["state"] == "offer-sent"
+    ##assert resp_json["state"] == "offer-sent"
 
     # Check the state of the holder after issuers call of send-offer
-    assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
+    ##assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
 
     
 @when('"{holder}" requests the credential')
@@ -265,20 +266,23 @@ def step_impl(context, holder):
     # reveived the thread_id.
     #if "Indy" in context.tags:
     if "cred_thread_id" in context:
-        #sleep(1)
         (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential", operation="send-request", id=context.cred_thread_id)
 
     # If we are starting from here in the protocol you won't have the cred_ex_id or the thread_id
     else:
-        #sleep(1)
         (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential", operation="send-request", id=context.connection_id_dict[holder][context.issuer_name])
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    #assert resp_json["state"] == "request-sent"
+    
+    # If the protocol starts with a request we need a thread_id to call the issue command
+    if "cred_thread_id" not in context:
+            context.cred_thread_id = resp_json["thread_id"]
+
+    ##assert resp_json["state"] == "request-sent"
 
     # Verify issuer status
-    #assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "request-received", wait_time=60.0)
+    ##assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "request-received", wait_time=60.0)
 
 
 @when('"{issuer}" issues the credential')
@@ -306,7 +310,7 @@ def step_impl(context, issuer):
     #assert resp_json["state"] == "credential-issued"
 
     # Verify holder status
-    #sleep(1.0)
+    sleep(1.0)
     #assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "credential-received")
 
 

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -162,7 +162,7 @@ def step_impl(context, verifier, prover):
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
     # check the state of the presentation from the verifiers perspective
-    assert resp_json["state"] == "request-sent"
+    #assert resp_json["state"] == "request-sent"
 
     # save off anything that is returned in the response to use later?
     context.presentation_thread_id = resp_json["thread_id"]
@@ -170,7 +170,8 @@ def step_impl(context, verifier, prover):
     # check the state of the presentation from the provers perspective
     # if the protocol is connectionless then don't do this, the prover has not recieved anything yet.
     if ('connectionless' not in context) or (context.connectionless == False):
-        assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
+        #assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
+        pass
     else:
         # save off the presentation exchange id for use when the prover sends the presentation with a service decorator
         context.presentation_exchange_id = resp_json["presentation_exchange_id"]
@@ -251,10 +252,10 @@ def step_impl(context, prover):
     (resp_status, resp_text) = agent_backchannel_POST(prover_url + "/agent/command/", "proof", operation="send-presentation", id=context.presentation_thread_id, data=presentation)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    assert resp_json["state"] == "presentation-sent"
+    ##assert resp_json["state"] == "presentation-sent"
 
     # check the state of the presentation from the verifier's perspective
-    assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received", wait_time=60.0)
+    ##assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received", wait_time=60.0)
 
 @when('"{prover}" makes the {presentation} of the proof')
 def step_impl(context, prover, presentation):
@@ -341,13 +342,13 @@ def step_impl(context, prover):
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
     # check the state of the presentation from the verifiers perspective
-    assert resp_json["state"] == "proposal-sent"
+    ##assert resp_json["state"] == "proposal-sent"
 
     # save off anything that is returned in the response to use later?
     context.presentation_thread_id = resp_json["thread_id"]
 
     # check the state of the presentation from the provers perspective
-    assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "proposal-received")
+    ##assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "proposal-received")
 
 
 @when(u'"{verifier}" agrees to continue so sends a request for proof presentation')
@@ -385,13 +386,13 @@ def step_impl(context, verifier):
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
     # check the state of the presentation from the verifiers perspective
-    assert resp_json["state"] == "request-sent"
+    ##assert resp_json["state"] == "request-sent"
 
     # save off anything that is returned in the response to use later?
     #context.presentation_thread_id = resp_json["thread_id"]
 
     # check the state of the presentation from the provers perspective
-    assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
+    ##assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
     #assert present_proof_status(context.prover_url, context.presentation_thread_id, "request-received")
 
 @when('"{prover}" doesn’t want to reveal what was requested so makes a {proposal}')
@@ -476,7 +477,7 @@ def step_impl(context, prover, presentation, verifier):
     assert resp_status == 400, f'resp_status {resp_status} is not 400; {resp_text}'
 
     # check the state of the presentation from the verifier's perspective
-    assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received")
+    ##assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received")
 
     # context.execute_steps('''
     #     When "''' + prover + '''" makes the ''' + presentation + ''' of the proof

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -252,11 +252,7 @@ def step_impl(context, prover):
 
     (resp_status, resp_text) = agent_backchannel_POST(prover_url + "/agent/command/", "proof", operation="send-presentation", id=context.presentation_thread_id, data=presentation)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-    resp_json = json.loads(resp_text)
-    ##assert resp_json["state"] == "presentation-sent"
 
-    # check the state of the presentation from the verifier's perspective
-    ##assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received", wait_time=60.0)
 
 @when('"{prover}" makes the {presentation} of the proof')
 def step_impl(context, prover, presentation):
@@ -342,14 +338,9 @@ def step_impl(context, prover):
     (resp_status, resp_text) = agent_backchannel_POST(context.prover_url + "/agent/command/", "proof", operation="send-proposal", data=presentation_proposal)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    # check the state of the presentation from the verifiers perspective
-    ##assert resp_json["state"] == "proposal-sent"
 
     # save off anything that is returned in the response to use later?
     context.presentation_thread_id = resp_json["thread_id"]
-
-    # check the state of the presentation from the provers perspective
-    ##assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "proposal-received")
 
 
 @when(u'"{verifier}" agrees to continue so sends a request for proof presentation')
@@ -386,15 +377,7 @@ def step_impl(context, verifier):
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    # check the state of the presentation from the verifiers perspective
-    ##assert resp_json["state"] == "request-sent"
 
-    # save off anything that is returned in the response to use later?
-    #context.presentation_thread_id = resp_json["thread_id"]
-
-    # check the state of the presentation from the provers perspective
-    ##assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
-    #assert present_proof_status(context.prover_url, context.presentation_thread_id, "request-received")
 
 @when('"{prover}" doesn’t want to reveal what was requested so makes a {proposal}')
 @when('"{prover}" makes a {proposal} to "{verifier}"')
@@ -477,12 +460,7 @@ def step_impl(context, prover, presentation, verifier):
     (resp_status, resp_text) = agent_backchannel_POST(context.prover_url + "/agent/command/", "proof", operation="send-presentation", id=context.presentation_thread_id, data=presentation)
     assert resp_status == 400, f'resp_status {resp_status} is not 400; {resp_text}'
 
-    # check the state of the presentation from the verifier's perspective
-    ##assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received")
 
-    # context.execute_steps('''
-    #     When "''' + prover + '''" makes the ''' + presentation + ''' of the proof
-    # ''')
 
 # @when(u'"{verifier}" rejects the proof so sends a presentation rejection')
 # def step_impl(context, verifier):

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -170,7 +170,8 @@ def step_impl(context, verifier, prover):
     # check the state of the presentation from the provers perspective
     # if the protocol is connectionless then don't do this, the prover has not recieved anything yet.
     if ('connectionless' not in context) or (context.connectionless == False):
-        #assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
+        # TODO Removing this line causes too many failures in Acapy-Dotnet Acapy-Afgo. 
+        assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
         pass
     else:
         # save off the presentation exchange id for use when the prover sends the presentation with a service decorator

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -88,9 +88,6 @@ def step_impl(context, holder, cred_format, issuer, credential_data):
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
 
-    # Check the State of the credential
-    ##assert resp_json["state"] == "proposal-sent"
-
     # Get the thread ID from the response text.
     context.cred_thread_id = resp_json["thread_id"]
 
@@ -125,12 +122,6 @@ def step_impl(context, issuer, cred_format):
         (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential-v2", operation="send-offer", id=context.cred_thread_id)
         assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
         resp_json = json.loads(resp_text)
-        
-    # Check the issuers State
-    ##assert resp_json["state"] == "offer-sent"
-
-    # Check the state of the holder after issuers call of send-offer
-    ##assert expected_agent_state(context.holder_url, "issue-credential-v2", context.cred_thread_id, "offer-received")
 
 
 @when('"{holder}" requests the "{cred_format}" credential')
@@ -148,11 +139,6 @@ def step_impl(context, holder, cred_format):
     #     (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential-v2", operation="send-request", id=context.connection_id_dict[holder][context.issuer_name])
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-    resp_json = json.loads(resp_text)
-    ##assert resp_json["state"] == "request-sent"
-
-    # Verify issuer status
-    ##assert expected_agent_state(context.issuer_url, "issue-credential-v2", context.cred_thread_id, "request-received")
 
 
 @when('"{issuer}" issues the "{cred_format}" credential')
@@ -165,11 +151,6 @@ def step_impl(context, issuer, cred_format):
 
     (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential-v2", operation="issue", id=context.cred_thread_id, data=credential_issue)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-    resp_json = json.loads(resp_text)
-    ##assert resp_json["state"] == "credential-issued"
-
-    # Verify holder status
-    ##assert expected_agent_state(context.holder_url, "issue-credential-v2", context.cred_thread_id, "credential-received")
 
 
 @when('"{holder}" acknowledges the "{cred_format}" credential issue')

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -89,7 +89,7 @@ def step_impl(context, holder, cred_format, issuer, credential_data):
     resp_json = json.loads(resp_text)
 
     # Check the State of the credential
-    assert resp_json["state"] == "proposal-sent"
+    ##assert resp_json["state"] == "proposal-sent"
 
     # Get the thread ID from the response text.
     context.cred_thread_id = resp_json["thread_id"]
@@ -127,10 +127,10 @@ def step_impl(context, issuer, cred_format):
         resp_json = json.loads(resp_text)
         
     # Check the issuers State
-    assert resp_json["state"] == "offer-sent"
+    ##assert resp_json["state"] == "offer-sent"
 
     # Check the state of the holder after issuers call of send-offer
-    assert expected_agent_state(context.holder_url, "issue-credential-v2", context.cred_thread_id, "offer-received")
+    ##assert expected_agent_state(context.holder_url, "issue-credential-v2", context.cred_thread_id, "offer-received")
 
 
 @when('"{holder}" requests the "{cred_format}" credential')
@@ -149,10 +149,10 @@ def step_impl(context, holder, cred_format):
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    assert resp_json["state"] == "request-sent"
+    ##assert resp_json["state"] == "request-sent"
 
     # Verify issuer status
-    assert expected_agent_state(context.issuer_url, "issue-credential-v2", context.cred_thread_id, "request-received")
+    ##assert expected_agent_state(context.issuer_url, "issue-credential-v2", context.cred_thread_id, "request-received")
 
 
 @when('"{issuer}" issues the "{cred_format}" credential')
@@ -166,10 +166,10 @@ def step_impl(context, issuer, cred_format):
     (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential-v2", operation="issue", id=context.cred_thread_id, data=credential_issue)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    assert resp_json["state"] == "credential-issued"
+    ##assert resp_json["state"] == "credential-issued"
 
     # Verify holder status
-    assert expected_agent_state(context.holder_url, "issue-credential-v2", context.cred_thread_id, "credential-received")
+    ##assert expected_agent_state(context.holder_url, "issue-credential-v2", context.cred_thread_id, "credential-received")
 
 
 @when('"{holder}" acknowledges the "{cred_format}" credential issue')

--- a/aries-test-harness/features/steps/0454-present-proof-v2.py
+++ b/aries-test-harness/features/steps/0454-present-proof-v2.py
@@ -123,8 +123,6 @@ def step_impl(context, verifier, request_for_proof, prover):
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    # check the state of the presentation from the verifiers perspective
-    ##assert resp_json["state"] == "request-sent"
 
     # save off anything that is returned in the response to use later?
     context.presentation_thread_id = resp_json["thread_id"]
@@ -132,7 +130,6 @@ def step_impl(context, verifier, request_for_proof, prover):
     # check the state of the presentation from the provers perspective
     # if the protocol is connectionless then don't do this, the prover has not recieved anything yet.
     if ('connectionless' not in context) or (context.connectionless == False):
-        ##assert expected_agent_state(context.prover_url, "proof-v2", context.presentation_thread_id, "request-received")
         pass
     else:
         # save off the presentation exchange id for use when the prover sends the presentation with a service decorator
@@ -215,11 +212,6 @@ def step_impl(context, prover, presentation):
 
     (resp_status, resp_text) = agent_backchannel_POST(prover_url + "/agent/command/", "proof-v2", operation="send-presentation", id=context.presentation_thread_id, data=presentation)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-    resp_json = json.loads(resp_text)
-    ##assert resp_json["state"] == "presentation-sent"
-
-    # check the state of the presentation from the verifier's perspective
-    ##assert expected_agent_state(context.verifier_url, "proof-v2", context.presentation_thread_id, "presentation-received")
 
 
 @when('"{verifier}" acknowledges the proof with formats')

--- a/aries-test-harness/features/steps/0454-present-proof-v2.py
+++ b/aries-test-harness/features/steps/0454-present-proof-v2.py
@@ -124,7 +124,7 @@ def step_impl(context, verifier, request_for_proof, prover):
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
     # check the state of the presentation from the verifiers perspective
-    assert resp_json["state"] == "request-sent"
+    ##assert resp_json["state"] == "request-sent"
 
     # save off anything that is returned in the response to use later?
     context.presentation_thread_id = resp_json["thread_id"]
@@ -132,7 +132,8 @@ def step_impl(context, verifier, request_for_proof, prover):
     # check the state of the presentation from the provers perspective
     # if the protocol is connectionless then don't do this, the prover has not recieved anything yet.
     if ('connectionless' not in context) or (context.connectionless == False):
-        assert expected_agent_state(context.prover_url, "proof-v2", context.presentation_thread_id, "request-received")
+        ##assert expected_agent_state(context.prover_url, "proof-v2", context.presentation_thread_id, "request-received")
+        pass
     else:
         # save off the presentation exchange id for use when the prover sends the presentation with a service decorator
         context.presentation_exchange_id = resp_json["presentation_exchange_id"]
@@ -215,10 +216,10 @@ def step_impl(context, prover, presentation):
     (resp_status, resp_text) = agent_backchannel_POST(prover_url + "/agent/command/", "proof-v2", operation="send-presentation", id=context.presentation_thread_id, data=presentation)
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
-    assert resp_json["state"] == "presentation-sent"
+    ##assert resp_json["state"] == "presentation-sent"
 
     # check the state of the presentation from the verifier's perspective
-    assert expected_agent_state(context.verifier_url, "proof-v2", context.presentation_thread_id, "presentation-received")
+    ##assert expected_agent_state(context.verifier_url, "proof-v2", context.presentation_thread_id, "presentation-received")
 
 
 @when('"{verifier}" acknowledges the proof with formats')


### PR DESCRIPTION
This PR adds support for auto-respond in AATH, along with the removal of interim agent state checks.  These changes affect Issue Credential 1.0 and 2.0 along with Presentation 1.0 and 2.0.  

There are two instances (one for Issue Credential and one for Presentation) where the state check could not  be removed at this time. Removing them causes problems with the Acapy to Dotnet runset. 
One is in `@when('"{issuer}" offers a credential')` on line 254 of `0036-issue-credential.py`.
```
assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
```
The other is in `@when('"{verifier}" sends a request for proof presentation to "{prover}"')` on line 174 of `0037-present-proof.py`
```
assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
```
For backchannel developers that do not need this state check in an auto responding agent, please just return 200, with the expected state for now. These lines will be removed once the problem is determined and fixed. 
See outstanding issues below for further details of this issue. 

**HOW TO VERIFY**
This PR affects all run sets and all agents. No need to run them all, but a few runset executions would be prudent. Get the runset configurations from [here](https://github.com/hyperledger/aries-agent-test-harness/tree/main/.github/workflows). 


**OUTSTANDING ISSUES**
Mobile Issue: @ianco I've added the state checks in certain instances where the mobile tests are expected to wait, to the acapy backchannel. However, I only get 9 out of 10 passing. At the end of some of the tests I also get a `something went wrong` error in Trinsic Wallet, but the credential is issued properly and the presentation is made. Wondering if you can take a look and let me know if it is something I've done or this is expected? 

Dotnet Backchannel Issue: @TimoGlastra It seems, with all the state checks removed, Dotnet or the combination of Dotnet with Acapy has a problem. Executing Dotnet in all agent rolls doesn't cause this issue. I've logged an issue for this #326 . I'm wondering if you can take a look and help diagnose the problem. I'm assuming the Dotnet backchannel was doing something to advance the protocol in those state checks. 

**AWARENESS**
@smithbk @Matt-Spence 

**SPAWNED ISSUES**
#325 
#326 
#330 

Closes #320