### PR TITLE
Pin tar version for javascript backchannel

### DIFF
--- a/aries-backchannels/javascript/server/yarn.lock
+++ b/aries-backchannels/javascript/server/yarn.lock
@@ -2495,9 +2495,9 @@ supports-color@^7.1.0:
     has-flag "^4.0.0"
 
 tar@^6.0.2, tar@^6.1.0:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.4.tgz#9f0722b772a5e00dba7d52e1923b37a7ec3799b3"
-  integrity sha512-kcPWrO8S5ABjuZ/v1xQHP8xCEvj1dQ1d9iAb6Qs4jLYzaAIYWwST2IQpz7Ud8VNYRI+fGhFjrnzRKmRggKWg3g==
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Pin the tar version due to security vulnerability.

Manually "fixed" the yarn.lock file, not sure that this is the best approach :-S
