### PR TITLE
Add verity afj dotnet runsets

### DIFF
--- a/.github/workflows/test-harness-verity-afj.yml
+++ b/.github/workflows/test-harness-verity-afj.yml
@@ -1,0 +1,53 @@
+name: test-harness-verity-afj
+# RUNSET_NAME: "Verity to Javascript"
+# Scope: AIP 1.0
+# Exceptions: None
+#
+# Summary
+#
+# This runset uses the current main branch of Javascript for all of the agents except Acme (Issuer),
+# which uses the dev branch of Evernym Verity. The runset covers all of the AIP 1.0 tests
+# under the connection protocol RFC1060.
+#
+# Current
+#
+# All the Connection tests are running. All tests are passing
+#
+# *Status Note Updated: 2021.09.16*
+#
+# End
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "25 1 * * *"
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
+    env:
+      LEDGER_URL_CONFIG: "http://dev.bcovrin.vonx.io"
+      TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+    steps:
+      - name: checkout-test-harness
+        uses: actions/checkout@v2
+        with:
+          path: test-harness
+      - name: run-indy-tails-server
+        uses: ./test-harness/actions/run-indy-tails-server
+      - name: run-test-harness-wo-reports
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a javascript -a verity"
+          TEST_AGENTS: "-d javascript -a verity"
+          TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip"
+          REPORT_PROJECT: javascript-a-verity
+        continue-on-error: true
+      - name: run-send-gen-test-results-secure
+        uses: ./test-harness/actions/run-send-gen-test-results-secure
+        with:
+          REPORT_PROJECT: acapy-b-verity
+          ADMIN_USER: ${{ secrets.AllureAdminUser }}
+          ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-verity-afj.yml
+++ b/.github/workflows/test-harness-verity-afj.yml
@@ -6,13 +6,14 @@ name: test-harness-verity-afj
 #
 # Summary
 #
+# Initial implementation to get the tests running smoothly. Currently testing connection only.
 # This runset uses the current main branch of Javascript for all of the agents except Acme (Issuer),
 # which uses the dev branch of Evernym Verity. The runset covers all of the AIP 1.0 tests
 # under the connection protocol RFC0160.
 #
 # Current
 #
-# All the Connection tests are running. All tests are passing
+# Initial implementation to get the tests running smoothly. Currently testing connection only.
 #
 # *Status Note Updated: 2021.09.23*
 #

--- a/.github/workflows/test-harness-verity-afj.yml
+++ b/.github/workflows/test-harness-verity-afj.yml
@@ -1,19 +1,20 @@
 name: test-harness-verity-afj
 # RUNSET_NAME: "Verity to Javascript"
-# Scope: AIP 1.0
+# Scope: Connections RFC0160
 # Exceptions: None
+# SKIP
 #
 # Summary
 #
 # This runset uses the current main branch of Javascript for all of the agents except Acme (Issuer),
 # which uses the dev branch of Evernym Verity. The runset covers all of the AIP 1.0 tests
-# under the connection protocol RFC1060.
+# under the connection protocol RFC0160.
 #
 # Current
 #
 # All the Connection tests are running. All tests are passing
 #
-# *Status Note Updated: 2021.09.16*
+# *Status Note Updated: 2021.09.23*
 #
 # End
 on:

--- a/.github/workflows/test-harness-verity-afj.yml
+++ b/.github/workflows/test-harness-verity-afj.yml
@@ -18,8 +18,8 @@ name: test-harness-verity-afj
 # End
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "25 1 * * *"
+  # schedule:
+  #   - cron: "25 1 * * *"
 defaults:
   run:
     shell: bash
@@ -44,10 +44,10 @@ jobs:
           TEST_AGENTS: "-d javascript -a verity"
           TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip"
           REPORT_PROJECT: javascript-a-verity
-        continue-on-error: true
-      - name: run-send-gen-test-results-secure
-        uses: ./test-harness/actions/run-send-gen-test-results-secure
-        with:
-          REPORT_PROJECT: acapy-b-verity
-          ADMIN_USER: ${{ secrets.AllureAdminUser }}
-          ADMIN_PW: ${{ secrets.AllureAdminPW }}
+      #   continue-on-error: true
+      # - name: run-send-gen-test-results-secure
+      #   uses: ./test-harness/actions/run-send-gen-test-results-secure
+      #   with:
+      #     REPORT_PROJECT: javascript-a-verity
+      #     ADMIN_USER: ${{ secrets.AllureAdminUser }}
+      #     ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-verity-dotnet.yml
+++ b/.github/workflows/test-harness-verity-dotnet.yml
@@ -1,0 +1,53 @@
+name: test-harness-verity-dotnet
+# RUNSET_NAME: "Verity to DotNet"
+# Scope: AIP 1.0
+# Exceptions: None
+#
+# Summary
+#
+# This runset uses the current main branch of DotNet for all of the agents except Acme (Issuer),
+# which uses the dev branch of Evernym Verity. The runset covers all of the AIP 1.0 tests
+# under the connection protocol RFC1060.
+#
+# Current
+#
+# All the Connection tests are running. All tests are passing
+#
+# *Status Note Updated: 2021.09.16*
+#
+# End
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "25 1 * * *"
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
+    env:
+      LEDGER_URL_CONFIG: "http://dev.bcovrin.vonx.io"
+      TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+    steps:
+      - name: checkout-test-harness
+        uses: actions/checkout@v2
+        with:
+          path: test-harness
+      - name: run-indy-tails-server
+        uses: ./test-harness/actions/run-indy-tails-server
+      - name: run-test-harness-wo-reports
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a dotnet-master -a verity"
+          TEST_AGENTS: "-d dotnet-master -a verity"
+          TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip"
+          REPORT_PROJECT: dotnet-a-verity
+        continue-on-error: true
+      - name: run-send-gen-test-results-secure
+        uses: ./test-harness/actions/run-send-gen-test-results-secure
+        with:
+          REPORT_PROJECT: acapy-b-verity
+          ADMIN_USER: ${{ secrets.AllureAdminUser }}
+          ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-verity-dotnet.yml
+++ b/.github/workflows/test-harness-verity-dotnet.yml
@@ -12,7 +12,7 @@ name: test-harness-verity-dotnet
 #
 # Current
 #
-# All the Connection tests are running. All tests are passing
+# Initial implementation to get the tests running smoothly. Currently testing connection only.
 #
 # *Status Note Updated: 2021.09.23*
 #

--- a/.github/workflows/test-harness-verity-dotnet.yml
+++ b/.github/workflows/test-harness-verity-dotnet.yml
@@ -1,19 +1,20 @@
 name: test-harness-verity-dotnet
 # RUNSET_NAME: "Verity to DotNet"
-# Scope: AIP 1.0
+# Scope: Connections RFC0160
 # Exceptions: None
+# SKIP
 #
 # Summary
 #
 # This runset uses the current main branch of DotNet for all of the agents except Acme (Issuer),
 # which uses the dev branch of Evernym Verity. The runset covers all of the AIP 1.0 tests
-# under the connection protocol RFC1060.
+# under the connection protocol RFC0160.
 #
 # Current
 #
 # All the Connection tests are running. All tests are passing
 #
-# *Status Note Updated: 2021.09.16*
+# *Status Note Updated: 2021.09.23*
 #
 # End
 on:

--- a/.github/workflows/test-harness-verity-dotnet.yml
+++ b/.github/workflows/test-harness-verity-dotnet.yml
@@ -18,8 +18,8 @@ name: test-harness-verity-dotnet
 # End
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "25 1 * * *"
+  # schedule:
+  #   - cron: "25 1 * * *"
 defaults:
   run:
     shell: bash
@@ -44,10 +44,10 @@ jobs:
           TEST_AGENTS: "-d dotnet-master -a verity"
           TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip"
           REPORT_PROJECT: dotnet-a-verity
-        continue-on-error: true
-      - name: run-send-gen-test-results-secure
-        uses: ./test-harness/actions/run-send-gen-test-results-secure
-        with:
-          REPORT_PROJECT: acapy-b-verity
-          ADMIN_USER: ${{ secrets.AllureAdminUser }}
-          ADMIN_PW: ${{ secrets.AllureAdminPW }}
+      #   continue-on-error: true
+      # - name: run-send-gen-test-results-secure
+      #   uses: ./test-harness/actions/run-send-gen-test-results-secure
+      #   with:
+      #     REPORT_PROJECT: dotnet-a-verity
+      #     ADMIN_USER: ${{ secrets.AllureAdminUser }}
+      #     ADMIN_PW: ${{ secrets.AllureAdminPW }}


### PR DESCRIPTION
This PR adds Verity with javascript and dotnet agents. They are failing locally, so this PR is just to try the execution in GHA to determine if the same issue exists as locally. 