### PR TITLE
Centralize docker host IP script.

### DIFF
--- a/manage
+++ b/manage
@@ -5,22 +5,9 @@
 export VALID_AGENTS=$(ls aries-backchannels/*/Dockerfile.* | sed "s/^.*file.//" |  tr "\n" " " | sort -u)
 
 export MSYS_NO_PATHCONV=1
-# ====================================================================
-# Set the DOCKERHOST address depending on host system
-# --------------------------------------------------------------------
-function getDockerHost() {
-  (
-    unset dockerHostAddress
-    if [[ $(uname) == "Linux" ]] ; then
-      dockerHostAddress=$(docker run --rm --net=host eclipse/che-ip)
-    else
-      dockerHostAddress=host.docker.internal
-    fi
-    echo ${DOCKERHOST:-${APPLICATION_URL:-${dockerHostAddress}}}
-  )
-}
+# getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))" 
 export DOCKERHOST=$(getDockerHost)
-# ====================================================================
 
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-aath}"

--- a/services/orb/wrapper.sh
+++ b/services/orb/wrapper.sh
@@ -40,22 +40,9 @@ setupFollowers() {
 	($SCRIPT_HOME/cli-scripts/setup_followers.sh)
 }
 
-# ====================================================================
-# Set the DOCKERHOST address depending on host system
-# --------------------------------------------------------------------
-function getDockerHost() {
-  (
-    unset dockerHostAddress
-    if [[ $(uname) == "Linux" ]] ; then
-      dockerHostAddress=$(docker run --rm --net=host eclipse/che-ip)
-    else
-      dockerHostAddress=host.docker.internal
-    fi
-    echo ${DOCKERHOST:-${APPLICATION_URL:-${dockerHostAddress}}}
-  )
-}
+# getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))" 
 export DOCKERHOST=$(getDockerHost)
-# ====================================================================
 
 generateAgentServices() {
 	pushd ${SCRIPT_HOME} > /dev/null


### PR DESCRIPTION
- This is an update to the previous commit to update the support for Docker networking.  The `getDockerHost` has been pulled out and placed in a central location where it can be updated as needed rather than having to update dozens of scripts the next time there is a change.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>