### PR TITLE
Removed Proof tests that are causing job cancellation

### DIFF
--- a/.github/workflows/test-harness-dotnet-findy.yml
+++ b/.github/workflows/test-harness-dotnet-findy.yml
@@ -12,9 +12,10 @@ name: test-harness-dotnet-findy
 # Current
 # 
 # Two connection tests are passing out of Nineteen total. There are multiple issues in Issue Credential and Proof
-# with dotnet as the issuer and findy as the holder.
+# with dotnet as the issuer and findy as the holder. Removed a large portion of Proof tests since jobs were getting cancelled.
+# These will be added back when tests or agents are fixed and stability has returned.
 # 
-# *Status Note Updated: 2021.10.15*
+# *Status Note Updated: 2022.01.28*
 #
 # End
 on:
@@ -45,7 +46,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a dotnet-master -a findy"
           TEST_AGENTS: "-d dotnet-master -b findy"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@T001.3-RFC0037 -t ~@T001.4-RFC0037 -t ~@T001.5-RFC0037 -t ~@T003-RFC0037 -t ~@T003.1-RFC0037 -t ~@T006-RFC0037"
           REPORT_PROJECT: dotnet-b-findy
         continue-on-error: true
       - name: run-send-gen-test-results-secure


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Offending tests for the cancellation of daily runs have been excluded from the dotnet-findy runset until the tests/agents are fixed. 