### PR TITLE
moved verity to the inviter roll

### DIFF
--- a/.github/workflows/test-harness-acapy-verity.yml
+++ b/.github/workflows/test-harness-acapy-verity.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a acapy-main -a verity"
-          TEST_AGENTS: "-d acapy-main -b verity"
+          TEST_AGENTS: "-d acapy-main -a verity"
           TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip"
           REPORT_PROJECT: acapy-b-verity
         continue-on-error: true


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR fixes the accidental role reversal for verity. Verity cannot play the invitee role. 

To test this PR
`LEDGER_URL_CONFIG=http://dev.bcovrin.vonx.io ./manage run -d acapy-main -a verity -t @RFC0160 -t @AcceptanceTest -t ~@wip`