### PR TITLE
Add backchannel for findy-agent

### DIFF
--- a/.github/workflows/test-harness-acapy-findy.yml
+++ b/.github/workflows/test-harness-acapy-findy.yml
@@ -1,0 +1,55 @@
+name: test-harness-acapy-findy
+# RUNSET_NAME: "ACA-PY to findy"
+# Scope: AIP 1.0
+# Exceptions: Revocation
+#
+# Summary
+#
+# This runset uses the current main branch of ACA-Py for all of the agents except Bob (holder),
+# which uses the latest release of findy-agent. The runset covers all of the AIP 1.0 tests that 
+# are known to work with the findy-agent as the holder. Excluded are those tests that involve Revocation.
+#
+# Current
+# 
+# All of the tests being executed in this runset are passing.
+# 
+# *Status Note Updated: 2021.09.14*
+#
+# End
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 1 * * *"
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
+    env:
+      LEDGER_URL_CONFIG: "http://localhost:9000"
+      TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+    steps:
+      - name: checkout-test-harness
+        uses: actions/checkout@v2
+        with:
+          path: test-harness
+      - name: run-von-network
+        uses: ./test-harness/actions/run-von-network
+      - name: run-indy-tails-server
+        uses: ./test-harness/actions/run-indy-tails-server
+      - name: run-test-harness-wo-reports
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a acapy-main -a findy"
+          TEST_AGENTS: "-d acapy-main -b findy"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation"
+          REPORT_PROJECT: acapy-b-findy
+        continue-on-error: true
+      - name: run-send-gen-test-results-secure
+        uses: ./test-harness/actions/run-send-gen-test-results-secure
+        with:
+          REPORT_PROJECT: acapy-b-findy
+          ADMIN_USER: ${{ secrets.AllureAdminUser }}
+          ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-findy-acapy.yml
+++ b/.github/workflows/test-harness-findy-acapy.yml
@@ -1,0 +1,55 @@
+name: test-harness-findy-acapy
+# RUNSET_NAME: "findy to ACA-PY"
+# Scope: AIP 1.0
+# Exceptions: Revocation
+#
+# Summary
+#
+# This runset uses the latest release of findy-agent for all of the agents except Bob (holder),
+# which uses the current main branch of ACA-Py. The runset covers all of the AIP 1.0 tests that 
+# are known to work with the ACA-Py as the holder. Excluded are those tests that involve Revocation.
+#
+# Current
+# 
+# All of the tests being executed in this runset are passing.
+# 
+# *Status Note Updated: 2021.09.14*
+#
+# End
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "25 1 * * *"
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
+    env:
+      LEDGER_URL_CONFIG: "http://localhost:9000"
+      TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+    steps:
+      - name: checkout-test-harness
+        uses: actions/checkout@v2
+        with:
+          path: test-harness
+      - name: run-von-network
+        uses: ./test-harness/actions/run-von-network
+      - name: run-indy-tails-server
+        uses: ./test-harness/actions/run-indy-tails-server
+      - name: run-test-harness-wo-reports
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a acapy-main -a findy"
+          TEST_AGENTS: "-d findy -b acapy-main"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation"
+          REPORT_PROJECT: findy-b-acapy
+        continue-on-error: true
+      - name: run-send-gen-test-results-secure
+        uses: ./test-harness/actions/run-send-gen-test-results-secure
+        with:
+          REPORT_PROJECT: findy-b-acapy
+          ADMIN_USER: ${{ secrets.AllureAdminUser }}
+          ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-findy.yml
+++ b/.github/workflows/test-harness-findy.yml
@@ -1,0 +1,55 @@
+name: test-harness-findy-findy
+# RUNSET_NAME: "findy to findy"
+# Scope: AIP 1.0
+# Exceptions: Revocation
+# SKIP
+# 
+# Summary
+#
+# This runset uses the latest release of findy-agent for all of the agents. The runset runs all of the tests in the suite
+# that are expected to pass given the current state of ACA-Py support for AIP 1.
+#
+# Current
+# 
+# All of the tests being executed in this runset are passing.
+# 
+# *Status Note Updated: 2021.09.14*
+#
+# End
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
+    env:
+      LEDGER_URL_CONFIG: "http://localhost:9000"
+      TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+    steps:
+      - name: checkout-test-harness
+        uses: actions/checkout@v2
+        with:
+          path: test-harness
+      - name: run-von-network
+        uses: ./test-harness/actions/run-von-network
+      - name: run-indy-tails-server
+        uses: ./test-harness/actions/run-indy-tails-server
+      - name: run-test-harness-wo-reports
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a findy"
+          TEST_AGENTS: "-d findy"
+          REPORT_PROJECT: findy  
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation"
+        continue-on-error: true
+      - name: run-send-gen-test-results-secure
+        uses: ./test-harness/actions/run-send-gen-test-results-secure
+        with:
+          REPORT_PROJECT: findy 
+          ADMIN_USER: ${{ secrets.AllureAdminUser }}
+          ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/aries-backchannels/findy/Dockerfile.findy
+++ b/aries-backchannels/findy/Dockerfile.findy
@@ -1,0 +1,1 @@
+FROM ghcr.io/findy-network/findy-agent-backchannel:findy-bc-bundle-latest

--- a/aries-test-harness/allure/allure-results/environment.properties
+++ b/aries-test-harness/allure/allure-results/environment.properties
@@ -1,8 +1,8 @@
-role.acme=verity-agent-backchannel
-acme.agent.version=0.7.0
-role.bob=acapy-main-agent-backchannel
-bob.agent.version=0.7.0
-role.faber=acapy-main-agent-backchannel
-faber.agent.version=0.7.0
-role.mallory=acapy-main-agent-backchannel
-mallory.agent.version=0.7.0
+role.acme=acapy-agent-backchannel
+acme.agent.version=0.7.1
+role.bob=findy-agent-backchannel
+bob.agent.version="0.24.27"
+role.faber=acapy-agent-backchannel
+faber.agent.version=0.7.1
+role.mallory=acapy-agent-backchannel
+mallory.agent.version=0.7.1


### PR DESCRIPTION
Signed-off-by: Laura Vuorenoja <laura.vuorenoja@op.fi>

Add backchannel for testing compatibility with [Findy Agency](https://findy-network.github.io) agent. Current interoperability target for findy-agent is IOP1.0 excluding revocation.