### PR TITLE
removal of one revocation test as mobile

### DIFF
--- a/aries-test-harness/features/0183-revocation.feature
+++ b/aries-test-harness/features/0183-revocation.feature
@@ -332,7 +332,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T013-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense @Indy @MobileTest
+   @T013-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense @Indy
    Scenario Outline: Non-revocable Credential, not revoked, and holder proves claims with the credential with timesstamp
       Given "2" agents
          | name  | role     |


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Simple fix to remove a mistakenly added Revocation MobileTest in a previous PR. 

This PR closes #330
There is still a failure with the esatus wallet on revocation test `T001.2-HIPE0011`. This test revokes a credential, but since the verifier doesn't include a timestamp in the proof request, that means they don't care if the credential was revoked.  This case is derived from [RFC 0441](https://github.com/hyperledger/aries-rfcs/tree/main/concepts/0441-present-proof-best-practices#semantics-of-non-revocation-interval-presence-and-absence) and states the following, 
```
The absence of any non-revocation interval applicable to a requested item signifies that the verifier has no interest in its
credential's non-revocation status.

A revocable or non-revocable credential may satisfy a presentation request with or without a non-revocation interval. 
The presence of a non-revocation interval conveys that if the prover presents a revocable credential, the presentation 
must include proof of non-revocation. Its presence does not convey any restriction on the revocability of the credential to 
present: in many cases the verifier cannot know whether a prover's credential is revocable or not.
```
Depending on how we interpret that section, we may want to talk to esatus about it. 