### PR TITLE
Support afgo-acapy RFC0453 interop, and fix 0023 interop issues

### DIFF
--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -50,7 +50,7 @@ jobs:
           BUILD_AGENTS: "-a acapy-main -a afgo-interop"
           TEST_AGENTS: "-d acapy-main -b afgo-interop"
           OTHER_PARAMS: "-v 20"
-          TEST_SCOPE: "-t @RFC0023 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023"
+          TEST_SCOPE: "-t @RFC0023,@RFC0453 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023 -t ~@CredFormat_Indy"
           REPORT_PROJECT: acapy-b-afgo
         env:
           EMIT_NEW_DIDCOMM_PREFIX: true

--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -50,7 +50,7 @@ jobs:
           BUILD_AGENTS: "-a acapy-main -a afgo-interop"
           TEST_AGENTS: "-d acapy-main -b afgo-interop"
           OTHER_PARAMS: "-v 20"
-          TEST_SCOPE: "-t @RFC0023,@RFC0453 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023 -t ~@CredFormat_Indy"
+          TEST_SCOPE: "-t @RFC0023,@RFC0453 -t ~@wip -t ~@ProofType_BbsBlsSignature2020 -t ~@CredFormat_Indy"
           REPORT_PROJECT: acapy-b-afgo
         env:
           EMIT_NEW_DIDCOMM_PREFIX: true

--- a/.github/workflows/test-harness-afgo-acapy.yml
+++ b/.github/workflows/test-harness-afgo-acapy.yml
@@ -50,7 +50,7 @@ jobs:
           BUILD_AGENTS: "-a afgo-interop -a acapy-main"
           TEST_AGENTS: "-d afgo-interop -b acapy-main"
           OTHER_PARAMS: "-v 20"
-          TEST_SCOPE: "-t @RFC0023 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023"
+          TEST_SCOPE: "-t @RFC0023,@RFC0453 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023 -t ~@CredFormat_Indy"
           REPORT_PROJECT: afgo-b-acapy
         env:
           EMIT-NEW-DIDCOMM-PREFIX: true

--- a/.github/workflows/test-harness-afgo-acapy.yml
+++ b/.github/workflows/test-harness-afgo-acapy.yml
@@ -50,7 +50,7 @@ jobs:
           BUILD_AGENTS: "-a afgo-interop -a acapy-main"
           TEST_AGENTS: "-d afgo-interop -b acapy-main"
           OTHER_PARAMS: "-v 20"
-          TEST_SCOPE: "-t @RFC0023,@RFC0453 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023 -t ~@CredFormat_Indy"
+          TEST_SCOPE: "-t @RFC0023,@RFC0453 -t ~@wip -t ~@CredFormat_Indy"
           REPORT_PROJECT: afgo-b-acapy
         env:
           EMIT-NEW-DIDCOMM-PREFIX: true

--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a afgo-master"
           TEST_AGENTS: "-d afgo-master"
-          TEST_SCOPE: "-t @RFC0023,@T001.1-RFC0036,@RFC0453,@RFC0454 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023  -t ~@T005-RFC0023 -t ~@T006-RFC0023"
+          TEST_SCOPE: "-t @RFC0023,@T001.1-RFC0036,@RFC0453,@RFC0454 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023  -t ~@T005-RFC0023 -t ~@T006-RFC0023 -t ~@CredFormat_Indy"
           REPORT_PROJECT: afgo 
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a afgo-master"
           TEST_AGENTS: "-d afgo-master"
-          TEST_SCOPE: "-t @RFC0023,@T001.1-RFC0036,@RFC0453,@RFC0454 -t ~@wip -t ~@T003-RFC0023 -t ~@T004-RFC0023  -t ~@T005-RFC0023 -t ~@T006-RFC0023 -t ~@CredFormat_Indy"
+          TEST_SCOPE: "-t @RFC0023,@T001.1-RFC0036,@RFC0453,@RFC0454 -t ~@wip -t ~@CredFormat_Indy"
           REPORT_PROJECT: afgo 
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/afgo/afgo-interop.env
+++ b/aries-backchannels/afgo/afgo-interop.env
@@ -1,6 +1,6 @@
 ARIESD_LOG_LEVEL=DEBUG
 
 AFGO_ORBDID_NAME=my_orb_did
-AFGO_ORBDID_PRIVKEY=/data-mount/priv/key1_jwk.json
+AFGO_ORBDID_PRIVKEY=/data-mount/priv/priv_jwks.json
 
 ARIESD_HTTP_RESOLVER=sov@http://uni-resolver-web.local:8080/1.0/identifiers/,orb@http://uni-resolver-web.local:8080/1.0/identifiers/

--- a/aries-backchannels/afgo/afgo-master.env
+++ b/aries-backchannels/afgo/afgo-master.env
@@ -1,6 +1,6 @@
 ARIESD_LOG_LEVEL=DEBUG
 
 AFGO_ORBDID_NAME=my_orb_did
-AFGO_ORBDID_PRIVKEY=/data-mount/priv/key1_jwk.json
+AFGO_ORBDID_PRIVKEY=/data-mount/priv/priv_jwks.json
 
 ARIESD_HTTP_RESOLVER=orb@http://uni-resolver-web.local:8080/1.0/identifiers/

--- a/aries-backchannels/afgo/afgo_backchannel.py
+++ b/aries-backchannels/afgo/afgo_backchannel.py
@@ -24,12 +24,13 @@ from aiohttp import (
 from python.agent_backchannel import AgentBackchannel, default_genesis_txns, RUN_MODE, START_TIMEOUT
 from python.utils import flatten, log_json, log_msg, log_timer, output_reader, prompt_loop
 from python.storage import store_resource, get_resource, delete_resource, push_resource, pop_resource, pop_resource_latest, get_resource_latest
+from python.message_queue import push_message_queue, pop_message_queue, push_message_stack, pop_message_stack
 
 #from helpers.jsonmapper.json_mapper import JsonMapper
 
 LOGGER = logging.getLogger(__name__)
 
-MAX_TIMEOUT = 5
+MAX_TIMEOUT = 20
 
 DEFAULT_BIN_PATH = "../venv/bin"
 DEFAULT_PYTHON_PATH = ".."
@@ -302,13 +303,16 @@ class AfGoAgentBackchannel(AgentBackchannel):
         # oob didexcahgne states are usually invitations
         if "invitationID" in message["message"]["Properties"]:
             invitation_id = message["message"]["Properties"]["invitationID"]
-            push_resource(invitation_id, "didexchange-states-msg", message)
+            # push_resource(invitation_id, "didexchange-states-msg", message)
+            await push_message_queue("didexchange-states-msg" + ","+invitation_id, message)
+            # backup: shared stack, for cases when the consumer doesn't know the current connection ID / invitation ID
+            await push_message_stack("didexchange-states-msg", message)
         else:
             raise Exception(
             f"invitation_ID not found in didexchange_states Webhook Message: {json.dumps(message)}"
             )
-        log_msg('Processed a didexchange_states Webhook message: ' + json.dumps(message))
-    
+        print('Processed a didexchange_states Webhook message: ' + json.dumps(message))
+
     async def handle_didexchange_actions(self, message):
         if "connectionID" in message["message"]["Properties"]:
             conection_id = message["message"]["Properties"]["connectionID"]
@@ -376,12 +380,12 @@ class AfGoAgentBackchannel(AgentBackchannel):
         # No thread id in the webhook for revocation registry messages
         cred_def_id = message["cred_def_id"]
         push_resource(cred_def_id, "revocation-registry-msg", message)
-        log_msg('Received Revocation Registry Webhook message: ' + json.dumps(message)) 
+        log_msg('Received Revocation Registry Webhook message: ' + json.dumps(message))
 
     async def handle_problem_report(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "problem-report-msg", message)
-        log_msg('Received Problem Report Webhook message: ' + json.dumps(message)) 
+        log_msg('Received Problem Report Webhook message: ' + json.dumps(message))
 
     async def swap_thread_id_for_exchange_id(self, thread_id, data_type, id_txt):
         timeout = 0
@@ -456,7 +460,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
                 return (resp_status, resp_text)
 
-            elif (operation == "accept-invitation" 
+            elif (operation == "accept-invitation"
                 or operation == "accept-request"
                 or operation == "remove"
                 or operation == "start-introduction"
@@ -501,14 +505,14 @@ class AfGoAgentBackchannel(AgentBackchannel):
         elif op["topic"] == "issue-credential" or op["topic"] == "issue-credential-v2":
             (resp_status, resp_text) = await self.handle_issue_credential_POST(op, rec_id=rec_id, data=data)
             return (resp_status, resp_text)
-            
+
         elif op["topic"] == "revocation":
             #set the acapyversion to master since work to set it is not complete. Remove when master report proper version
             operation = op["operation"]
             agent_operation, admin_data = await self.get_agent_operation_afgo_version_based(op["topic"], operation, rec_id, data)
-            
+
             log_msg(agent_operation, admin_data)
-            
+
             if admin_data is None:
                 (resp_status, resp_text) = await self.admin_POST(agent_operation)
             else:
@@ -522,8 +526,8 @@ class AfGoAgentBackchannel(AgentBackchannel):
             (resp_status, resp_text) = await self.handle_present_proof_POST(op, rec_id=rec_id, data=data)
             return (resp_status, resp_text)
 
-            
-        # Handle out of band POST operations 
+
+        # Handle out of band POST operations
         elif op["topic"] == "out-of-band":
             (resp_status, resp_text) = await self.handle_out_of_band_POST(op, data=data)
             return (resp_status, resp_text)
@@ -545,9 +549,10 @@ class AfGoAgentBackchannel(AgentBackchannel):
         agent_operation = f"/{agent_operation}/{self.map_test_ops_to_bachchannel[operation]}"
 
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+
         resp_json = json.loads(resp_text)
         if resp_status == 200:
-            # call get connection to get the status based on the invitation id. 
+            # call get connection to get the status based on the invitation id.
             resp_text = await self.amend_response_with_state("connection", resp_text)
         if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
         return (resp_status, resp_text)
@@ -567,7 +572,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             if len(get_resp_json) != 0:
                 if 'results' in resp_json: resp_json["state"] = get_resp_json["results"]["State"]
                 else: resp_json["state"] = get_resp_json["result"]["State"]
-            else: 
+            else:
                 # If the message is empty with 200, it probably means that an invitation was created
                 # but no conection record exists yet. Set the state to invitation-sent
                 resp_json["state"] = 'invitation-sent'
@@ -610,7 +615,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             # This label is needed for the accept invitation.
             data = { f"label": "Invitation created by {self.admin_url}" }
         elif operation == 'receive-invitation':
-            # Accept invitation requires my_label be part of the data. 
+            # Accept invitation requires my_label be part of the data.
             # That is wy the create invitation above adds a label to have some consistency.
             data = { "invitation": data }
             data["my_label"] = data["invitation"]["label"]
@@ -659,9 +664,12 @@ class AfGoAgentBackchannel(AgentBackchannel):
             agent_operation = f'/connections/create-implicit-invitation?their_did={their_public_did}'
 
         elif operation == "receive-request-resolvable-did":
-            (resp_status, resp_text) = await self.make_agent_GET_request_response("did-exchange", rec_id=data["their_did"])
+            # Note: we don't provide any rec_id in the receive-request-resolvable-did case.
+            # this is because the agent with the public DID doesn't have a connection ID until it's received the front-channel
+            # OOB message from the invitee.
+            (resp_status, resp_text) = await self.make_agent_GET_request_response("did-exchange")
             return (resp_status, resp_text)
-        
+
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
         return (resp_status, resp_text)
@@ -678,26 +686,55 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
         if data is not None: log_msg(f"Data passed to backchannel by test for operation: {agent_operation}", data)
 
+        await self.load_jsonld_contexts()
+
         if operation == "prepare-json-ld":
-            return (200, json.dumps({"did":"dummy-value"}))
+            (orb_did_status, orb_did_text, priv_key_kids) = await self.get_orb_did()
+            return (orb_did_status, orb_did_text)
 
         if operation == "send-proposal" or operation == "send-offer":
             if data is None:
                 # get the credential_proposal from the webhook
-                if rec_id is not None:
-                    (wh_status, wh_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id, message_name="issue-credential-actions-msg")
-                    issue_credential_actions_msg = json.loads(wh_text)
-                    # Format the proposal for afgo offer
-                    data = {
-                        "offer_credential": {
-                            "credential_preview": issue_credential_actions_msg["message"]["Message"]["credential_proposal"]
-                        }
-                    }
-                    # Save Issuer DID off for ease of later use
-                    self.myDID = issue_credential_actions_msg["message"]["Properties"]["myDID"]
-                else:
+                if rec_id is None:
                     raise Exception(f"Cannot have both data and rec_id empty for issuecredential/{op['operation']}")
+
+                (wh_status, wh_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id, message_name="issue-credential-actions-msg")
+                issue_credential_actions_msg = json.loads(wh_text)
+                # Format the proposal for afgo offer
+
+                data = {}
+
+                cred_prev = {}
+
+                if "credential_proposal" in issue_credential_actions_msg["message"]["Message"]:
+                    cred_prev = issue_credential_actions_msg["message"]["Message"]["credential_proposal"]
+                elif "credential_preview" in issue_credential_actions_msg["message"]["Message"]:
+                    cred_prev = issue_credential_actions_msg["message"]["Message"]["credential_preview"]
+
+                if operation == "send-proposal":
+                    data["credential_proposal"] = cred_prev
+                elif operation == "send-offer":
+                    data["credential_preview"] = cred_prev
+
+                if "filters~attach" in issue_credential_actions_msg["message"]["Message"]:
+                    filters_attach = issue_credential_actions_msg["message"]["Message"]["filters~attach"]
+                    # TODO support more than one filter
+                    if len(filters_attach) > 0:
+                        filter_attmt = filters_attach[0]["data"]
+                        if "json" in filter_attmt:
+                            data["filter"] = filter_attmt["json"]
+                        elif "base64" in filter_attmt:
+                            filter_dec = base64.b64decode(filter_attmt["base64"])
+                            filter_json = json.loads(filter_dec)
+                            data["filter"] = filter_json
+
+                # Save Issuer DID off for ease of later use
+                self.myDID = issue_credential_actions_msg["message"]["Properties"]["myDID"]
+                their_did = issue_credential_actions_msg["message"]["Properties"]["theirDID"]
+
             else:
+                data_text = json.dumps(data)
+
                 # Get connection by connection id contained in the data received
                 # Get the DID keys from the connection record
                 (their_did, my_did) = await self.get_DIDs_for_participants(data["connection_id"])
@@ -712,100 +749,104 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 if "schema_version" in data: data.pop("schema_version")
                 if "connection_id" in data: data.pop("connection_id")
 
-                # add thier did and my did to the data
-                data["my_did"] = my_did
-                data["their_did"] = their_did
+            # add their did and my did to the data
+            data["my_did"] = self.myDID
+            data["their_did"] = their_did
 
-                # Properly construct the credential proposal for afgo
-                if operation == "send-proposal":
-                    if "credential_proposal" in data:
-                        data["propose_credential"] = {
-                            "credential_proposal": data["credential_proposal"]
+            # Properly construct the credential proposal for afgo
+            if operation == "send-proposal":
+                if "credential_proposal" in data:
+                    data["propose_credential"] = {
+                        "credential_proposal": data["credential_proposal"]
+                    }
+                    data.pop("credential_proposal")
+                elif "credential_preview" in data:
+                    data["propose_credential"] = {
+                        "credential_proposal": data["credential_preview"]
+                    }
+                    data.pop("credential_preview")
+                else:
+                    raise Exception(f"Message data passed for issuecredential/{op['operation']} doesn't contain a credential_proposal: {data}")
+
+                if "filter" in data:
+                    # TODO support more than one filter
+                    json_filter = data["filter"]
+                    if "json-ld" in json_filter:
+                        json_filter = json_filter["json-ld"]
+                    elif "indy" in json_filter:
+                        json_filter = json_filter["indy"]
+
+                    # add an id for the filter
+                    filter_id = str(uuid.uuid1())
+                    # add mime_type (json)
+                    mime_type = "application/json"
+                    # add the filters~attach to the data
+                    data["propose_credential"]["filters~attach"] = [
+                        {
+                            "@id": filter_id,
+                            "mime_type": mime_type,
+                            "data": {
+                                "json": json_filter
+                            }
                         }
-                        data.pop("credential_proposal")
-                    elif "credential_preview" in data:
-                        data["propose_credential"] = {
-                            "credential_proposal": data["credential_preview"]
-                        }
-                        data.pop("credential_preview")
+                    ]
+                    # add formats to the data with attach_id and format
+                    if "indy" in data["filter"]:
+                        filter_format = "hlindy/cred-filter@v2.0"
                     else:
-                        raise Exception(f"Message data passed for issuecredential/{op['operation']} doesn't contain a credential_proposal: {data}")
+                        filter_format = "aries/ld-proof-vc@v1.0"
 
-                    if "filter" in data:
-                        # TODO support more than one filter
-                        # encode the json to base64
-                        json_filter = data["filter"]
-                        # add an id for the filter
-                        filter_id = str(uuid.uuid1())
-                        # add mime_type (json)
-                        mime_type = "application/json"
-                        # add the filters~attach to the data
-                        data["propose_credential"]["filters~attach"] = [
-                            {
-                                "@id": filter_id, 
-                                "mime_type": mime_type,
-                                "data": {
-                                    "json": json_filter
-                                }
-                            }
-                        ]
-                        # add formats to the data with attach_id and format
-                        if "json-ld" in data["filter"]:
-                            filter_format = "aries/ld-proof-vc@v1.0"
-                        else:
-                            filter_format = "hlindy/cred-filter@v2.0"
-
-                        data["propose_credential"]["formats"] = [
-                            {
-                                "attach_id": filter_id,
-                                "format": filter_format
-                            }
-                        ]
-
-                        data.pop("filter")
-
-                elif operation == "send-offer":
-                    if "credential_preview" in data:
-                        data["offer_credential"] = {
-                            "credential_preview": data["credential_preview"]
+                    data["propose_credential"]["formats"] = [
+                        {
+                            "attach_id": filter_id,
+                            "format": filter_format
                         }
-                        data.pop("credential_preview")
-                    else:
-                        raise Exception(f"Message data passed for issuecredential/{op['operation']} doesn't contain a credential_preview: {data}")
-            
-                    if "filter" in data:
-                        # TODO support more than one filter
-                        # encode the json to base64
-                        json_filter = data["filter"]
-                        #json_filter_b64 = base64.b64encode(json_filter.encode('utf-8'))
-                        # add an id for the filter
-                        filter_id = str(uuid.uuid1())
-                        # add mime_type (json)
-                        mime_type = "application/json"
-                        # add the filters~attach to the data
-                        data["propose_credential"]["offers~attach"] = [
-                            {
-                                "@id": filter_id, 
-                                "mime_type": mime_type,
-                                "data": {
-                                    "json": json_filter
-                                }
-                            }
-                        ]
-                        # add formats to the data with attach_id and format
-                        if "json-ld" in data["filter"]:
-                            filter_format = "aries/ld-proof-vc@v1.0"
-                        else:
-                            filter_format = "hlindy/cred-filter@v2.0"
+                    ]
 
-                        data["propose_credential"]["formats"] = [
-                            {
-                                "attach_id": filter_id,
-                                "format": filter_format
+                    data.pop("filter")
+
+            elif operation == "send-offer":
+                if "credential_preview" in data:
+                    data["offer_credential"] = {
+                        "credential_preview": data["credential_preview"]
+                    }
+                    data.pop("credential_preview")
+                else:
+                    raise Exception(f"Message data passed for issuecredential/{op['operation']} doesn't contain a credential_preview: {data}")
+
+                if "filter" in data:
+                    # TODO support more than one filter
+                    # encode the json to base64
+                    json_filter = data["filter"]
+                    #json_filter_b64 = base64.b64encode(json_filter.encode('utf-8'))
+                    # add an id for the filter
+                    filter_id = str(uuid.uuid1())
+                    # add mime_type (json)
+                    mime_type = "application/json"
+                    # add the filters~attach to the data
+                    data["offer_credential"]["offers~attach"] = [
+                        {
+                            "@id": filter_id,
+                            "mime_type": mime_type,
+                            "data": {
+                                "json": json_filter
                             }
-                        ]
-                        
-                        data.pop("filter")
+                        }
+                    ]
+                    # add formats to the data with attach_id and format
+                    if "indy" in data["filter"]:
+                        filter_format = "hlindy/cred-filter@v2.0"
+                    else:
+                        filter_format = "aries/ld-proof-vc@v1.0"
+
+                    data["offer_credential"]["formats"] = [
+                        {
+                            "attach_id": filter_id,
+                            "format": filter_format
+                        }
+                    ]
+
+                    data.pop("filter")
 
             log_msg(f"Data translated by backchannel to send to agent for operation: {agent_operation}", data)
 
@@ -816,7 +857,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             if resp_status == 200:
                 # Get the state form the webhook callback.
                 if rec_id == None:
-                    if "piid" in resp_json: 
+                    if "piid" in resp_json:
                         rec_id = resp_json["piid"]
                     else:
                         raise Exception(f"No piid found to retrieve State from webhook message: {resp_text}")
@@ -829,13 +870,12 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
                 if operation == "send-proposal":
                     resp_json["thread_id"] = resp_json["piid"]
-                    
+
                 resp_text = json.dumps(resp_json)
 
             return (resp_status, resp_text)
 
         elif operation == "send-request":
-            
             log_msg(f"Data translated by backchannel to send to agent for operation: {agent_operation}", data)
 
             (resp_status, resp_text) =  await self.admin_POST(agent_operation, data)
@@ -845,7 +885,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             if resp_status == 200:
                 # Get the state form the webhook callback.
                 if rec_id == None:
-                    if "piid" in resp_json: 
+                    if "piid" in resp_json:
                         rec_id = resp_json["piid"]
                     else:
                         raise Exception(f"No piid found to retrieve State from webhook message: {resp_text}")
@@ -857,11 +897,11 @@ class AfGoAgentBackchannel(AgentBackchannel):
                     raise Exception(f"Could not retieve State from webhook message: {issue_credential_states_msg}")
 
                 resp_json["thread_id"] = rec_id
-                    
+
                 resp_text = json.dumps(resp_json)
 
             return (resp_status, resp_text)
-            
+
 
         elif operation == "store":
             # if data != None:
@@ -880,7 +920,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 resp_json = json.loads(resp_text)
                 # Get the state form the webhook callback.
                 if rec_id == None:
-                    if "piid" in resp_json: 
+                    if "piid" in resp_json:
                         rec_id = resp_json["piid"]
                     else:
                         raise Exception(f"No piid found to retrieve State from webhook message: {resp_text}")
@@ -906,59 +946,129 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
 
         elif operation == "issue":
+            cred = {}
+
             # TODO Need to get their DID to add to the data. Dummy input for now, which works fine.
-            #(their_did, my_did) = await self.get_DIDs_for_participants()
             # Get data from the last issue-credential_states webhook message which contrains the credential_proposal
             if data is None or "issue_credential" not in data:
                 # get the credential_proposal from the webhook
-                if rec_id is not None:
-                    #(wh_status, wh_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id, message_name="issue-credential-actions-msg")
-                    (wh_status, wh_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id, message_name="issue-credential-states-msg")
-                    log_msg(f"Credential Data retreived from webhook message: ", wh_text)
-                    
-                    # if the messsage doesn't contain credential details get it from the credential_details_msg
-                    if "filters~attach" not in wh_text:
-                        wh_text = pop_resource(rec_id, "credential-details-msg")
-                        wh_text = json.dumps(wh_text)
-                    
-                    issue_credential_states_msg = json.loads(wh_text)
-                    # Format the proposal for afgo issue
-                    if topic == "issue-credential-v2":
-                        data = {
-                            "issue_credential": {
-                                "credentials~attach": issue_credential_states_msg["message"]["Message"]["filters~attach"],
-                                "formats": issue_credential_states_msg["message"]["Message"]["formats"]
-                            }
-                        }
-
-                else:
+                if rec_id is None:
                     raise Exception(f"Have not passed a thread id for issuecredential/{op['operation']}")
 
+                #(wh_status, wh_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id, message_name="issue-credential-actions-msg")
+                (wh_status, wh_text) = await self.make_agent_GET_request_response(topic, rec_id=rec_id, message_name="issue-credential-states-msg")
+                log_msg(f"Credential Data retreived from webhook message: ", wh_text)
+
+                # if the messsage doesn't contain credential details get it from the credential_details_msg
+                if "filters~attach" in wh_text:
+                    issue_credential_states_msg = json.loads(wh_text)
+                else:
+                    issue_credential_states_msg = pop_resource(rec_id, "credential-details-msg")
+                    wh_text = json.dumps(issue_credential_states_msg)
+
+                # Format the proposal for afgo issue
                 # suppliment the message data with whatever afgo needs to make the store credential work
                 # IMO this is a defect in afgo
                 if topic == "issue-credential-v2":
-                    for dat in data["issue_credential"]["credentials~attach"]:
-                        #dat["data"]["json"].append(afgo_ammendment)
-                        dat["data"]["json"]["@context"] = []
-                        dat["data"]["json"]["credentialSubject"] = {}
-                        dat["data"]["json"]["issuanceDate"] = str(datetime.datetime.now().isoformat(timespec='seconds'))  + "Z"
-                        dat["data"]["json"]["issuer"] = {
-                            "id": json.loads(wh_text)["message"]["Properties"]["myDID"]
+                    data = {
+                        "issue_credential": {
+                            "credentials~attach": issue_credential_states_msg["message"]["Message"]["filters~attach"],
+                            "formats": issue_credential_states_msg["message"]["Message"]["formats"]
                         }
+                    }
 
-                        if "json-ld" in dat["data"]["json"]:
-                            dat["data"]["json"]["json-ld"]["credential"]["issuer"] = {
+                    (orb_did_status, orb_did_text, priv_key_kids) = await self.get_orb_did()
+                    if orb_did_status != 200:
+                        print(f"Couldn't retrieve my public did: status={orb_did_status} body={orb_did_text}")
+
+                    my_pub_did = json.loads(orb_did_text)["did"]
+
+                    for dat in data["issue_credential"]["credentials~attach"]:
+                        if "json" in dat["data"]:
+                            cred = dat["data"]["json"]
+                        elif "base64" in dat["data"]:
+                            dat_dec = base64.b64decode(dat["data"]["base64"])
+                            cred = json.loads(dat_dec)
+                            del dat["data"]["base64"]
+                        else:
+                            cred = {}
+
+                        if "indy" in cred:
+                            cred["@context"] = []
+                            cred["credentialSubject"] = {}
+                            cred["issuanceDate"] = str(datetime.datetime.now().isoformat(timespec='seconds'))  + "Z"
+                            cred["issuer"] = {
                                 "id": json.loads(wh_text)["message"]["Properties"]["myDID"]
                             }
-                            dat["data"]["json"]["json-ld"]["credential"]["issuanceDate"] = str(datetime.datetime.now().isoformat(timespec='seconds'))  + "Z"
-                            dat["data"]["json"]["json-ld"]["credential"]["id"] = json.loads(wh_text)["message"]["Properties"]["theirDID"]
-                            dat["data"]["json"]["json-ld"]["credential"]["type"] = "VerifiableCredential"
 
-                        dat["data"]["json"]["type"] = [
-                            # "AATHTestCredential",
-                            "VerifiableCredential"
-                        ]
-                #data["issue_credential"]["credentials~attach"]["data"]["json"].append(afgo_ammendment)
+                            cred["type"] = [
+                                "VerifiableCredential",
+                                "AATHTestCredential"
+                            ]
+
+                            dat["data"]["json"] = cred
+
+                        else:
+                            # handle json-ld creds that might or might not be in a "json-ld" field of the attachment
+                            # TODO: we need a better way to distinguish indy and json-ld creds for the backchannel
+                            if "json-ld" in cred:
+                                cred = cred["json-ld"]
+
+                            if "options" in cred:
+                                options = cred["options"]
+                            else:
+                                options = {}
+
+                            if "credential" in cred:
+                                cred = cred["credential"]
+
+                            # datetime in iso 8601 format, satisfies ietf rfc3339 so afgo can parse it from json
+                            created_datetime = str(datetime.datetime.now().replace(microsecond=0).isoformat(timespec='seconds')) + "Z"
+
+                            cred_type = cred["type"]
+
+                            proof_type = options.get("proofType", "")
+
+                            selected_kid = priv_key_kids.get(proof_type, "")
+
+                            # signatureRepresentation is an integer code used in afgo
+                            # to indicate the representation of the signature
+                            # 0: proofValue
+                            # 1: jws
+                            # ed25519 uses jws, bbs+ uses proofValue
+                            if proof_type == "Ed25519Signature2018":
+                                signature_representation = 1
+                            else:
+                                signature_representation = 0
+
+                            # sign credential
+                            sign_cred_endpoint = "/verifiable/signcredential"
+                            sign_cred_req = {
+                                "did": my_pub_did,
+                                "created": created_datetime,
+                                "kid": selected_kid,
+                                "signatureType": proof_type,
+                                "signatureRepresentation": signature_representation,
+                                "credential": cred
+                            }
+
+                            (resp_status, resp_text) =  await self.admin_POST(sign_cred_endpoint, sign_cred_req)
+                            if resp_status != 200:
+                                log_msg(f"failed to sign credential: status={resp_status}, data={resp_text}")
+                                return (resp_status, resp_text)
+
+                            sign_cred_resp = json.loads(resp_text)
+
+                            cred = sign_cred_resp["verifiableCredential"]
+
+                            # workaround for acapy being overly strict (requiring type be a list, in excess of the spec)
+                            cred["type"] = cred_type
+
+                            # convert base64-url to standard base64 for acapy's sake
+                            if "proofValue" in cred["proof"]:
+                                cred["proof"]["proofValue"] = cred["proof"]["proofValue"].replace("-","+").replace("_","/")
+
+                            dat["data"]["json"] = cred
 
                 else:
                     data = {
@@ -995,7 +1105,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 resp_json = json.loads(resp_text)
                 # Get the state form the webhook callback.
                 if rec_id == None:
-                    if "piid" in resp_json: 
+                    if "piid" in resp_json:
                         rec_id = resp_json["piid"]
                     else:
                         raise Exception(f"No piid found to retrieve State from webhook message: {resp_text}")
@@ -1004,7 +1114,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 if "StateID" in issue_credential_states_msg["message"]:
                     resp_json["state"] = self.issueCredentialStateTranslationDict[issue_credential_states_msg["message"]["StateID"]]
                 else:
-                    raise Exception(f"Could not retieve State from webhook message: {issue_credential_states_msg}")
+                    raise Exception(f"Could not retrieve State from webhook message: {issue_credential_states_msg}")
 
                 resp_text = json.dumps(resp_json)
 
@@ -1017,9 +1127,9 @@ class AfGoAgentBackchannel(AgentBackchannel):
             publish = data["publish_immediately"]
             agent_operation = "/issue-credential/" + operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id + "&publish=" + str(publish).lower()
             data = None
-        
+
         log_msg(agent_operation, data)
-            
+
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
         log_msg(resp_status, resp_text)
@@ -1037,7 +1147,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
         if data is not None: log_msg(f"Data passed to backchannel by test for operation: {agent_operation}", data)
 
-        # Ammend the passed in data to what afgo expects. 
+        # Ammend the passed in data to what afgo expects.
         # This is a general ammendment that may apply to multiple operations
         if data is None:
             # Not sure what to do here yet
@@ -1063,7 +1173,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 format_key = "dif/presentation-exchange/definitions@v1.0"
                 mime_type = "application/ld+json"
 
-                await self.load_jsonld_contexts()
+                # await self.load_jsonld_contexts()
 
             else:
                 raise Exception(f"format not recognized: {data}")
@@ -1144,11 +1254,12 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 for cred_attach in cred_attach_list:
                     cred_attach["mime-type"] = "application/ld+json"
 
-                    # merge the cred proper with its wrapping
-                    cred_attach["data"]["json"]["json-ld"]["credential"]["issuer"] = cred_attach["data"]["json"]["issuer"]
-                    cred_attach["data"]["json"]["json-ld"]["credential"]["issuanceDate"] = cred_attach["data"]["json"]["issuanceDate"]
+                    if "json" in cred_attach["data"] and "json-ld" in cred_attach["data"]["json"]:
+                        # merge the cred proper with its wrapping
+                        cred_attach["data"]["json"]["json-ld"]["credential"]["issuer"] = cred_attach["data"]["json"]["issuer"]
+                        cred_attach["data"]["json"]["json-ld"]["credential"]["issuanceDate"] = cred_attach["data"]["json"]["issuanceDate"]
 
-                    cred_attach["data"]["json"] = cred_attach["data"]["json"]["json-ld"]["credential"]
+                        cred_attach["data"]["json"] = cred_attach["data"]["json"]["json-ld"]["credential"]
 
                 ammended_data["presentation"]["presentations~attach"] = cred_attach_list
 
@@ -1161,7 +1272,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                     rec_id
                 ]
             }
-            
+
         log_msg(f"Data translated by backchannel to send to agent for operation: {agent_operation}", data)
 
         (resp_status, resp_text) =  await self.admin_POST(agent_operation, data)
@@ -1170,11 +1281,11 @@ class AfGoAgentBackchannel(AgentBackchannel):
         if resp_status == 200:
             if operation == "send-request":
                 # set a thread_id for the test harness
-                if "piid" in resp_json: 
+                if "piid" in resp_json:
                     resp_json["thread_id"] = resp_json["piid"]
                 else:
                     raise Exception(f"No piid(thread_id) found in response for operation: {agent_operation} {resp_text}")
-            
+
             # The response doesn't have a state. Get it from the present_proof_states webhook message
             if "piid" in resp_json:
                 wh_id = resp_json["piid"]
@@ -1189,7 +1300,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             else:
                 raise Exception(f"Could not retieve State from webhook message: {present_proof_states_msg}")
             resp_text = json.dumps(resp_json)
-        
+
         log_msg(resp_status, resp_text)
         if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], operation, resp_text)
         return (resp_status, resp_text)
@@ -1231,11 +1342,16 @@ class AfGoAgentBackchannel(AgentBackchannel):
         if should_post:
             (resp_status, resp_text) = await self.admin_POST("/ld/context", data=req)
             if resp_status != 200:
+                print("failed: add json-ld contexts")
                 raise Exception(f"Could not add contexts: {resp_text}")
+            else:
+                print("success: add json-ld contexts")
+        else:
+            print("skipped: add json-ld contexts")
 
     def add_did_exchange_state_to_response(self, operation, raw_response):
         resp_json = json.loads(raw_response)
-        
+
         if operation == 'send-response':
             resp_json['state'] = 'response-sent'
         elif operation == 'send-message':
@@ -1250,7 +1366,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             status = 200 if self.ACTIVE else 418
             status_msg = "Active" if self.ACTIVE else "Inactive"
             return (status, json.dumps({"status": status_msg}))
-        
+
         if op["topic"] == "version":
             if self.afgo_version is not None:
                 status = 200
@@ -1266,7 +1382,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 agent_operation = "/connections/" + connection_id
             else:
                 agent_operation = "/connections"
-            
+
             log_msg('GET Request agent operation: ', agent_operation)
 
             (resp_status, resp_text) = await self.admin_GET(agent_operation, params=params)
@@ -1292,33 +1408,8 @@ class AfGoAgentBackchannel(AgentBackchannel):
             return (resp_status, resp_text)
 
         elif op["topic"] == "did":
-            agent_operation = "/vdr/did"
-
-            agent_name = os.getenv("AGENT_NAME")
-            orb_did_path = f"/data-mount/orb-dids/{agent_name}.json"
-
-            orb_did_name = os.getenv("AFGO_ORBDID_NAME")
-            if orb_did_name is None or len(orb_did_name) == 0:
-                orb_did_name = "<default orb did>"
-
-            with open(orb_did_path) as orb_did_file:
-                orb_did = orb_did_file.read()
-                orb_did_json = json.loads(orb_did)
-                (resp_status, resp_text) = await self.admin_POST(agent_operation, data={"did": orb_did_json, "name": orb_did_name})
-            if resp_status != 200:
-                if resp_status == 400: # we've already posted the DID to the agent, so we can just return the did
-                    return (200, json.dumps({"did":orb_did_json["id"]}))
-                return (resp_status, "")
-
-            # import the ed25519 private key for orb did
-            priv_key_path = os.getenv("AFGO_ORBDID_PRIVKEY")
-
-            with open(priv_key_path) as priv_key_file:
-                priv_key = priv_key_file.read()
-                priv_key_json = json.loads(priv_key)
-                (resp_status, resp_text) = await self.admin_POST("/kms/import", data=priv_key_json)
-
-            return (resp_status, json.dumps({"did":orb_did_json["id"]}))
+            (resp_status, resp_text, resp_kids) = await self.get_orb_did()
+            return (resp_status, resp_text)
 
         elif op["topic"] == "schema":
             schema_id = rec_id
@@ -1330,7 +1421,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
             # afgo not have did schema
             # dummy schema
-            schema = { "id": "did:", "name": "", "version": self.afgo_version } 
+            schema = { "id": "did:", "name": "", "version": self.afgo_version }
             return (200, json.dumps(schema))
 
         elif op["topic"] == "credential-definition":
@@ -1396,6 +1487,50 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
         return (501, '501: Not Implemented\n\n'.encode('utf8'))
 
+    async def get_orb_did(self) -> (int, str, dict):
+        agent_operation = "/vdr/did"
+
+        agent_name = os.getenv("AGENT_NAME")
+        orb_did_path = f"/data-mount/orb-dids/{agent_name}.json"
+
+        orb_did_name = os.getenv("AFGO_ORBDID_NAME")
+        if orb_did_name is None or len(orb_did_name) == 0:
+            orb_did_name = "<default orb did>"
+
+        with open(orb_did_path) as orb_did_file:
+            orb_did = orb_did_file.read()
+            orb_did_json = json.loads(orb_did)
+            (resp_status, resp_text) = await self.admin_POST(agent_operation, data={"did": orb_did_json, "name": orb_did_name})
+        if resp_status != 200 and resp_status != 400:
+            return (resp_status, resp_text, {})
+
+        # import the ed25519 and Bls private keys for orb did
+        priv_key_path = os.getenv("AFGO_ORBDID_PRIVKEY")
+
+
+        kid_map = {}
+
+        with open(priv_key_path) as priv_key_file:
+            priv_keys = priv_key_file.read()
+            priv_key_set = json.loads(priv_keys)
+            for signature_type, priv_key_json in priv_key_set.items():
+                priv_key_kid = ""
+                if "kid" in priv_key_json:
+                    priv_key_kid = priv_key_json["kid"]
+
+                (resp_status, resp_text) = await self.admin_POST("/kms/import", data=priv_key_json)
+                if resp_status != 200:
+                    print(f"failed to import private key: status={resp_status} body={resp_text}")
+                    if resp_status == 500 and "already exists" in resp_text:
+                        resp_status = 200 # it's fine if we already created the key
+                    else:
+                        return (resp_status, resp_text, {})
+
+                kid_map[signature_type] = priv_key_kid
+
+
+        return (resp_status, json.dumps({"did":orb_did_json["id"]}), kid_map)
+
     async def handle_issue_credential_GET(self, op, rec_id=None, data=None):
         pass
 
@@ -1419,6 +1554,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
     async def make_agent_GET_request_response(
         self, topic, rec_id=None, text=False, params=None, message_name=None
     ) -> (int, str):
+        # TODO: make_agent_GET_request_response() is only called for didexchange, issue-credential, and present-proof
         if topic == "connection" and rec_id:
             connection_msg = pop_resource(rec_id, "connection-msg")
             i = 0
@@ -1439,13 +1575,22 @@ class AfGoAgentBackchannel(AgentBackchannel):
             # TODO: change to actual method call
             return (200, 'some stats')
 
-        elif topic == "did-exchange" and rec_id:
-            didexchange_msg = pop_resource(rec_id, "didexchange-states-msg")
-            i = 0
-            while didexchange_msg is None and i < MAX_TIMEOUT:
-                await asyncio.sleep(1)
-                didexchange_msg = pop_resource(rec_id, "didexchange-states-msg")
-                i = i + 1
+        elif topic == "did-exchange":
+            if rec_id:
+                try:
+                    didexchange_msg = await pop_message_queue("didexchange-states-msg" + ","+rec_id, MAX_TIMEOUT)
+                except:
+                    print("didex timeout waiting for didexchange-states-msg")
+                    return (200, "{}")
+            else:
+                try:
+                    # fallback: check last message if none is available under rec_id
+                    # for implicit invitation the harness can't pass in the invitation ID
+                    await asyncio.sleep(2)
+                    didexchange_msg = await pop_message_stack("didexchange-states-msg", MAX_TIMEOUT)
+                except:
+                    print("didex timeout waiting for didexchange-states-msg fallback")
+                    return (200, "{}")
 
             resp_status = 200
             if didexchange_msg:
@@ -1457,11 +1602,13 @@ class AfGoAgentBackchannel(AgentBackchannel):
                     resp_text = json.dumps({ 'connection_id': conn_id, 'data': didexchange_msg })
 
             else:
+                print("didex NO RESULT FOUND for didexchange-states-msg")
                 resp_text = "{}"
 
             return (resp_status, resp_text)
 
         elif topic == "out-of-band" and rec_id:
+            # TODO: no result will ever be found in this branch, since nothing ever pushes 'didexchange-msg'
             c_msg = pop_resource(rec_id, "didexchange-msg")
             i = 0
             while didexchange_msg is None and i < MAX_TIMEOUT:

--- a/aries-backchannels/python/message_queue.py
+++ b/aries-backchannels/python/message_queue.py
@@ -1,0 +1,97 @@
+import threading, asyncio
+
+message_queues = {}
+mq_lock = threading.Lock()
+
+def _get_queue(message_type):
+    if message_type in message_queues:
+        return message_queues[message_type]
+    else:
+        try:
+            mq_lock.acquire()
+            if message_type in message_queues:
+                return message_queues[message_type]
+            else:
+                selected_queue = asyncio.Queue()
+                message_queues[message_type] = selected_queue
+                return selected_queue
+        finally:
+            mq_lock.release()
+
+async def pop_message_queue(message_type, timeout=0):
+    print(f"calling message_queue.pop_message_queue({message_type}, {timeout})")
+    if timeout <= 0:
+        timeout = None
+
+    selected_queue = _get_queue(message_type)
+
+    res = await asyncio.wait_for(asyncio.shield(message_queues[message_type].get()), timeout)
+    print(f"finished message_queue.pop_message_queue({message_type}, {timeout}) -> {res}")
+    return res
+
+async def push_message_queue(message_type, value, timeout=0):
+    print(f"calling message_queue.push_message_queue({message_type}, {value}, {timeout})")
+    if timeout <= 0:
+        timeout = None
+
+    selected_queue = _get_queue(message_type)
+
+    await asyncio.wait_for(asyncio.shield(selected_queue.put(value)), timeout)
+    print(f"finished message_queue.push_message_queue({message_type}, {value}, {timeout})")
+
+async def clear_all():
+    try:
+        mq_lock.acquire()
+        message_queues = {}
+    finally:
+        mq_lock.release()
+
+
+
+message_stacks = {}
+ms_lock = threading.Lock()
+
+def _get_stack(message_type):
+    if message_type in message_stacks:
+        return message_stacks[message_type]
+    else:
+        try:
+            ms_lock.acquire()
+            if message_type in message_stacks:
+                return message_stacks[message_type]
+            else:
+                selected_stack = asyncio.LifoQueue()
+                message_stacks[message_type] = selected_stack
+                return selected_stack
+        finally:
+            ms_lock.release()
+
+async def pop_message_stack(message_type, timeout=0):
+    print(f"calling message_stack.pop_message({message_type}, {timeout})")
+    if timeout <= 0:
+        timeout = None
+
+    selected_stack = _get_stack(message_type)
+
+    res = await asyncio.wait_for(asyncio.shield(message_stacks[message_type].get()), timeout)
+    print(f"finished message_stack.pop_message({message_type}, {timeout}) -> {res}")
+    return res
+
+async def push_message_stack(message_type, value, timeout=0):
+    print(f"calling message_stack.push_message({message_type}, {value}, {timeout})")
+    if timeout <= 0:
+        timeout = None
+
+    selected_stack = _get_stack(message_type)
+
+    await asyncio.wait_for(asyncio.shield(selected_stack.put(value)), timeout)
+    print(f"finished message_stack.push_message({message_type}, {value}, {timeout})")
+
+async def clear_all_stacks():
+    try:
+        ms_lock.acquire()
+        message_stacks = {}
+    finally:
+        ms_lock.release()
+
+

--- a/aries-test-harness/agent_test_utils.py
+++ b/aries-test-harness/agent_test_utils.py
@@ -1,4 +1,5 @@
 import time
+import datetime
 
 def create_non_revoke_interval(timeframe):
     # timeframe containes two variables, the To and from of the non-revoked to and from parameters in the send presentation request message
@@ -105,6 +106,9 @@ def amend_filters_with_runtime_data(context, filters):
                 credential["issuer"]["id"] = issuer
         if options.get("proofType") == "replace_me":
             options["proofType"] = context.proof_type
+        if "issuanceDate" in credential:
+            created_datetime = str(datetime.datetime.now().replace(microsecond=0).isoformat(timespec='seconds'))  + "Z"
+            credential["issuanceDate"] = created_datetime
 
 
     return filters

--- a/aries-test-harness/features/data/cred_data_schema_driverslicense_v2.json
+++ b/aries-test-harness/features/data/cred_data_schema_driverslicense_v2.json
@@ -36,7 +36,7 @@
                   "https://www.w3.org/2018/credentials/v1", 
                   "https://w3id.org/security/bbs/v1",
                   {
-                     "dl": "http://example.com/drivers-license",
+                     "dl": "http://example.com/drivers-license#",
                      "AATHDriversLicense": "dl:AATHDriversLicense",
                      "address": "dl:address",
                      "DL_number": "dl:DL_number",

--- a/manage
+++ b/manage
@@ -209,6 +209,10 @@ function initEnv() {
   export RUST_LOG=${RUST_LOG:-warning}
 }
 
+# TODO: set up image builds so you don't need to use `./manage rebuild` to refresh remote source repo
+# - image Dockerfile has an ARG for the commit hash,
+# - build script grabs the HEAD commit hash from the agent's github repo
+
 # Build images -- add more backchannels here...
 # TODO: Define args to build only what's needed
 buildImages() {
@@ -515,6 +519,89 @@ auxiliaryService() {
   fi
 }
 
+startServices() {
+  # sets if services this procedure starts should be stopped automatically
+  local AUTO_CLEANUP
+  if [[ "auto" = $1 ]]; then
+    AUTO_CLEANUP=true
+  else
+    AUTO_CLEANUP=false
+  fi
+
+  if [[ "all" = $1 ]]; then
+    auxiliaryService orb start
+  fi
+
+  # if we're *not* using an external VON ledger, start the local one
+  if [[ -z ${LEDGER_URL_CONFIG} ]]; then
+    if [[ -z `docker ps -q --filter="name=von_webserver_1"` ]]; then
+      echo "starting local von-network..."
+      auxiliaryService von-network start
+      if [[ $AUTO_CLEANUP ]]; then
+        export STARTED_LOCAL_LEDGER=true
+      fi
+    fi
+  fi
+
+  if ! waitForLedger; then
+    echoRed "\nThe Indy Ledger is not running.\n"
+    exit 1
+  fi
+
+  if [[ -z `docker ps -q --filter="name=uni-resolver-web.local"` ]]; then
+      echo "starting local uniresolver..."
+    auxiliaryService uniresolver start
+    if [[ $AUTO_CLEANUP ]]; then
+      export STARTED_LOCAL_UNIRESOLVER=true
+    fi
+  fi
+
+  # if we're *not* using an external indy tails server, start the local one
+  if [[ -z ${TAILS_SERVER_URL_CONFIG} ]]; then
+    if [[ -z `docker ps -q --filter="name=docker_tails-server_1"` ]]; then
+      echo "starting local indy-tails-server..."
+      auxiliaryService indy-tails start
+      if [[ $AUTO_CLEANUP ]]; then
+        export STARTED_LOCAL_TAILS=true
+      fi
+    fi
+  fi
+
+  if ! waitForTailsServer; then
+    echoRed "\nThe Indy Tails Server is not running.\n"
+    exit 1
+  fi
+
+  if ! waitForUniresolver; then
+    echoRed "\nUniversal Resolver is not running.\n"
+    exit 1
+  fi
+}
+
+stopServices() {
+  if [[ "auto" = $1 ]]; then
+    if [[ ${STARTED_LOCAL_UNIRESOLVER} ]]; then
+      echo "stopping local uniresolver..."
+      auxiliaryService uniresolver stop
+    fi
+
+    if [[ ${STARTED_LOCAL_TAILS} ]]; then
+      echo "stopping local indy-tails-server..."
+      auxiliaryService indy-tails stop
+    fi
+
+    if [[ ${STARTED_LOCAL_LEDGER} ]]; then
+      echo "stopping local von-network..."
+      auxiliaryService von-network stop
+    fi
+  elif [[ "all" = $1 ]]; then
+    auxiliaryService uniresolver stop
+    auxiliaryService orb stop
+    auxiliaryService indy-tails stop
+    auxiliaryService von-network stop
+  fi
+}
+
 serviceCommand() {
   local SERVICE_COMMAND
   SERVICE_COMMAND=$1
@@ -522,6 +609,23 @@ serviceCommand() {
   SERVICE_TARGET=$2
 
   # TODO: allow multiple services to be named - but can we handle logs command then?
+  if [[ "all" = $SERVICE_TARGET ]]; then
+    case "${SERVICE_COMMAND}" in
+      start)
+          createNetwork
+          startServices all
+        ;;
+      stop)
+          stopServices all
+          cleanupNetwork
+        ;;
+      *)
+          echo err: \'start\' and \'stop\' are only valid commands for target \'all\'
+        ;;
+    esac
+
+    return
+  fi
 
   case "${SERVICE_COMMAND}" in
     start)
@@ -551,44 +655,7 @@ startHarness(){
 
   createNetwork
 
-  # if we're *not* using an external VON ledger, start the local one
-  if [[ -z ${LEDGER_URL_CONFIG} ]]; then
-    if [[ -z `docker ps -q --filter="name=von_webserver_1"` ]]; then
-      echo "starting local von-network..."
-      auxiliaryService von-network start
-      export STARTED_LOCAL_LEDGER=true
-    fi
-  fi
-
-  if ! waitForLedger; then
-    echoRed "\nThe Indy Ledger is not running.\n"
-    exit 1
-  fi
-
-  if [[ -z `docker ps -q --filter="name=uni-resolver-web.local"` ]]; then
-      echo "starting local uniresolver..."
-    auxiliaryService uniresolver start
-    export STARTED_LOCAL_UNIRESOLVER=true
-  fi
-
-  # if we're *not* using an external indy tails server, start the local one
-  if [[ -z ${TAILS_SERVER_URL_CONFIG} ]]; then
-    if [[ -z `docker ps -q --filter="name=docker_tails-server_1"` ]]; then
-      echo "starting local indy-tails-server..."
-      auxiliaryService indy-tails start
-      export STARTED_LOCAL_TAILS=true
-    fi
-  fi
-
-  if ! waitForTailsServer; then
-    echoRed "\nThe Indy Tails Server is not running.\n"
-    exit 1
-  fi
-
-  if ! waitForUniresolver; then
-    echoRed "\nUniversal Resolver is not running.\n"
-    exit 1
-  fi
+  startServices auto
 
   dockerhost_url_templates
 
@@ -687,20 +754,7 @@ stopHarness(){
     fi
   fi
 
-  if [[ ${STARTED_LOCAL_UNIRESOLVER} ]]; then
-      echo "stopping local uniresolver..."
-      auxiliaryService uniresolver stop
-  fi
-
-  if [[ ${STARTED_LOCAL_TAILS} ]]; then
-      echo "stopping local indy-tails-server..."
-      auxiliaryService indy-tails stop
-  fi
-
-  if [[ ${STARTED_LOCAL_LEDGER} ]]; then
-      echo "stopping local von-network..."
-      auxiliaryService von-network stop
-  fi
+  stopServices auto
 
   cleanupNetwork
 

--- a/services/orb/.env
+++ b/services/orb/.env
@@ -16,7 +16,7 @@ COMPOSE_IGNORE_ORPHANS=True
 
 # orb node
 ORB_FIXTURE_IMAGE=ghcr.io/trustbloc/orb
-ORB_FIXTURE_VERSION=latest
+ORB_FIXTURE_VERSION=v0.1.3
 
 # couch settings
 COUCHDB_IMAGE=couchdb

--- a/services/orb/.env
+++ b/services/orb/.env
@@ -16,7 +16,7 @@ COMPOSE_IGNORE_ORPHANS=True
 
 # orb node
 ORB_FIXTURE_IMAGE=ghcr.io/trustbloc/orb
-ORB_FIXTURE_VERSION=v0.1.2
+ORB_FIXTURE_VERSION=latest
 
 # couch settings
 COUCHDB_IMAGE=couchdb

--- a/services/orb/cli-scripts/create_did.sh
+++ b/services/orb/cli-scripts/create_did.sh
@@ -7,7 +7,7 @@ agent_names=( "Acme" "Bob" "Faber" "Mallory" )
 for AGENT_NAME in "${agent_names[@]}"; do
   .build/orb-cli did create \
     --domain https://orb.domain1.com \
-    --did-anchor-origin https://orb.domain1.com/services/orb \
+    --did-anchor-origin https://orb.domain1.com \
     --publickey-file did-keys/create/publickeys.json \
     --sidetree-write-token ADMIN_TOKEN \
     --service-file .build/services/${AGENT_NAME}.json \

--- a/services/orb/cli-scripts/setup_followers.sh
+++ b/services/orb/cli-scripts/setup_followers.sh
@@ -16,52 +16,99 @@ domain2External=https://localhost:48426/services/orb
 
 CURL_CA_BUNDLE=.build/keys/tls/ec-cacert.pem
 
+curl -d "$(cat <<EOF
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "id": "https://orb.domain1.com/services/orb/activities/77bdd005-bbb6-223d-b889-58bc1de84985",
+  "type": "Create",
+  "actor": "https://orb.domain1.com/services/orb",
+  "to": [
+    "https://orb.domain1.com/services/orb/followers",
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "published": "2021-03-31T09:30:10Z",
+  "object": {
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/activityanchors/v1"
+    ],
+    "id": "https://orb.domain1.com/transactions/uEiB0I06Yr-dJj7Xa8fNqwteKzDOUZPlQcDuMAZiS-YK5Cw",
+    "type": "AnchorCredentialReference",
+    "target": {
+      "type": "ContentAddressedStorage",
+      "id": "https://orb.domain1.com/cas/uEiB0I06Yr-dJj7Xa8fNqwteKzDOUZPlQcDuMAZiS-YK5Cw",
+      "cid": "hl:uEiB0I06Yr-dJj7Xa8fNqwteKzDOUZPlQcDuMAZiS-YK5Cw:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQjBJMDZZci1kSmo3WGE4Zk5xd3RlS3pET1VaUGxRY0R1TUFaaVMtWUs1Q3c"
+    }
+  }
+}
+EOF
+)" -H "Content-Type: application/json" -H "Authorization: Bearer ADMIN_TOKEN" -X POST -k ${domain1External}/outbox
+
 followID=$(random_string)
 
-curl -d "{\
-  \"@context\":\"https://www.w3.org/ns/activitystreams\",\
-  \"id\":\"${domain2}/activities/${followID}\",\
-  \"type\":\"Follow\",\
-  \"actor\":\"${domain2}\",\
-  \"to\":\"${domain1}\",\
-  \"object\":\"${domain1}\"\
-}" \
+curl -d "$(cat <<EOF
+{
+  "@context":"https://www.w3.org/ns/activitystreams",
+  "id":"${domain2}/activities/${followID}",
+  "type":"Follow",
+  "actor":"${domain2}",
+  "to":"${domain1}",
+  "object":"${domain1}"
+}
+EOF
+)" \
   -H "Content-Type: application/json" -H "Authorization: Bearer ADMIN_TOKEN" -X POST -k ${domain2External}/outbox
 
 followID=$(random_string)
 
-curl -d "{\
-  \"@context\":\"https://www.w3.org/ns/activitystreams\",\
-  \"id\":\"${domain1}/activities/${followID}\",\
-  \"type\":\"Follow\",\
-  \"actor\":\"${domain1}\",\
-  \"to\":\"${domain2}\",\
-  \"object\":\"${domain2}\"\
-}" \
+
+curl -d "$(cat <<EOF
+{
+  "@context":"https://www.w3.org/ns/activitystreams",
+  "id":"${domain1}/activities/${followID}",
+  "type":"Follow",
+  "actor":"${domain1}",
+  "to":"${domain2}",
+  "object":"${domain2}"
+}
+EOF
+)" \
   -H "Content-Type: application/json" -H "Authorization: Bearer ADMIN_TOKEN" -X POST -k ${domain1External}/outbox
 
 inviteWitnessID=$(random_string)
 
-curl -d "{\
-  \"@context\":[\"https://www.w3.org/ns/activitystreams\",\"https://trustbloc.github.io/did-method-orb/contexts/anchor/v1\"],\
-  \"id\":\"${domain1}/activities/${inviteWitnessID}\",\
-  \"type\":\"InviteWitness\",\
-  \"actor\":\"${domain1}\",\
-  \"to\":\"${domain2}\",\
-  \"object\":\"${domain2}\"\
-}" \
+
+curl -d "$(cat <<EOF
+{
+  "@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],
+  "id":"${domain1}/activities/${inviteWitnessID}",
+  "type":"Invite",
+  "actor":"${domain1}",
+  "to":"${domain2}",
+  "object":"https://w3id.org/activityanchors#AnchorWitness",
+  "target":"${domain2}"
+}
+EOF
+)" \
   -H "Content-Type: application/json" -H "Authorization: Bearer ADMIN_TOKEN" -X POST -k ${domain1External}/outbox
 
 inviteWitnessID=$(random_string)
 
-curl -d "{\
-  \"@context\":[\"https://www.w3.org/ns/activitystreams\",\"https://trustbloc.github.io/did-method-orb/contexts/anchor/v1\"],\
-  \"id\":\"${domain2}/activities/${inviteWitnessID}\",\
-  \"type\":\"InviteWitness\",\
-  \"actor\":\"${domain2}\",\
-  \"to\":\"${domain1}\",\
-  \"object\":\"${domain1}\"\
-}" \
+curl -d "$(cat <<EOF
+{
+  "@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],
+  "id":"${domain2}/activities/${inviteWitnessID}",
+  "type":"Invite",
+  "actor":"${domain2}",
+  "to":"${domain1}",
+  "object":"https://w3id.org/activityanchors#AnchorWitness",
+  "target":"${domain1}"
+}
+EOF
+)" \
   -H "Content-Type: application/json" -H "Authorization: Bearer ADMIN_TOKEN" -X POST -k ${domain2External}/outbox
 
 echo

--- a/services/orb/compose-2.yml
+++ b/services/orb/compose-2.yml
@@ -57,7 +57,7 @@ services:
       - KMS_KEY_MANAGER_STORAGE_TYPE=couchdb
       - KMS_KEY_MANAGER_STORAGE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.kms.com:5984
       - KMS_KEY_MANAGER_STORAGE_PREFIX=kmskm
-      - KMS_LOG_LEVEL=debug
+      - KMS_LOG_LEVEL=WARNING
     ports:
       - 7878:7878
     entrypoint: ""
@@ -78,6 +78,7 @@ services:
       - VCT_DSN=couchdb://${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.kms.com:5984
       - VCT_DATABASE_PREFIX=vct-db
       - VCT_TLS_CACERTS=/etc/orb/tls/ec-cacert.pem
+      - VCT_LOG_LEVEL=WARNING
     volumes:
       - ./.build/keys/tls:/etc/orb/tls
     ports:

--- a/services/orb/compose-3.yml
+++ b/services/orb/compose-3.yml
@@ -33,6 +33,7 @@ services:
       - HTTP_SIGNATURES_ENABLED=true
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain1.com
       - ORB_HOST_URL=0.0.0.0:443
+      - ORB_HOST_METRICS_URL=0.0.0.0:48327
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
 
       - LOG_LEVEL=${ORB_SERVER_LOG_LEVEL}
@@ -43,6 +44,7 @@ services:
       - ORB_VCT_URL=http://orb.vct:8077/aath-orb
     ports:
       - 48326:443
+      - 48327:48327
     command: start
     volumes:
       - ./.build/keys/tls:/etc/orb/tls
@@ -59,6 +61,7 @@ services:
       - ORB_VCT_URL=http://orb.vct:8077/aath-orb
       - LOG_LEVEL=${ORB_SERVER_LOG_LEVEL}
       - ORB_HOST_URL=0.0.0.0:443
+      - ORB_HOST_METRICS_URL=0.0.0.0:48527
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain2.com
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
@@ -80,6 +83,7 @@ services:
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
       - 48426:443
+      - 48527:48527
     command: start
     volumes:
       - ./.build/keys/tls:/etc/orb/tls

--- a/services/orb/compose-3.yml
+++ b/services/orb/compose-3.yml
@@ -12,7 +12,7 @@ services:
     image: ${ORB_FIXTURE_IMAGE}:${ORB_FIXTURE_VERSION}
     restart: always
     environment:
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain1.com
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain1.com
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
@@ -66,7 +66,7 @@ services:
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - CID_VERSION=${CID_VERSION_DOMAIN2}
@@ -93,7 +93,7 @@ services:
 
   orb.driver:
     container_name: orb.driver
-    image: ghcr.io/trustbloc/orb-did-driver:latest
+    image: ghcr.io/trustbloc/orb-did-driver:v0.1.3
     environment:
       - ORB_DRIVER_HOST_URL=0.0.0.0:8070
       - ORB_DRIVER_DOMAIN=https://orb.domain1.com

--- a/services/orb/did-keys/create/key3_jwk.json
+++ b/services/orb/did-keys/create/key3_jwk.json
@@ -1,0 +1,5 @@
+{
+	"kty": "EC",
+	"crv": "BLS12381_G2",
+	"x": "oqAJot77k-nHS1wIGWnsbQnTSbha78phuwjGAnBQwCf6Y7ojdW9c9CPoAufenSEzBTWJ6ZQN_6I63Jc0uDfn-gCSFYZJkEh1LYpS160VRtORUls95eR_csuFduSbbqpR"
+}

--- a/services/orb/did-keys/create/publickeys.json
+++ b/services/orb/did-keys/create/publickeys.json
@@ -2,7 +2,7 @@
  {
   "id": "key1",
   "type": "Ed25519VerificationKey2018",
-  "purposes": ["authentication"],
+  "purposes": ["authentication", "assertionMethod"],
   "jwkPath": "./did-keys/create/key1_jwk.json"
  },
  {
@@ -10,5 +10,11 @@
   "type": "JsonWebKey2020",
   "purposes": ["capabilityInvocation"],
   "jwkPath": "./did-keys/create/key2_jwk.json"
+ },
+ {
+  "id": "key3",
+  "type": "Bls12381G2Key2020",
+  "purposes": ["assertionMethod"],
+  "b58Key":"y2BD5ZME7awdMPYS4FY5AFsk18qjwh45ZJi3vMrjATiGL74eL7tgK7p96ztNtvZFAGVKm5SwNMPhg5qmGaZgvJWHR9cHGEisrdKvGHWSTDN2uc6wTA1C1pPDXqiaRiA6WyN"
  }
 ]

--- a/services/orb/did-keys/priv/key1_jwk.json
+++ b/services/orb/did-keys/priv/key1_jwk.json
@@ -1,8 +1,0 @@
-{
-  "kty":"OKP",
-  "crv":"Ed25519",
-  "kid": "EX6zbuWZCABtwk7dpYm7t6uCfe9y0KZYoTCGra7l4cc",
-  "d":"ez77KrfyV059aMvZi_2JNpZVvAV5-nlu-PhY-JlpPJk",
-  "x":"HyggxTz873aKJcjRPKcASEStx_FginCLZI9n8XZDJJI",
-  "y":""
-}

--- a/services/orb/did-keys/priv/priv_jwks.json
+++ b/services/orb/did-keys/priv/priv_jwks.json
@@ -1,0 +1,17 @@
+{
+  "Ed25519Signature2018": {
+    "kty":"OKP",
+    "crv":"Ed25519",
+    "kid": "EX6zbuWZCABtwk7dpYm7t6uCfe9y0KZYoTCGra7l4cc",
+    "d":"ez77KrfyV059aMvZi_2JNpZVvAV5-nlu-PhY-JlpPJk",
+    "x":"HyggxTz873aKJcjRPKcASEStx_FginCLZI9n8XZDJJI",
+    "y":""
+  },
+  "BbsBlsSignature2020": {
+    "kty":"EC",
+    "crv":"BLS12381_G2",
+    "kid": "oqAJot77k-nHS1wIGWnsbQnTSbha78phuwjGAnBQwCf",
+    "x":"oqAJot77k-nHS1wIGWnsbQnTSbha78phuwjGAnBQwCf6Y7ojdW9c9CPoAufenSEzBTWJ6ZQN_6I63Jc0uDfn-gCSFYZJkEh1LYpS160VRtORUls95eR_csuFduSbbqpR",
+    "d":"P6yf2ydsLHmx9BwEBH9i7xdoTfynmfPza2dxZUBNX64"
+  }
+}

--- a/services/orb/wrapper.sh
+++ b/services/orb/wrapper.sh
@@ -25,7 +25,19 @@ setupCLI() {
 	pushd .build > /dev/null
 
 	if [[ ! -f orb-cli ]]; then
-		curl -sL https://github.com/trustbloc/orb/releases/download/v0.1.1/orb-cli-linux-amd64.tar.gz | tar -x -z -O -f - > orb-cli
+		if [[ -f ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64 ]]; then
+			echo copying cli binary from local orb repo...
+			cp ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64 orb-cli
+		elif [[ -f ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64.tar.gz ]]; then
+			echo copying cli binary from local orb repo...
+			cp ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64.tar.gz orb-cli.tar.gz
+			tar -xzf orb-cli.tar.gz
+			mv orb-cli-linux-amd64 orb-cli
+			rm orb-cli.tar.gz
+		# else
+		#	# -- TODO: can't use v.0.1.1 orb cli any more
+		# 	curl -sL https://github.com/trustbloc/orb/releases/download/v0.1.1/orb-cli-linux-amd64.tar.gz | tar -x -z -O -f - > orb-cli
+		fi
 		chmod +x orb-cli
 	fi
 

--- a/services/orb/wrapper.sh
+++ b/services/orb/wrapper.sh
@@ -25,19 +25,7 @@ setupCLI() {
 	pushd .build > /dev/null
 
 	if [[ ! -f orb-cli ]]; then
-		if [[ -f ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64 ]]; then
-			echo copying cli binary from local orb repo...
-			cp ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64 orb-cli
-		elif [[ -f ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64.tar.gz ]]; then
-			echo copying cli binary from local orb repo...
-			cp ~/go/src/github.com/trustbloc/orb/.build/dist/bin/orb-cli-linux-amd64.tar.gz orb-cli.tar.gz
-			tar -xzf orb-cli.tar.gz
-			mv orb-cli-linux-amd64 orb-cli
-			rm orb-cli.tar.gz
-		# else
-		#	# -- TODO: can't use v.0.1.1 orb cli any more
-		# 	curl -sL https://github.com/trustbloc/orb/releases/download/v0.1.1/orb-cli-linux-amd64.tar.gz | tar -x -z -O -f - > orb-cli
-		fi
+		curl -sL https://github.com/trustbloc/orb/releases/download/v0.1.3/orb-cli-linux-amd64.tar.gz | tar -x -z -O -f - > orb-cli
 		chmod +x orb-cli
 	fi
 
@@ -87,11 +75,11 @@ createDID() {
 	mkdir -p $SCRIPT_HOME/../../aries-backchannels/afgo/.build/afgo-master.data
 	mkdir -p $SCRIPT_HOME/../../aries-backchannels/afgo/.build/afgo-interop.data
 
-	cp -r .build/orb-dids ../../aries-backchannels/afgo/.build/afgo-master.data/
-	cp -r .build/orb-dids ../../aries-backchannels/afgo/.build/afgo-interop.data/
+	cp -r .build/orb-dids ../../aries-backchannels/afgo/.build/afgo-master.data
+	cp -r .build/orb-dids ../../aries-backchannels/afgo/.build/afgo-interop.data
 
-	cp -r did-keys/priv ../../aries-backchannels/afgo/.build/afgo-master.data/
-	cp -r did-keys/priv ../../aries-backchannels/afgo/.build/afgo-interop.data/
+	cp -r did-keys/priv ../../aries-backchannels/afgo/.build/afgo-master.data
+	cp -r did-keys/priv ../../aries-backchannels/afgo/.build/afgo-interop.data
 
 
 	popd > /dev/null # to caller


### PR DESCRIPTION
AFGO-ACAPy interop tests that are now enabled:
- all didexchange tests 
- all JSON-LD issue-credential tests, with the exception of BBS+ with ACA-Py issuer, as there's an intermittent error where ACA-Py gets the public orb DID of the afgo holder instead of a peer DID.