### PR TITLE
added sleeps in the javascript backchannel to wait for appropriate states to proceed

### DIFF
--- a/aries-backchannels/javascript/server/src/controllers/ConnectionController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/ConnectionController.ts
@@ -68,6 +68,7 @@ export class ConnectionController {
 
   @Post("/accept-request")
   async acceptRequest(@BodyParams("id") connectionId: string) {
+    await new Promise(f => setTimeout(f, 5000));
     const connection = await this.agent.connections.acceptRequest(connectionId);
 
     return this.mapConnection(connection);

--- a/aries-backchannels/javascript/server/src/controllers/IssueCredentialController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/IssueCredentialController.ts
@@ -80,7 +80,7 @@ export class IssueCredentialController {
     }
   ) {
     let credentialRecord: CredentialRecord;
-
+    await new Promise(f => setTimeout(f, 5000));
     if (threadId) {
       const { id } = await this.credentialUtils.getCredentialByThreadId(
         threadId

--- a/aries-backchannels/javascript/server/src/controllers/PresentProofController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/PresentProofController.ts
@@ -185,6 +185,7 @@ export class PresentProofController {
 
   @Post("/verify-presentation")
   async verifyPresentation(@BodyParams("id") threadId: string) {
+    await new Promise(f => setTimeout(f, 5000));
     let proofRecord = await this.proofUtils.getProofByThreadId(threadId);
     if (proofRecord) {
       return this.mapProofRecord(


### PR DESCRIPTION
This PR should fix the Javascript with acapy daily test runset failures.  It problems ended up being the removal of the interim state checks in the tests, since we are not checking (and waiting) for the proper state before proceeding, the waits have to be done in the javascript backchannel instead.  These are all passing on my local machine, if some still fail in the daily runs, then we may have to increase the new wait times.  

Use the following command to test this:
`./manage run -d javascript -b acapy-main -t @AcceptanceTest -t ~@wip -t @AIP10`

Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>