### PR TITLE
Add container logs upload step to common GitHub test action.

### DIFF
--- a/.github/workflows/test-harness-afj-findy.yml
+++ b/.github/workflows/test-harness-afj-findy.yml
@@ -6,14 +6,14 @@ name: test-harness-javascript-findy
 # Summary
 #
 # This runset uses the latest release of Aries Framework Javascript for all of the agents except Bob (holder),
-# which uses the current main branch of findy-agent. The runset covers all of the AIP 1.0 tests that 
+# which uses the current main branch of findy-agent. The runset covers all of the AIP 1.0 tests that
 # are known to work with findy as the holder. Excluded are those tests that involve Revocation.
 #
 # Current
-# 
-# All of the tests being executed in this runset are failing. There is an issue with afj sending the connection 
+#
+# All of the tests being executed in this runset are failing. There is an issue with afj sending the connection
 # response, and throws an error processing inbound message.
-# 
+#
 # *Status Note Updated: 2021.09.28*
 #
 # End

--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -37,12 +37,28 @@ runs:
       run: ./manage build ${{ inputs.BUILD_AGENTS }}
       shell: bash
       working-directory: test-harness
+    - name: start-harness-agents
+      run: ./manage start ${{ inputs.TEST_AGENTS }}
+      shell: bash
+      working-directory: test-harness
     - name: run-test-harness-acapy
-      run: PROJECT_ID=${{inputs.REPORT_PROJECT}} ./manage run ${{ inputs.TEST_AGENTS }} ${{ inputs.REPORTING }} ${{ inputs.OTHER_PARAMS }} ${{ inputs.TEST_SCOPE }}
+      run: PROJECT_ID=${{inputs.REPORT_PROJECT}} ./manage test ${{ inputs.TEST_AGENTS }} ${{ inputs.REPORTING }} ${{ inputs.OTHER_PARAMS }} ${{ inputs.TEST_SCOPE }}
       shell: bash
       env:
         NO_TTY: "1"
       working-directory: test-harness
+    - name: Collect docker logs
+      if: ${{ always() }}
+      uses: jwalton/gh-docker-logs@v2.2.0
+      with:
+        dest: "./.logs/docker-logs"
+    - name: archive logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: container-logs
+        path: .logs
+        retention-days: 14
 branding:
   icon: "mic"
   color: "purple"

--- a/aries-backchannels/findy/Dockerfile.findy
+++ b/aries-backchannels/findy/Dockerfile.findy
@@ -1,1 +1,1 @@
-FROM ghcr.io/findy-network/findy-agent-backchannel:findy-bc-bundle-latest
+FROM ghcr.io/findy-network/findy-agent-backchannel/findy-bc-bundle:latest


### PR DESCRIPTION
It would be beneficial sometimes to inspect the logs for the different containers that were run during the test flow in GitHub Actions. This change will collect and archive the container logs as artifacts.

Signed-off-by: Laura Vuorenoja <laura.vuorenoja@op.fi>