### PR TITLE
enhancement: Starting only agents given in cmd

### DIFF
--- a/manage
+++ b/manage
@@ -730,30 +730,34 @@ startHarness(){
   if [[ "$ACME" != "none" ]]; then
     export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
     startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
-    waitForAgent Acme 9020
-    echo
   fi
-
   if [[ "$BOB" != "none" ]]; then
     export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
     startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
-    waitForAgent Bob 9030
-    echo
   fi
-
   if [[ "$FABER" != "none" ]]; then
     export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
     startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
-    waitForAgent Faber 9040
-    echo
   fi
-
   if [[ "$MALLORY" != "none" ]]; then
     export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
     startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
-    waitForAgent Mallory 9050
-    echo
   fi
+  echo
+  # Check if agents were successfully started. 
+  if [[ "$ACME" != "none" ]]; then
+    waitForAgent Acme 9020
+  fi
+  if [[ "$BOB" != "none" ]]; then
+    waitForAgent Bob 9030
+  fi
+  if [[ "$FABER" != "none" ]]; then
+    waitForAgent Faber 9040
+  fi
+  if [[ "$MALLORY" != "none" ]]; then
+    waitForAgent Mallory 9050
+  fi
+  echo
 
   export PROJECT_ID=${PROJECT_ID:-general}
 

--- a/manage
+++ b/manage
@@ -743,6 +743,7 @@ startHarness(){
     export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
     startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
   fi
+  
   echo
   # Check if agents were successfully started. 
   if [[ "$ACME" != "none" ]]; then

--- a/manage
+++ b/manage
@@ -724,24 +724,58 @@ startHarness(){
 
   dockerhost_url_templates
 
-  export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
-  export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
-  export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
-  export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
+  # Old startup of agents
+  # export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
+  # export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
+  # export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
+  # export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
+  # export AIP_CONFIG=${AIP_CONFIG:-10}
+
+  # export PROJECT_ID=${PROJECT_ID:-general}
+
+  # startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
+  # startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
+  # startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
+  # startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
+
+  # echo
+  # waitForAgent Acme 9020
+  # waitForAgent Bob 9030
+  # waitForAgent Faber 9040
+  # waitForAgent Mallory 9050
+
   export AIP_CONFIG=${AIP_CONFIG:-10}
 
+  # Only start agents that are asked for in the ./manage start command
+  if [[ "$ACME" != "none" ]]; then
+    export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
+    startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
+    waitForAgent Acme 9020
+    echo
+  fi
+
+  if [[ "$BOB" != "none" ]]; then
+    export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
+    startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
+    waitForAgent Bob 9030
+    echo
+  fi
+
+  if [[ "$FABER" != "none" ]]; then
+    export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
+    startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
+    waitForAgent Faber 9040
+    echo
+  fi
+
+  if [[ "$MALLORY" != "none" ]]; then
+    export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
+    startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
+    waitForAgent Mallory 9050
+    echo
+  fi
+
   export PROJECT_ID=${PROJECT_ID:-general}
-
-  startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
-  startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
-  startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
-  startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
-
-  echo
-  waitForAgent Acme 9020
-  waitForAgent Bob 9030
-  waitForAgent Faber 9040
-  waitForAgent Mallory 9050
 
   echo
   # Allure Reports environment.properties file handling

--- a/manage
+++ b/manage
@@ -724,26 +724,6 @@ startHarness(){
 
   dockerhost_url_templates
 
-  # Old startup of agents
-  # export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
-  # export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
-  # export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
-  # export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
-  # export AIP_CONFIG=${AIP_CONFIG:-10}
-
-  # export PROJECT_ID=${PROJECT_ID:-general}
-
-  # startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
-  # startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
-  # startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
-  # startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
-
-  # echo
-  # waitForAgent Acme 9020
-  # waitForAgent Bob 9030
-  # waitForAgent Faber 9040
-  # waitForAgent Mallory 9050
-
   export AIP_CONFIG=${AIP_CONFIG:-10}
 
   # Only start agents that are asked for in the ./manage start command


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR modifies manage to only start agents specifically stated in the command. Previously it would attempt to start all roles even if they we not given. Now we can do commands like the following to just start agents needed. 
`./manage start -a acapy-main` Only starts acme as acapy-main. All other roles are not started.
`./manage start -a acapy-main -b afgo-interop` Only starts acme and bob. 
`./manage start -a afgo-interop -d acapy-main` This still works as before, acme is started as afgo, and all other roles are started as acapy-main. 

This enhancement is being done to support aries-mobile-test-harness that can use these agents as services when running mobile tests. It will not need 4 agents running so limiting to only what is asked for is required. 