### PR TITLE
Set timeout on waiting for test harnesses to complete.

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -59,6 +59,7 @@ jobs:
       fail-fast: false
     steps:
       - name: ${{ matrix.test-workflow }}
+        timeout-minutes: 60
         if: success() || failure()
         uses: convictional/trigger-workflow-and-wait@v1.6.0
         with:


### PR DESCRIPTION
- Some test harnesses can take up to 45 minutes to complete.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>