### PR TITLE
WACI Issuance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ env/
 
 # VSCode
 .vscode/settings.json
+
+#JetBrains
+.idea

--- a/aries-backchannels/afgo/afgo_backchannel.py
+++ b/aries-backchannels/afgo/afgo_backchannel.py
@@ -189,6 +189,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
         self.TopicTranslationDict = {
             "issue-credential": "/issuecredential/",
             "issue-credential-v2": "/issuecredential/",
+            "issue-credential-v3": "/issuecredential/",
             "proof": "/presentproof/",
             "proof-v2": "/presentproof/",
             "proof-v3": "/presentproof/",
@@ -548,6 +549,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
         elif (
             command.topic == "issue-credential"
             or command.topic == "issue-credential-v2"
+            or command.topic == "issue-credential-v3"
         ):
             (resp_status, resp_text) = await self.handle_issue_credential_POST(command)
             return (resp_status, resp_text)
@@ -928,109 +930,153 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
         await self.load_jsonld_contexts()
 
+        isWACI = False
+
+        if operation == "send-proposal" and "pthid" in data:
+            isWACI = True
+        elif operation == "send-offer":
+            if isinstance(data, list) and "credential_manifest" in data[0]["data"]["json"]:
+                isWACI = True
+        elif operation == "send-request":
+            if isinstance(data, list) and "credential_application" in data[0]["data"]["json"]:
+                isWACI = True
+        elif operation == "issue":
+            if isinstance(data, list) and "credential_fulfillment" in data[0]["data"]["json"]:
+                isWACI = True
+
         if operation == "prepare-json-ld":
             (orb_did_status, orb_did_text, priv_key_kids) = await self.get_orb_did()
             return (orb_did_status, orb_did_text)
 
         if operation == "send-proposal" or operation == "send-offer":
-            if data is None:
-                # get the credential_proposal from the webhook
-                if record_id is None:
-                    raise Exception(
-                        f"Cannot have both data and rec_id empty for issuecredential/{operation}"
-                    )
+            if operation == "send-proposal" and isWACI:
+                # Get connection by connection id contained in the data received
+                # Get the DID keys from the connection record
+                (their_did, my_did) = await self.get_DIDs_for_participants(data["connectionID"])
+                self.myDID = my_did
+
+                data = {"pthid": data["pthid"],
+                    "my_did": my_did,
+                        "their_did": their_did,
+                        "propose_credential": {}}
+
+            elif operation == "send-offer" and isWACI:
+                # The data passed in to the handler here contains just the
+                # Credential Manifest and Credential Fulfillment preview attachments.
+                # Below we arrange them as needed to be accepted by the AFGo agent's accept-proposal endpoint.
 
                 (wh_status, wh_text) = await self.request_response_issue_credential(
                     rec_id=record_id, message_name="issue-credential-actions-msg"
                 )
                 issue_credential_actions_msg = json.loads(wh_text)
-                # Format the proposal for afgo offer
 
-                data = {}
+                record_id = issue_credential_actions_msg["message"]["Properties"]["piid"]
 
-                cred_prev = {}
+                agent_operation = make_agent_operation(record_id)
 
-                if (
-                    "credential_proposal"
-                    in issue_credential_actions_msg["message"]["Message"]
-                ):
-                    cred_prev = issue_credential_actions_msg["message"]["Message"][
-                        "credential_proposal"
-                    ]
-                elif (
-                    "credential_preview"
-                    in issue_credential_actions_msg["message"]["Message"]
-                ):
-                    cred_prev = issue_credential_actions_msg["message"]["Message"][
-                        "credential_preview"
-                    ]
-
-                if operation == "send-proposal":
-                    data["credential_proposal"] = cred_prev
-                elif operation == "send-offer":
-                    data["credential_preview"] = cred_prev
-
-                if (
-                    "filters~attach"
-                    in issue_credential_actions_msg["message"]["Message"]
-                ):
-                    filters_attach = issue_credential_actions_msg["message"]["Message"][
-                        "filters~attach"
-                    ]
-                    # TODO support more than one filter
-                    if len(filters_attach) > 0:
-                        filter_attmt = filters_attach[0]["data"]
-                        if "json" in filter_attmt:
-                            data["filter"] = filter_attmt["json"]
-                        elif "base64" in filter_attmt:
-                            filter_dec = base64.b64decode(filter_attmt["base64"])
-                            filter_json = json.loads(filter_dec)
-                            data["filter"] = filter_json
-
-                # Save Issuer DID off for ease of later use
-                self.myDID = issue_credential_actions_msg["message"]["Properties"][
-                    "myDID"
-                ]
-                their_did = issue_credential_actions_msg["message"]["Properties"][
-                    "theirDID"
-                ]
-
-                record_id = issue_credential_actions_msg["message"]["Properties"][
-                    "piid"
-                ]
+                data = {"offer_credential": {
+                    "@type": "https://didcomm.org/issue-credential/3.0/offer-credential",
+                    "attachments": data
+                }}
 
             else:
-                data_text = json.dumps(data)
+                if data is None:
+                    # get the credential_proposal from the webhook
+                    if record_id is None:
+                        raise Exception(
+                            f"Cannot have both data and rec_id empty for issuecredential/{operation}"
+                        )
 
-                # Get connection by connection id contained in the data received
-                # Get the DID keys from the connection record
-                (their_did, my_did) = await self.get_DIDs_for_participants(
-                    data["connection_id"]
-                )
-                self.myDID = my_did
+                    (wh_status, wh_text) = await self.request_response_issue_credential(
+                        rec_id=record_id, message_name="issue-credential-actions-msg"
+                    )
+                    issue_credential_actions_msg = json.loads(wh_text)
+                    # Format the proposal for afgo offer
 
-                # remove schema/indy related items from data
-                if "schema_id" in data:
-                    data.pop("schema_id")
-                if "schema_issuer_did" in data:
-                    data.pop("schema_issuer_did")
-                if "issuer_did" in data:
-                    data.pop("issuer_did")
-                if "schema_name" in data:
-                    data.pop("schema_name")
-                if "cred_def_id" in data:
-                    data.pop("cred_def_id")
-                if "schema_version" in data:
-                    data.pop("schema_version")
-                if "connection_id" in data:
-                    data.pop("connection_id")
+                    data = {}
 
-            # add their did and my did to the data
-            data["my_did"] = self.myDID
-            data["their_did"] = their_did
+                    cred_prev = {}
+
+                    if (
+                            "credential_proposal"
+                            in issue_credential_actions_msg["message"]["Message"]
+                    ):
+                        cred_prev = issue_credential_actions_msg["message"]["Message"][
+                            "credential_proposal"
+                        ]
+                    elif (
+                            "credential_preview"
+                            in issue_credential_actions_msg["message"]["Message"]
+                    ):
+                        cred_prev = issue_credential_actions_msg["message"]["Message"][
+                            "credential_preview"
+                        ]
+
+                    if operation == "send-proposal" and not isWACI:
+                        data["credential_proposal"] = cred_prev
+                    elif operation == "send-offer" and not isWACI:
+                        data["credential_preview"] = cred_prev
+
+                    if (
+                            "filters~attach"
+                            in issue_credential_actions_msg["message"]["Message"]
+                    ):
+                        filters_attach = issue_credential_actions_msg["message"]["Message"][
+                            "filters~attach"
+                        ]
+                        # TODO support more than one filter
+                        if len(filters_attach) > 0:
+                            filter_attmt = filters_attach[0]["data"]
+                            if "json" in filter_attmt:
+                                data["filter"] = filter_attmt["json"]
+                            elif "base64" in filter_attmt:
+                                filter_dec = base64.b64decode(filter_attmt["base64"])
+                                filter_json = json.loads(filter_dec)
+                                data["filter"] = filter_json
+
+                    # Save Issuer DID off for ease of later use
+                    self.myDID = issue_credential_actions_msg["message"]["Properties"][
+                        "myDID"
+                    ]
+                    their_did = issue_credential_actions_msg["message"]["Properties"][
+                        "theirDID"
+                    ]
+
+                    record_id = issue_credential_actions_msg["message"]["Properties"][
+                        "piid"
+                    ]
+                else:
+                    data_text = json.dumps(data)
+
+                    # Get connection by connection id contained in the data received
+                    # Get the DID keys from the connection record
+                    (their_did, my_did) = await self.get_DIDs_for_participants(
+                        data["connection_id"]
+                    )
+                    self.myDID = my_did
+
+                    # remove schema/indy related items from data
+                    if "schema_id" in data:
+                        data.pop("schema_id")
+                    if "schema_issuer_did" in data:
+                        data.pop("schema_issuer_did")
+                    if "issuer_did" in data:
+                        data.pop("issuer_did")
+                    if "schema_name" in data:
+                        data.pop("schema_name")
+                    if "cred_def_id" in data:
+                        data.pop("cred_def_id")
+                    if "schema_version" in data:
+                        data.pop("schema_version")
+                    if "connection_id" in data:
+                        data.pop("connection_id")
+
+                # add their did and my did to the data
+                data["my_did"] = self.myDID
+                data["their_did"] = their_did
 
             # Properly construct the credential proposal for afgo
-            if operation == "send-proposal":
+            if operation == "send-proposal" and not isWACI:
                 if "credential_proposal" in data:
                     data["propose_credential"] = {
                         "credential_proposal": data["credential_proposal"]
@@ -1078,7 +1124,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
                     data.pop("filter")
 
-            elif operation == "send-offer":
+            elif operation == "send-offer" and not isWACI:
                 if "credential_preview" in data:
                     data["offer_credential"] = {
                         "credential_preview": data["credential_preview"]
@@ -1159,6 +1205,69 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 resp_text = json.dumps(resp_json)
 
             return (resp_status, resp_text)
+
+        elif operation == "send-request" and isWACI:
+            log_msg(
+                f"Data translated by backchannel to send to agent for operation: {agent_operation}",
+                data,
+            )
+
+            # The data passed in to the handler here contains just the
+            # Credential Application attachment.
+            # Below we arrange it as needed to be accepted by the AFGo agent's accept-offer endpoint.
+
+            data = {
+                "request_credential": {
+                    "ID": "ae639a44-1c63-4d11-ba05-39a1f97993aa",
+                    "Type": "https://didcomm.org/issue-credential/3.0/request-credential",
+                    "Comment": "",
+                    "GoalCode": "",
+                    "Attachments": data
+                }
+            }
+
+            (wh_status, wh_text) = await self.request_response_issue_credential(
+                rec_id=record_id, message_name="issue-credential-actions-msg"
+            )
+            issue_credential_actions_msg = json.loads(wh_text)
+
+            record_id = issue_credential_actions_msg["message"]["Properties"]["piid"]
+
+            agent_operation = make_agent_operation(record_id)
+
+            (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+
+            log_msg(resp_status, resp_text)
+            resp_json = json.loads(resp_text)
+
+            if resp_status == 200:
+                # Get the state form the webhook callback.
+                if record_id == None:
+                    if "piid" in resp_json:
+                        record_id = resp_json["piid"]
+                    else:
+                        raise Exception(
+                            f"No piid found to retrieve State from webhook message: {resp_text}"
+                        )
+
+                (wh_status, wh_text) = await self.request_response_issue_credential(
+                    record_id
+                )
+                issue_credential_states_msg = json.loads(wh_text)
+                if "StateID" in issue_credential_states_msg["message"]:
+                    resp_json["state"] = issue_credential_states_msg["message"][
+                        "StateID"
+                    ]
+                else:
+                    raise Exception(
+                        f"Could not retieve State from webhook message: {issue_credential_states_msg}"
+                    )
+
+                resp_json["thread_id"] = record_id
+
+                resp_text = json.dumps(resp_json)
+
+            return resp_status, resp_text
 
         elif operation == "send-request":
             (wh_status, wh_text) = await self.request_response_issue_credential(
@@ -1267,6 +1376,62 @@ class AfGoAgentBackchannel(AgentBackchannel):
 
             return (resp_status, resp_text)
 
+        elif operation == "issue" and isWACI:
+            # The data passed in to the handler here contains just the
+            # Credential fulfillment attachment.
+            # Below we arrange it as needed to be accepted by the AFGo agent's accept-request endpoint.
+
+            data = {
+                "issue_credential": {
+                    "Type": "https://didcomm.org/issue-credential/3.0/issue-credential",
+                    "ID": "1c60ffac-cd87-4433-9909-fa6e93431a14",
+                    "Comment": "",
+                    "Attachments": data,
+                    "GoalCode": "",
+                    "ReplacementID": ""
+                }
+            }
+
+            (wh_status, wh_text) = await self.request_response_issue_credential(
+                rec_id=record_id, message_name="issue-credential-states-msg"
+            )
+            issue_credential_actions_msg = json.loads(wh_text)
+
+            record_id = issue_credential_actions_msg["message"]["Properties"]["piid"]
+
+            agent_operation = make_agent_operation(record_id)
+
+            (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+            log_msg(resp_status, resp_text)
+
+            if resp_status == 200:
+                resp_json = json.loads(resp_text)
+                # Get the state form the webhook callback.
+                if record_id == None:
+                    if "piid" in resp_json:
+                        record_id = resp_json["piid"]
+                    else:
+                        raise Exception(
+                            f"No piid found to retrieve State from webhook message: {resp_text}"
+                        )
+                (wh_status, wh_text) = await self.request_response_issue_credential(
+                    record_id
+                )
+                issue_credential_states_msg = json.loads(wh_text)
+                if "StateID" in issue_credential_states_msg["message"]:
+                    resp_json["state"] = self.issueCredentialStateTranslationDict[
+                        issue_credential_states_msg["message"]["StateID"]
+                    ]
+                else:
+                    raise Exception(
+                        f"Could not retrieve State from webhook message: {issue_credential_states_msg}"
+                    )
+
+                resp_text = json.dumps(resp_json)
+
+            return (resp_status, resp_text)
+
+
         elif operation == "issue":
             cred = {}
 
@@ -1298,7 +1463,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 # Format the proposal for afgo issue
                 # suppliment the message data with whatever afgo needs to make the store credential work
                 # IMO this is a defect in afgo
-                if topic == "issue-credential-v2":
+                if topic == "issue-credential-v2" or topic == "issue-credential-v3":
                     src_msg = issue_credential_states_msg["message"]["Message"]
 
                     cred_attachments = []
@@ -1455,7 +1620,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                                                     timespec="seconds"
                                                 )
                                             )
-                                            + "Z",
+                                                + "Z",
                                             "issuer": {"id": self.myDID},
                                             "type": [
                                                 "VerifiableCredential",
@@ -1504,6 +1669,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                 resp_text = json.dumps(resp_json)
 
             return (resp_status, resp_text)
+
 
         # Make Special provisions for revoke since it is passing multiple query params not just one id.
         elif operation == "revoke":
@@ -2047,7 +2213,23 @@ class AfGoAgentBackchannel(AgentBackchannel):
         elif (
             command.topic == "issue-credential"
             or command.topic == "issue-credential-v2"
+            or command.topic == "issue-credential-v3"
         ):
+            if command.record_id == "retrieve-credential-proposal":
+                propose_credential_message_from_holder = get_resource_latest("issue-credential-actions-msg")
+
+                propose_credential_message = propose_credential_message_from_holder["message"]["Message"]
+
+                return 200, json.dumps(propose_credential_message)
+
+            elif command.record_id == "retrieve-credential-application":
+                request_credential_message_from_holder = get_resource_latest("issue-credential-actions-msg")
+
+                credential_application_attachment = \
+                    request_credential_message_from_holder["message"]["Message"]["attachments"][0]["data"]["json"]
+
+                return 200, json.dumps(credential_application_attachment)
+
             (wh_status, wh_text) = await self.request_response_issue_credential(
                 record_id
             )
@@ -2425,7 +2607,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
             return await self.request_response_out_of_band(record_id)
 
         elif (
-            topic == "issue-credential" or topic == "issue-credential-v2"
+            topic == "issue-credential" or topic == "issue-credential-v2" or topic == "issue-credential-v3"
         ) and record_id:
             return await self.request_response_issue_credential(
                 record_id, message_name=message_name
@@ -2638,7 +2820,7 @@ class AfGoAgentBackchannel(AgentBackchannel):
                         agent_state,
                         self.connectionResponderStateTranslationDict[agent_state],
                     )
-            elif topic == "issue-credential" or topic == "issue-credential-v2":
+            elif topic == "issue-credential" or topic == "issue-credential-v2" or topic == "issue-credential-v3":
                 data = data.replace(
                     agent_state, self.issueCredentialStateTranslationDict[agent_state]
                 )

--- a/aries-test-harness/features/data/waci_issue_credential_attachment.json
+++ b/aries-test-harness/features/data/waci_issue_credential_attachment.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "df3311ef-894d-4092-9227-22f092d19356",
+    "media_type": "application/json",
+    "lastmod_time": "0001-01-01T00:00:00Z",
+    "data": {
+      "json": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://identity.foundation/credential-manifest/fulfillment/v1"
+        ],
+        "credential_fulfillment": {
+          "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+          "manifest_id": "dcc75a16-19f5-4273-84ce-4da69ee2b7fe",
+          "descriptor_map": [
+            {
+              "id": "driver_license_output",
+              "format": "ldp_vc",
+              "path": "$.verifiableCredential[0]"
+            }
+          ]
+        },
+        "proof": {
+          "created": "2021-06-07T20:02:44.730614315Z",
+          "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NVum9BeYkhzwslZXm2cDOveQB9njlrCRSrdMZgwV3zZfLRXmZQ1AXdKLLmo4ClTYXFX_TWNyB8aFt9cN6sSvCg",
+          "proofPurpose": "authentication",
+          "type": "Ed25519Signature2018",
+          "verificationMethod": "did:orb:EiA3Xmv8A8vUH5lRRZeKakd-cjAxGC2A4aoPDjLysjghow#tMIstfHSzXfBUF7O0m2FiBEfTb93_j_4ron47IXPgEo"
+        },
+        "type": [
+          "VerifiablePresentation",
+          "CredentialFulfillment"
+        ],
+        "verifiableCredential": [
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1"
+            ],
+            "credentialSubject": {
+              "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+              "license": {
+                "dob": "07/13/80",
+                "number": "34DGE352"
+              }
+            },
+            "id": "https://ontario.ca/claims/DriversLicense",
+            "issuanceDate": "2010-01-01T19:53:24Z",
+            "issuer": "did:foo:123",
+            "proof": {
+              "created": "2021-06-07T20:02:44.730614315Z",
+              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NVum9BeYkhzwslZXm2cDOveQB9njlrCRSrdMZgwV3zZfLRXmZQ1AXdKLLmo4ClTYXFX_TWNyB8aFt9cN6sSvCg",
+              "proofPurpose": "assertionMethod",
+              "type": "Ed25519Signature2018",
+              "verificationMethod": "did:orb:EiA3Xmv8A8vUH5lRRZeKakd-cjAxGC2A4aoPDjLysjghow#tMIstfHSzXfBUF7O0m2FiBEfTb93_j_4ron47IXPgEo"
+            },
+            "type":[
+              "VerifiableCredential",
+              "OntarioDriversLicense"
+            ]
+          }
+        ]
+      }
+    },
+    "format": "dif/credential-manifest/fulfillment@v1.0"
+  }
+]

--- a/aries-test-harness/features/data/waci_send_offer_attachments.json
+++ b/aries-test-harness/features/data/waci_send_offer_attachments.json
@@ -1,0 +1,239 @@
+[
+  {
+    "@id": "0ebbf26f-a726-4e73-8c6b-4fee39a0acd6",
+    "mime-type": "application/json",
+    "lastmod_time": "0001-01-01T00:00:00Z",
+    "data": {
+      "json": {
+        "credential_manifest": {
+          "id": "dcc75a16-19f5-4273-84ce-4da69ee2b7fe",
+          "version": "0.1.0",
+          "issuer": {
+            "id": "did:example:123?linked-domains=3",
+            "name": "Government of Ontario",
+            "styles": {
+              "thumbnail": {
+
+              },
+              "hero": {
+
+              },
+              "background": {
+                "color": ""
+              },
+              "text": {
+                "color": ""
+              }
+            }
+          },
+          "output_descriptors": [
+            {
+              "id": "driver_license_output",
+              "schema": "https://schema.org/EducationalOccupationalCredential",
+              "display": {
+                "title": {
+                  "path": [
+                    "$.name",
+                    "$.vc.name"
+                  ],
+                  "schema": {
+                    "type": "string"
+                  },
+                  "fallback": "Ontario Driver's License"
+                },
+                "subtitle": {
+                  "path": [
+                    "$.class",
+                    "$.vc.class"
+                  ],
+                  "schema": {
+                    "type": "string"
+                  },
+                  "fallback": "Class A, Commercial"
+                },
+                "description": {
+                  "text": "License to operate a vehicle with a gross combined weight rating (GCWR) of 26,001 or more pounds, as long as the GVWR of the vehicle(s) being towed is over 10,000 pounds.",
+                  "schema": {
+
+                  }
+                },
+                "properties": [
+                  {
+                    "path": [
+                      "$.donor",
+                      "$.vc.donor"
+                    ],
+                    "schema": {
+                      "type": "boolean"
+                    },
+                    "fallback": "Unknown",
+                    "label": "Organ Donor"
+                  }
+                ]
+              },
+              "styles": {
+                "thumbnail": {
+                  "uri": "https://ontario.ca/logo.png",
+                  "alt": "Washington State Seal"
+                },
+                "hero": {
+                  "uri": "https://dol.wa.com/happy-people-driving.png",
+                  "alt": "Happy people driving"
+                },
+                "background": {
+                  "color": "#ff0000"
+                },
+                "text": {
+                  "color": "#d4d400"
+                }
+              }
+            }
+          ],
+          "format": {
+            "jwt": {
+              "alg": [
+                "EdDSA",
+                "ES256K",
+                "ES384"
+              ]
+            },
+            "jwt_vc": {
+              "alg": [
+                "ES256K",
+                "ES384"
+              ]
+            },
+            "jwt_vp": {
+              "alg": [
+                "EdDSA",
+                "ES256K"
+              ]
+            },
+            "ldp": {
+              "proof_type": [
+                "RsaSignature2018"
+              ]
+            },
+            "ldp_vc": {
+              "proof_type": [
+                "JsonWebSignature2020",
+                "Ed25519Signature2018",
+                "EcdsaSecp256k1Signature2019",
+                "RsaSignature2018"
+              ]
+            },
+            "ldp_vp": {
+              "proof_type": [
+                "Ed25519Signature2018"
+              ]
+            }
+          },
+          "presentation_definition": {
+            "id": "8246867e-fdce-48de-a825-9d84ec16c6c9",
+            "input_descriptors": [
+              {
+                "id": "prc_input",
+                "name": "Permanent Resident Card",
+                "purpose": "We need a PRC to verify your status.",
+                "schema": [
+                  {
+                    "uri": "https://w3id.org/citizenship#PermanentResidentCard"
+                  }
+                ],
+                "constraints": {
+                  "fields": [
+                    {
+                      "path": [
+                        "$.credentialSubject.givenName"
+                      ],
+                      "filter": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "path": [
+                        "$.credentialSubject.familyName"
+                      ],
+                      "filter": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "path": [
+                        "$.credentialSubject.birthCountry"
+                      ],
+                      "filter": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "path": [
+                        "$.credentialSubject.birthDate"
+                      ],
+                      "filter": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "options": {
+          "challenge": "508adef4-b8e0-4edf-a53d-a260371c1423",
+          "domain": "9rf25a28rs96"
+        }
+      }
+    }
+  },
+  {
+    "@id": "638c66fb-a981-49e9-ba10-63eee1db7b94",
+    "mime-type": "application/json",
+    "lastmod_time": "0001-01-01T00:00:00Z",
+    "data": {
+      "json": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://identity.foundation/credential-manifest/fulfillment/v1"
+        ],
+        "credential_fulfillment": {
+          "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+          "manifest_id": "dcc75a16-19f5-4273-84ce-4da69ee2b7fe",
+          "descriptor_map": [
+            {
+              "id": "driver_license_output",
+              "format": "ldp_vc",
+              "path": "$.verifiableCredential[0]"
+            }
+          ]
+        },
+        "type": [
+          "VerifiablePresentation",
+          "CredentialFulfillment"
+        ],
+        "verifiableCredential": [
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1"
+            ],
+            "credentialSubject": {
+              "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+              "license": {
+                "dob": "07/13/80",
+                "number": "34DGE352"
+              }
+            },
+            "id": "https://ontario.ca/claims/DriversLicense",
+            "issuanceDate": "2010-01-01T19:53:24Z",
+            "issuer": "did:foo:123",
+            "type":[
+              "VerifiableCredential",
+              "OntarioDriversLicense"
+            ]
+          }
+        ]
+      }
+    }
+  }
+]

--- a/aries-test-harness/features/data/waci_send_request_attachment.json
+++ b/aries-test-harness/features/data/waci_send_request_attachment.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "632db4c0-8e6f-4101-9b92-4ab7e9e81985",
+    "media_type": "application/json",
+    "lastmod_time": "0001-01-01T00:00:00Z",
+    "data": {
+      "json": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://identity.foundation/credential-manifest/application/v1"
+        ],
+        "credential_application": {
+          "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+          "manifest_id": "dcc75a16-19f5-4273-84ce-4da69ee2b7fe",
+          "format": {
+            "ldp_vc": {
+              "proof_type": [
+                "JsonWebSignature2020",
+                "EcdsaSecp256k1Signature2019"
+              ]
+            }
+          }
+        },
+        "presentation_submission": {
+          "id": "2e161b2c-606b-416f-b04f-7f06edac55a1",
+          "definition_id": "8246867e-fdce-48de-a825-9d84ec16c6c9",
+          "descriptor_map": [
+            {
+              "id": "prc_input",
+              "format": "ldp_vp",
+              "path": "$.verifiableCredential[0]"
+            }
+          ]
+        },
+        "proof": {
+          "challenge": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+          "created": "2021-05-14T20:16:29.565377",
+          "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..7M9LwdJR1_SQayHIWVHF5eSSRhbVsrjQHKUrfRhRRrlbuKlggm8mm_4EI_kTPeBpalQWiGiyCb_0OWFPtn2wAQ",
+          "proofPurpose": "authentication",
+          "type": "Ed25519Signature2018",
+          "verificationMethod": "did:example:123#key-0"
+        },
+        "type": [
+          "VerifiablePresentation",
+          "CredentialApplication"
+        ],
+        "verifiableCredential": [
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://w3id.org/citizenship/v1",
+              "https://w3id.org/security/bbs/v1"
+            ],
+            "credentialSubject": {
+              "birthCountry": "Bahamas",
+              "birthDate": "1958-07-17",
+              "familyName": "Pasteur",
+              "givenName": "Louis",
+              "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+            },
+            "description": "Permanent Resident Card of Mr.Louis Pasteu",
+            "expirationDate": "2029-12-03T12:19:52Z",
+            "id": "urn:uvci:af5vshde843jf831j128fj",
+            "issuanceDate": "2019-12-03T12:19:52Z",
+            "issuer": "did:example:456",
+            "name": "Permanent Resident Card",
+            "proof": {
+              "created": "2021-02-18T23:04:28Z",
+              "nonce": "JNGovx4GGoi341v/YCTcZq7aLWtBtz8UhoxEeCxZFevEGzfh94WUSg8Ly/q+2jLqzzY=",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "AB0GQA//jbDwMgaIIJeqP3fRyMYi6WDGhk0JlGJc/sk4ycuYGmyN7CbO4bA7yhIW/YQbHEkOgeMy0QM+usBgZad8x5FRePxfo4v1dSzAbJwWjx87G9F1lAIRgijlD4sYni1LhSo6svptDUmIrCAOwS2raV3G02mVejbwltMOo4+cyKcGlj9CzfjCgCuS1SqAxveDiMKGAAAAdJJF1pO6hBUGkebu/SMmiFafVdLvFgpMFUFEHTvElUQhwNSp6vxJp6Rs7pOVc9zHqAAAAAI7TJuDCf7ramzTo+syb7Njf6ExD11UKNcChaeblzegRBIkg3HoWgwR0hhd4z4D5/obSjGPKpGuD+1DoyTZhC/wqOjUZ03J1EtryZrC+y1DD14b4+khQVLgOBJ9+uvshrGDbu8+7anGezOa+qWT0FopAAAAEG6p07ghODpi8DVeDQyPwMY/iu2Lh7x3JShWniQrewY2GbsACBYOPlkNNm/qSExPRMe2X7UPpdsxpUDwqbObye4EXfAabgKd9gCmj2PNdvcOQAi5rIuJSGa4Vj7AtKoW/2vpmboPoOu4IEM1YviupomCKOzhjEuOof2/y5Adfb8JUVidWqf9Ye/HtxnzTu0HbaXL7jbwsMNn5wYfZuzpmVQgEXss2KePMSkHcfScAQNglnI90YgugHGuU+/DQcfMoA0+JviFcJy13yERAueVuzrDemzc+wJaEuNDn8UiTjAdVhLcgnHqUai+4F6ONbCfH2B3ohB3hSiGB6C7hDnEyXFOO9BijCTHrxPv3yKWNkks+3JfY28m+3NO0e2tlyH71yDX0+F6U388/bvWod/u5s3MpaCibTZEYoAc4sm4jW03HFYMmvYBuWOY6rGGOgIrXxQjx98D0macJJR7Hkh7KJhMkwvtyI4MaTPJsdJGfv8I+RFROxtRM7RcFpa4J5wF/wQnpyorqchwo6xAOKYFqCqKvI9B6Y7Da7/0iOiWsjs8a4zDiYynfYavnz6SdxCMpHLgplEQlnntqCb8C3qly2s5Ko3PGWu4M8Dlfcn4TT8YenkJDJicA91nlLaE8TJbBgsvgyT+zlTsRSXlFzQc+3KfWoODKZIZqTBaRZMft3S/",
+              "type": "BbsBlsSignatureProof2020",
+              "verificationMethod": "did:example:123#key-1"
+            },
+            "type": [
+              "VerifiableCredential",
+              "VaccinationCertificate",
+              "PermanentResidentCard"
+            ]
+          }
+        ]
+      }
+    },
+    "format": "dif/credential-manifest/application@v1.0"
+  }
+]

--- a/aries-test-harness/features/environment.py
+++ b/aries-test-harness/features/environment.py
@@ -42,11 +42,7 @@ def before_scenario(context: Context, scenario: Scenario):
         )
 
     # Check for Present Proof Feature to be able to handle the loading of schemas and credential definitions before the scenarios.
-    if (
-        "present proof" in context.feature.name
-        or "revocation" in context.feature.name
-        or "Issue Credential" in context.feature.name
-    ):
+    if 'present proof' in context.feature.name or 'revocation' in context.feature.name or 'Issue Credential' in context.feature.name or 'WACI' in context.feature.name:
         # get the tag with "Schema_".
         for tag in context.tags:
             if "ProofType_" in tag:
@@ -66,7 +62,7 @@ def before_scenario(context: Context, scenario: Scenario):
                     # If this is issue credential then you can't created multiple credential defs at the same time, like Proof uses
                     # multiple credential types in the proof. So just set the context.schema here to be used in the issue cred test.
                     # This makes the rule that you can only have one @Schema_ tag in an issue credential test scenario.
-                    if "Issue Credential" in context.feature.name:
+                    if 'Issue Credential' in context.feature.name or 'WACI' in context.feature.name:
                         context.schema = schema_json["schema"]
                         # Get and assign the credential definition info to the context
                         context.support_revocation = schema_json[

--- a/aries-test-harness/features/issue-credential-v3.feature
+++ b/aries-test-harness/features/issue-credential-v3.feature
@@ -1,0 +1,22 @@
+@DIDComm-V2 @WACI
+Feature: WACI Issuance
+
+  @DIDExchangeConnection
+  Scenario: WACI issuance flow
+    Given "2" agents
+      | name | role   |
+      | Acme | issuer |
+      | Bob  | holder |
+    And "Acme" is ready to issue a credential using WACI
+    And "Acme" is running with parameters "{"mime-type":["didcomm/v2"]}"
+    And "Bob" is running with parameters "{"mime-type":["didcomm/v2"]}"
+    When "Acme" creates a didcomm v2 invitation
+    And "Bob" accepts the didcomm v2 invitation from "Acme"
+    When "Bob" uses WACI to propose a credential to "Acme"
+    And "Acme" has received a didcomm v2 message from "Bob" and created a connection
+    Then "Acme" validates the proposal
+    Then "Acme" sends a Credential Manifest along with a Credential Fulfillment preview
+    Then "Bob" sends a Credential Application
+    Then "Acme" validates the Credential Application
+    Then "Acme" sends a Credential Fulfillment
+    Then "Bob" accepts the Credential Fulfillment

--- a/aries-test-harness/features/steps/issue-credential-v3.py
+++ b/aries-test-harness/features/steps/issue-credential-v3.py
@@ -1,0 +1,137 @@
+from behave import *
+import json
+from agent_backchannel_client import agent_backchannel_POST, agent_backchannel_GET
+
+CRED_FORMAT_INDY = "indy"
+CRED_FORMAT_JSON_LD = "json-ld"
+
+
+@given('"{issuer}" is ready to issue a credential using WACI')
+def step_impl(context, issuer: str):
+    issuer_url = context.config.userdata.get(issuer)
+
+    data = {
+        "did_method": context.did_method,
+        "proof_type": context.proof_type
+    }
+
+    (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential-v3",
+                                                      operation="prepare-json-ld", data=data)
+
+    assert resp_status == 200, f'waci/prepare-json-ld: resp_status {resp_status} is not 200; {resp_text}'
+
+
+@when('"{holder}" uses WACI to propose a credential to "{issuer}"')
+def step_impl(context, holder, issuer):
+    holder_url = context.config.userdata.get(holder)
+
+    data = {
+        "pthid": context.invitation_v2[issuer]["id"],
+        "connectionID": context.connection_id_dict[holder][issuer]
+    }
+
+    (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential-v3",
+                                                      operation="send-proposal",
+                                                      data=data)
+
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+    resp_json = json.loads(resp_text)
+
+    # Get the thread ID from the response text.
+    context.cred_thread_id = resp_json["thread_id"]
+
+
+@then('"{issuer}" validates the proposal')
+def step_impl(context, issuer):
+    issuer_url = context.config.userdata.get(issuer)
+
+    (resp_status, resp_text) = agent_backchannel_GET(issuer_url + "/agent/command/", "issue-credential-v3",
+                                                     id="retrieve-credential-proposal")
+
+    credential_proposal = json.loads(resp_text)
+
+    pthid_from_proposal = credential_proposal["pthid"]
+
+    expected_pthid = context.invitation_v2[issuer]["id"]
+
+    assert pthid_from_proposal == expected_pthid, \
+        f"Failed to correlate the credential proposal with the out of band invitation. " \
+        f"The pthid in the proposal is {pthid_from_proposal} but {expected_pthid} was expected."
+
+
+@then('"{issuer}" sends a Credential Manifest along with a Credential Fulfillment preview')
+def step_impl(context, issuer):
+    waci_send_offer_attachments_json_file = open('features/data/waci_send_offer_attachments.json')
+    waci_send_offer_attachments_json = json.load(waci_send_offer_attachments_json_file)
+
+    # In a later step, the issuer will verify that the holder send the expected Credential Manifest ID.
+    # Here we save it in the context, so it can be checked later.
+    context.manifest_id = waci_send_offer_attachments_json[0]["data"]["json"]["credential_manifest"]["id"]
+
+    issuer_url = context.config.userdata.get(issuer)
+
+    (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential-v3",
+                                                      operation="send-offer", id=context.cred_thread_id,
+                                                      data=waci_send_offer_attachments_json)
+
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+
+@then('"{holder}" sends a Credential Application')
+def step_impl(context, holder):
+    waci_send_request_attachment_json_file = open('features/data/waci_send_request_attachment.json')
+    waci_send_request_attachment_json = json.load(waci_send_request_attachment_json_file)
+    holder_url = context.config.userdata.get(holder)
+
+    (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential-v3",
+                                                      operation="send-request", id=context.cred_thread_id,
+                                                      data=waci_send_request_attachment_json)
+
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+
+@then('"{issuer}" validates the Credential Application')
+def step_impl(context, issuer):
+    issuer_url = context.config.userdata.get(issuer)
+
+    (resp_status, resp_text) = agent_backchannel_GET(issuer_url + "/agent/command/", "issue-credential-v3",
+                                                     id="retrieve-credential-application")
+
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+    credential_application_attachment = json.loads(resp_text)
+
+    manifest_id_in_credential_application = credential_application_attachment["credential_application"]["manifest_id"]
+
+    assert manifest_id_in_credential_application == context.manifest_id, \
+        f"Credential Manifest ID in the received Credential Application ({manifest_id_in_credential_application}) " \
+        f"is unknown. Was expecting {context.manifest_id}"
+
+
+@then('"{issuer}" sends a Credential Fulfillment')
+def step_impl(context, issuer):
+    waci_issue_credential_attachment_json_file = open('features/data/waci_issue_credential_attachment.json')
+    waci_issue_credential_request_attachment_json = json.load(waci_issue_credential_attachment_json_file)
+    issuer_url = context.config.userdata.get(issuer)
+
+    (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "issue-credential-v3",
+                                                      operation="issue", id=context.cred_thread_id,
+                                                      data=waci_issue_credential_request_attachment_json)
+
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+
+@then('"{holder}" accepts the Credential Fulfillment')
+def step_impl(context, holder):
+    holder_url = context.config.userdata.get(holder)
+
+    (resp_status, resp_text) = agent_backchannel_POST(holder_url + "/agent/command/", "issue-credential-v3",
+                                                      operation="store", id=context.cred_thread_id)
+
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+    resp_json = json.loads(resp_text)
+
+    state = resp_json["state"]
+
+    assert state == "done", f"state is '{state}', expected 'done'"

--- a/docs/assets/openapi-spec.yml
+++ b/docs/assets/openapi-spec.yml
@@ -982,6 +982,189 @@ paths:
                           credential_id:
                             $ref: "#/components/schemas/CredentialId"
 
+  /agent/command/issue-credential-v3/send-proposal:
+    post:
+      tags:
+        - Issue Credential V3
+      summary: Send credential proposal
+      description: >
+        Send a `propose-credential` message to connection with `connection_id` and `pthid` in body.
+      externalDocs:
+        url: https://github.com/decentralized-identity/waci-presentation-exchange/blob/main/issue_credential/README.md#propose-credential
+      operationId: IssueCredentialV3SendProposal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: object
+                  required:
+                    - connection_id
+                    - pthid
+                  properties:
+                    connection_id:
+                      $ref: "#/components/schemas/ConnectionId"
+                    pthid:
+                      $ref: "#/components/schemas/pthid"
+
+      responses:
+        200:
+          description: Credential proposal sent
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: proposal-sent
+  /agent/command/issue-credential-v3/retrieve-credential-proposal:
+    get:
+      tags:
+        - Issue Credential V3
+      summary: Retrieves the Propose Credential object received by the agent.
+      description: >
+        Retrieves the Propose Credential object received by the agent.
+      externalDocs:
+        url: https://identity.foundation/waci-presentation-exchange/#issuance-2
+      operationId: IssueCredentialV3RetrieveCredentialProposal
+
+      responses:
+        200:
+          description: Propose Credential object
+  /agent/command/issue-credential-v3/send-offer:
+    post:
+      tags:
+        - Issue Credential V3
+      summary: Send credential offer
+      description: >
+        Send an `offer-credential` message.
+      externalDocs:
+        url: https://github.com/decentralized-identity/waci-presentation-exchange/blob/main/issue_credential/README.md#offer-credential
+      operationId: IssueCredentialV3SendOffer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          description: Credential offer sent
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: offer-sent
+  /agent/command/issue-credential-v3/send-request:
+    post:
+      tags:
+        - Issue Credential V3
+      summary: Send credential request
+      externalDocs:
+        url: https://github.com/decentralized-identity/waci-presentation-exchange/blob/main/issue_credential/README.md#request-credential
+      operationId: IssueCredentialV3SendRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+                type: object
+
+      responses:
+        200:
+          description: Credential request sent
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: request-sent
+  /agent/command/issue-credential-v3/retrieve-credential-application:
+    get:
+      tags:
+        - Issue Credential V3
+      summary: Retrieves the Credential Application object received by the agent.
+      description: >
+        Retrieves the Credential Application object received by the agent.
+      externalDocs:
+        url: https://identity.foundation/waci-presentation-exchange/#issuance-2
+      operationId: IssueCredentialV3RetrieveCredentialApplication
+
+      responses:
+        200:
+          description: Credential Application object
+  /agent/command/issue-credential-v3/issue:
+    post:
+      tags:
+        - Issue Credential V3
+      summary: Issue credential
+      externalDocs:
+        url: https://github.com/decentralized-identity/waci-presentation-exchange/blob/main/issue_credential/README.md#issue-credential
+      operationId: IssueCredentialV3Issue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+              properties:
+                id:
+                  $ref: "#/components/schemas/ThreadId"
+                data:
+                  type: object
+      responses:
+        200:
+          description: Credential issued
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - properties:
+                      state:
+                        example: credential-issued
+  /agent/command/issue-credential-v3/store:
+    post:
+      tags:
+        - Issue Credential V3
+      summary: Store/accept credential
+      operationId: IssueCredentialV3Store
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+              properties:
+                id:
+                  $ref: "#/components/schemas/ThreadId"
+      responses:
+        200:
+          description: Credential stored
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/IssueCredentialOperationResponse"
+                  - required:
+                      - credential_id
+                    properties:
+                      state:
+                        example: done
+
   /agent/command/credential/{credentialId}:
     get:
       tags:
@@ -1986,6 +2169,10 @@ components:
     ThreadId:
       title: Thread Id
       example: "e7280776-5315-4569-8cac-42cae108adfe"
+      type: string
+    pthid:
+      title: pthid
+      example: "5a7f69cf-ee3c-4a75-9975-1aa3c28db122"
       type: string
     MediatorId:
       title: Mediator Id


### PR DESCRIPTION
Basic WACI issuance tests using DIDComm V2 and Issue Credential V3. Spec for reference: https://identity.foundation/waci-presentation-exchange/#issuance-2

Also added the settings folder used by JetBrains IDEs to the gitignore.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>