### PR TITLE
waits added to dotnet backchannel

### DIFF
--- a/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/ConnectionController.cs
@@ -143,6 +143,12 @@ namespace DotNet.Backchannel.Controllers
             var connectionId = body.Id;
             var context = await _agentContextProvider.GetContextAsync();
 
+            // Adding a delay here. It seems that with the removal of the state checks in the tests,
+            // Some agents are not yet in the appropriate state for this call. 
+            // TODO There may be a better way to do this but adding the wait is a quick fix to get the tests
+            // running again.
+            await Task.Delay(5000);
+
             var THConnection = _connectionCache.Get<TestHarnessConnection>(connectionId);
             if (THConnection == null) return NotFound(); // Return early if not found
 

--- a/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/IssueCredentialController.cs
@@ -147,6 +147,12 @@ namespace DotNet.Backchannel.Controllers
             CredentialOfferMessage credentialOffer;
             CredentialRecord credentialRecord;
 
+            // Adding a delay here. It seems that with the removal of the state checks in the tests,
+            // Some agents are not yet in the appropriate state for this call. 
+            // TODO There may be a better way to do this but adding the wait is a quick fix to get the tests
+            // running again.
+            await Task.Delay(5000);
+
             // Send offer in response to proposal
             if (threadId != null)
             {
@@ -250,6 +256,13 @@ namespace DotNet.Backchannel.Controllers
         [HttpPost("issue")]
         public async Task<IActionResult> IssueCredentialAsync(OperationBody body)
         {
+
+            // Adding a delay here. It seems that with the removal of the state checks in the tests,
+            // Some agents are not yet in the appropriate state for this call. 
+            // TODO There may be a better way to do this but adding the wait is a quick fix to get the tests
+            // running again.
+            await Task.Delay(10000);
+
             var threadId = body.Id;
             var context = await _agentContextProvider.GetContextAsync();
             var THCredentialExchange = _credentialCache.Get<TestHarnessCredentialExchange>(threadId);

--- a/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
+++ b/aries-backchannels/dotnet/server/Controllers/PresentProofController.cs
@@ -163,6 +163,12 @@ namespace DotNet.Backchannel.Controllers
         [HttpPost("verify-presentation")]
         public async Task<IActionResult> VerifyPresentation(OperationBody body)
         {
+            // Adding a delay here. It seems that with the removal of the state checks in the tests,
+            // Some agents are not yet in the appropriate state for this call. 
+            // TODO There may be a better way to do this but adding the wait is a quick fix to get the tests
+            // running again.
+            await Task.Delay(10000);
+
             var context = await _agentContextProvider.GetContextAsync();
             var threadId = body.Id;
             var THPresentationExchange = _proofCache.Get<TestHarnessPresentationExchange>(threadId);


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Added waits for Connection, Issue Credential, and Proof. This should get us 5 passing tests. However there is an issue with the dotnet agent on issuing a credential when the test does a proposal. Details of this issue is documented in #356. More investigation on what is going on in that issue is required. 