### PR TITLE
Remove PR triggered tests until Allure problem can be resolved

### DIFF
--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -18,9 +18,6 @@ name: test-harness-acapy-afgo
 #
 # End
 on:
-  pull_request:
-    branches:
-    - main
   workflow_dispatch:
   schedule:
     - cron: "5 0 * * *"

--- a/.github/workflows/test-harness-afj-dotnet.yml
+++ b/.github/workflows/test-harness-afj-dotnet.yml
@@ -18,9 +18,6 @@ name: test-harness-javascript-dotnet
 #
 # End
 on:
-  pull_request:
-    branches:
-    - main
   workflow_dispatch:
   schedule:
     - cron: "55 0 * * *"


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

Removing the triggering of the tests on PR addition.  The tests are failing on every run because they don't have permission to run the Allure publishing. To re-add:

- figure out and correct the Allure publishing issue.
- make a new action that runs the test, but doesn't do the Allure testing.

For now, we'll just turn off the test runs.
