### PR TITLE
fix: waci tags and did method

### DIFF
--- a/aries-test-harness/features/issue-credential-v3.feature
+++ b/aries-test-harness/features/issue-credential-v3.feature
@@ -1,7 +1,7 @@
-@DIDComm-V2 @WACI
+@DIDComm-V2 @WACI @IssueCredentialV3
 Feature: WACI Issuance
 
-  @DIDExchangeConnection
+  @T001-IssueCredentialV3 @DIDExchangeConnection @DidMethod_orb
   Scenario: WACI issuance flow
     Given "2" agents
       | name | role   |


### PR DESCRIPTION
The waci tests weren't specifying any did method, causing the flow to fail after my recent pr to extend did methods