### PR TITLE
Add support for changes to internal Docker networking.

### DIFF
--- a/manage
+++ b/manage
@@ -5,7 +5,22 @@
 export VALID_AGENTS=$(ls aries-backchannels/*/Dockerfile.* | sed "s/^.*file.//" |  tr "\n" " " | sort -u)
 
 export MSYS_NO_PATHCONV=1
-export DOCKERHOST=${APPLICATION_URL-$(docker run --rm --net=host eclipse/che-ip)}
+# ====================================================================
+# Set the DOCKERHOST address depending on host system
+# --------------------------------------------------------------------
+function getDockerHost() {
+  (
+    unset dockerHostAddress
+    if [[ $(uname) == "Linux" ]] ; then
+      dockerHostAddress=$(docker run --rm --net=host eclipse/che-ip)
+    else
+      dockerHostAddress=host.docker.internal
+    fi
+    echo ${DOCKERHOST:-${APPLICATION_URL:-${dockerHostAddress}}}
+  )
+}
+export DOCKERHOST=$(getDockerHost)
+# ====================================================================
 
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-aath}"

--- a/services/orb/wrapper.sh
+++ b/services/orb/wrapper.sh
@@ -40,7 +40,22 @@ setupFollowers() {
 	($SCRIPT_HOME/cli-scripts/setup_followers.sh)
 }
 
-export DOCKERHOST=$(docker run --rm --net=host eclipse/che-ip)
+# ====================================================================
+# Set the DOCKERHOST address depending on host system
+# --------------------------------------------------------------------
+function getDockerHost() {
+  (
+    unset dockerHostAddress
+    if [[ $(uname) == "Linux" ]] ; then
+      dockerHostAddress=$(docker run --rm --net=host eclipse/che-ip)
+    else
+      dockerHostAddress=host.docker.internal
+    fi
+    echo ${DOCKERHOST:-${APPLICATION_URL:-${dockerHostAddress}}}
+  )
+}
+export DOCKERHOST=$(getDockerHost)
+# ====================================================================
 
 generateAgentServices() {
 	pushd ${SCRIPT_HOME} > /dev/null


### PR DESCRIPTION
- Networking changes introduced in Docker 4.1.x and forward on Windows and MAC stop the direct use of the internal docker host IP returned by the `docker run --rm --net=host eclipse/che-ip` process.  On Windows and MAC `host.docker.internal` needs to be used for internal connections between containers.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>