### PR TITLE
fix: sleep is not defined

### DIFF
--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -2,6 +2,7 @@ from behave import *
 import json
 from agent_backchannel_client import agent_backchannel_POST, expected_agent_state
 from agent_test_utils import get_relative_timestamp_to_epoch
+from time import sleep
 
 @when('{issuer} issues a new credential to "{prover}" with {credential_data}')
 @given('"{prover}" has an issued credential from {issuer} with {credential_data}')


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

Fixes an issue with `sleep` not being defined resulting in all present proof tests to fail (not sure how I missed this, as the tests ran successfully yesterday...)