### PR TITLE
fix(afj): revocation tests

### DIFF
--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a javascript"
           TEST_AGENTS: "-d acapy-main -b javascript"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@revocation -t ~@wip -t ~@DIDExchangeConnection"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441 -t ~@wip -t ~@DIDExchangeConnection"
           REPORT_PROJECT: acapy-b-javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/javascript/server/src/TestAgent.ts
+++ b/aries-backchannels/javascript/server/src/TestAgent.ts
@@ -1,6 +1,7 @@
 import { $log } from '@tsed/common'
 import { Agent, HttpOutboundTransport, InitConfig, WsOutboundTransport } from '@aries-framework/core'
 import { agentDependencies, HttpInboundTransport } from '@aries-framework/node'
+import indy from 'indy-sdk'
 
 import { TsedLogger } from './TsedLogger'
 
@@ -22,6 +23,14 @@ export async function createAgent({
   // TODO: Public did does not seem to be registered
   // TODO: Schema is prob already registered
   $log.level = 'debug'
+
+  // @ts-ignore
+  indy.setLogger(function (level: string, target: string, message: string, modulePath: string, file: string, line: string) {
+    console.log('libindy said:', level, target, message, modulePath, file, line)
+  })
+
+  // @ts-ignore
+  indy.setRuntimeConfig({ collect_backtrace: true })
 
   const agentConfig: InitConfig = {
     label: agentName,

--- a/aries-backchannels/javascript/server/src/controllers/PresentProofController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/PresentProofController.ts
@@ -138,6 +138,9 @@ export class PresentProofController {
 
     const retrievedCredentials = await this.agent.proofs.getRequestedCredentialsForProofRequest(proofRecord.id, {
       filterByPresentationPreview: true,
+      // Some tests include presenting a revoked credential, expecting the verification to fail
+      // So not excluding those from the retrieved credentials.
+      filterByNonRevocationRequirements: false,
     })
 
     this.logger.info('Created proof request', {

--- a/aries-test-harness/features/0183-revocation.feature
+++ b/aries-test-harness/features/0183-revocation.feature
@@ -59,7 +59,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T002-HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
+   @T002-HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with timesstamp
       Given "2" agents
          | name  | role     |
@@ -329,7 +329,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T013-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense @Indy
+   @T013-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense @Indy @RFC0441
    Scenario Outline: Non-revocable Credential, not revoked, and holder proves claims with the credential with timesstamp
       Given "2" agents
          | name  | role     |
@@ -346,7 +346,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | timeframe | request_for_proof        | presentation                 |
          | Acme   | Data_DL_MinValues | now:now   | proof_request_DL_address | presentation_DL_address_w_ts |
 
-   @T014-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
+   @T014-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Revocable Credential, not revoked, and holder proves claims with the credential with timesstamp
       Given "2" agents
          | name  | role     |


### PR DESCRIPTION
Fixes broken AFJ revocation tests. Also adds the missing @RFC0441 tags that we now use to only run the revocation tests following RFC0441