### PR TITLE
fix: tag rfc0025+rfc0160 test with @RFC0160 so afgo suite skips it

### DIFF
--- a/aries-test-harness/features/0025-didcomm-transports.feature
+++ b/aries-test-harness/features/0025-didcomm-transports.feature
@@ -46,7 +46,7 @@ Feature: RFC 0025 DIDComm Transports
       | ["http"]                | ["ws", "http"]           | ["ws"]                 | ["ws", "http"]          |
       | ["ws"]                  | ["ws", "http"]           | ["http"]               | ["ws", "http"]          |
 
-  @T002-RFC0025 @AcceptanceTest
+  @T002-RFC0025 @AcceptanceTest @RFC0160
   Scenario Outline: Create 0160 connection between two agents with overlapping transports
     Given we have "2" agents
       | name | role    |


### PR DESCRIPTION
Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>