### PR TITLE
Fail workflow if image building fails.

### DIFF
--- a/.github/workflows/skip-test-harness-verity-afj.yml
+++ b/.github/workflows/skip-test-harness-verity-afj.yml
@@ -47,7 +47,6 @@ jobs:
           TEST_AGENTS: "-d javascript -a verity"
           TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip -t ~AIP20"
           REPORT_PROJECT: javascript-a-verity
-      #   continue-on-error: true
       # - name: run-send-gen-test-results-secure
       #   uses: ./test-harness/actions/run-send-gen-test-results-secure
       #   with:

--- a/.github/workflows/skip-test-harness-verity-dotnet.yml
+++ b/.github/workflows/skip-test-harness-verity-dotnet.yml
@@ -46,7 +46,6 @@ jobs:
           TEST_AGENTS: "-d dotnet -a verity"
           TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip -t ~@AIP20"
           REPORT_PROJECT: dotnet-a-verity
-      #   continue-on-error: true
       # - name: run-send-gen-test-results-secure
       #   uses: ./test-harness/actions/run-send-gen-test-results-secure
       #   with:

--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -54,11 +54,11 @@ jobs:
         env:
           EMIT_NEW_DIDCOMM_PREFIX: true
           EMIT_NEW_DIDCOMM_MIME_TYPE: true
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
-        if: ((github.event_name != 'pull_request' && github.repository == 'hyperledger/aries-agent-test-harness'))
+        if: (( always() && github.event_name != 'pull_request' && github.repository == 'hyperledger/aries-agent-test-harness' ))
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-afgo
           ADMIN_USER: ${{ secrets.AllureAdminUser }}
           ADMIN_PW: ${{ secrets.AllureAdminPW }}
+

--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -44,8 +44,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main -b javascript"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211"
           REPORT_PROJECT: acapy-b-javascript
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-javascript

--- a/.github/workflows/test-harness-acapy-aip10.yml
+++ b/.github/workflows/test-harness-acapy-aip10.yml
@@ -42,8 +42,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0211 -t ~@wip -t ~@T004-RFC0211 -t ~@Transport_NoHttpOutbound"
           REPORT_PROJECT: acapy-aip10  
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-aip10 

--- a/.github/workflows/test-harness-acapy-aip20.yml
+++ b/.github/workflows/test-harness-acapy-aip20.yml
@@ -42,8 +42,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP20 -t ~@wip -t ~@T004-RFC0211 -t ~@Transport_NoHttpOutbound -t ~@DidMethod_orb"
           REPORT_PROJECT: acapy-aip20
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-aip20

--- a/.github/workflows/test-harness-acapy-ariesvcx.yml
+++ b/.github/workflows/test-harness-acapy-ariesvcx.yml
@@ -36,12 +36,12 @@ jobs:
           TEST_AGENTS: "-d acapy-main -b aries-vcx"
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@revocation -t ~@RFC0183 -t ~@wip -t ~@DIDExchangeConnection -t ~@T002-HIPE0011 -t ~@T003-RFC0160 -t ~@T004-RFC0160 -t ~@T014-HIPE0011 -t ~@RFC0434"
           REPORT_PROJECT: acapy-b-aries-vcx
-        continue-on-error: true
       - uses: actions/upload-artifact@v2
         with:
           name: agent-logs
           path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-aries-vcx

--- a/.github/workflows/test-harness-acapy-dotnet-javascript.yml
+++ b/.github/workflows/test-harness-acapy-dotnet-javascript.yml
@@ -47,8 +47,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main -b javascript -f dotnet"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@ProofProposal -t ~@RFC0025"
           REPORT_PROJECT: acapy-b-javascript-f-dotnet
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-javascript-f-dotnet 

--- a/.github/workflows/test-harness-acapy-dotnet.yml
+++ b/.github/workflows/test-harness-acapy-dotnet.yml
@@ -46,8 +46,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main -b dotnet"
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@ProofProposal -t ~@RFC0023 -t ~@DIDExchangeConnection -t ~@AIP20 -t ~@RFC0025"
           REPORT_PROJECT: acapy-b-dotnet
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-dotnet 

--- a/.github/workflows/test-harness-acapy-findy.yml
+++ b/.github/workflows/test-harness-acapy-findy.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main -b findy"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@RFC0025"
           REPORT_PROJECT: acapy-b-findy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-findy

--- a/.github/workflows/test-harness-acapy-verity.yml
+++ b/.github/workflows/test-harness-acapy-verity.yml
@@ -41,8 +41,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main -a verity"
           TEST_SCOPE: "-t @RFC0160 -t @AcceptanceTest -t ~@wip -t ~@AIP20"
           REPORT_PROJECT: acapy-b-verity
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-verity

--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d acapy-main"
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound"
           REPORT_PROJECT: acapy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy 

--- a/.github/workflows/test-harness-afgo-acapy.yml
+++ b/.github/workflows/test-harness-afgo-acapy.yml
@@ -51,8 +51,8 @@ jobs:
         env:
           EMIT-NEW-DIDCOMM-PREFIX: true
           EMIT-NEW-DIDCOMM-MIME-TYPE: true
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: afgo-b-acapy

--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -46,8 +46,8 @@ jobs:
           TEST_AGENTS: "-d afgo-master"
           TEST_SCOPE: "-t @RFC0023,@RFC0044,@T001.1-RFC0036,@RFC0453,@RFC0454,@RFC0211,@RFC0025,@DIDComm-V2 -t ~@wip -t ~@RFC0160 -t ~@CredFormat_Indy -t ~@RFC0434 -t ~@DidMethod_sov"
           REPORT_PROJECT: afgo
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: afgo

--- a/.github/workflows/test-harness-afj-acapy.yml
+++ b/.github/workflows/test-harness-afj-acapy.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d javascript -b acapy-main"
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection"
           REPORT_PROJECT: javascript-b-acapy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: javascript-b-acapy

--- a/.github/workflows/test-harness-afj-dotnet.yml
+++ b/.github/workflows/test-harness-afj-dotnet.yml
@@ -47,9 +47,8 @@ jobs:
           TEST_AGENTS: "-d javascript -b dotnet"
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@revocation -t ~@RFC0023 -t ~@DIDExchangeConnection -t ~@ProofProposal -t ~@RFC0025 -t ~@AIP20"
           REPORT_PROJECT: javascript-b-dotnet
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
-        if: ((github.event_name != 'pull_request' && github.repository == 'hyperledger/aries-agent-test-harness'))
+        if: (( always() && github.event_name != 'pull_request' && github.repository == 'hyperledger/aries-agent-test-harness'))
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: javascript-b-dotnet

--- a/.github/workflows/test-harness-afj-findy.yml
+++ b/.github/workflows/test-harness-afj-findy.yml
@@ -44,8 +44,8 @@ jobs:
           TEST_AGENTS: "-d javascript -b findy"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@RFC0025"
           REPORT_PROJECT: javascript-b-findy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: javascript-b-findy

--- a/.github/workflows/test-harness-afj.yml
+++ b/.github/workflows/test-harness-afj.yml
@@ -42,8 +42,8 @@ jobs:
           TEST_AGENTS: "-d javascript"
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211 -t ~@DIDExchangeConnection"
           REPORT_PROJECT: javascript
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: javascript

--- a/.github/workflows/test-harness-ariesvcx-acapy.yml
+++ b/.github/workflows/test-harness-ariesvcx-acapy.yml
@@ -36,12 +36,12 @@ jobs:
           TEST_AGENTS: "-d aries-vcx -b acapy-main"
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@revocation -t ~@RFC0183 -t ~@wip -t ~@RFC0183 -t ~@DIDExchangeConnection -t ~@T002-HIPE0011 -t ~@T014-HIPE0011 -t ~@AIP20"
           REPORT_PROJECT: aries-vcx-b-acapy
-        continue-on-error: true
       - uses: actions/upload-artifact@v2
         with:
           name: agent-logs
           path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: aries-vcx-b-acapy

--- a/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
+++ b/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
@@ -36,12 +36,12 @@ jobs:
           TEST_AGENTS: "-d aries-vcx"
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@revocation -t ~@wip -t ~@RFC0183 -t ~@DIDExchangeConnection -t ~@T002-HIPE0011 -t ~@AIP20"
           REPORT_PROJECT: aries-vcx
-        continue-on-error: true
       - uses: actions/upload-artifact@v2
         with:
           name: agent-logs
           path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: aries-vcx

--- a/.github/workflows/test-harness-dotnet-acapy.yml
+++ b/.github/workflows/test-harness-dotnet-acapy.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d dotnet -b acapy-main"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@ProofProposal -t ~@RFC0025"
           REPORT_PROJECT: dotnet-b-acapy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: dotnet-b-acapy 

--- a/.github/workflows/test-harness-dotnet-findy.yml
+++ b/.github/workflows/test-harness-dotnet-findy.yml
@@ -45,8 +45,8 @@ jobs:
           TEST_AGENTS: "-d dotnet -b findy"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@T001.3-RFC0037 -t ~@T001.4-RFC0037 -t ~@T001.5-RFC0037 -t ~@T003-RFC0037 -t ~@T003.1-RFC0037 -t ~@T006-RFC0037 -t ~@RFC0025"
           REPORT_PROJECT: dotnet-b-findy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: dotnet-b-findy

--- a/.github/workflows/test-harness-dotnet-javascript.yml
+++ b/.github/workflows/test-harness-dotnet-javascript.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d dotnet -b javascript"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@ProofProposal -t ~@RFC0025"
           REPORT_PROJECT: dotnet-b-javascript
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: dotnet-b-javascript 

--- a/.github/workflows/test-harness-dotnet.yml
+++ b/.github/workflows/test-harness-dotnet.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d dotnet"
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@revocation -t ~@ProofProposal -t ~@RFC0023 -t ~@DIDExchangeConnection -t ~@RFC0025 -t ~@AIP20"
           REPORT_PROJECT: dotnet
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: dotnet 

--- a/.github/workflows/test-harness-findy-acapy.yml
+++ b/.github/workflows/test-harness-findy-acapy.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d findy -b acapy-main"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@RFC0025"
           REPORT_PROJECT: findy-b-acapy
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: findy-b-acapy

--- a/.github/workflows/test-harness-findy-dotnet.yml
+++ b/.github/workflows/test-harness-findy-dotnet.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d findy -b dotnet"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@ProofProposal -t ~@RFC0025"
           REPORT_PROJECT: findy-b-dotnet
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: findy-b-dotnet

--- a/.github/workflows/test-harness-findy-javascript-dotnet.yml
+++ b/.github/workflows/test-harness-findy-javascript-dotnet.yml
@@ -45,8 +45,8 @@ jobs:
           TEST_AGENTS: "-d findy -b javascript -f dotnet"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@RFC0025"
           REPORT_PROJECT: findy-b-javascript-f-dotnet
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: findy-b-javascript-f-dotnet 

--- a/.github/workflows/test-harness-findy-javascript.yml
+++ b/.github/workflows/test-harness-findy-javascript.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d findy -b javascript"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@RFC0025"
           REPORT_PROJECT: findy-b-javascript
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: findy-b-javascript

--- a/.github/workflows/test-harness-findy.yml
+++ b/.github/workflows/test-harness-findy.yml
@@ -43,8 +43,8 @@ jobs:
           TEST_AGENTS: "-d findy"
           REPORT_PROJECT: findy  
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation -t ~@RFC0025"
-        continue-on-error: true
       - name: run-send-gen-test-results-secure
+        if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: findy 

--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -37,6 +37,10 @@ runs:
       run: ./manage build ${{ inputs.BUILD_AGENTS }}
       shell: bash
       working-directory: test-harness
+    - name: generate environment file
+      if: ${{ failure() }}
+      run: ${{ github.action_path }}/store-failed-env.sh ${{ inputs.TEST_AGENTS }}
+      shell: bash
     - name: run-test-harness-acapy
       run: PROJECT_ID=${{inputs.REPORT_PROJECT}} ./manage run ${{ inputs.TEST_AGENTS }} ${{ inputs.REPORTING }} ${{ inputs.OTHER_PARAMS }} ${{ inputs.TEST_SCOPE }}
       shell: bash

--- a/actions/run-test-harness-wo-reports/store-failed-env.sh
+++ b/actions/run-test-harness-wo-reports/store-failed-env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+BOB="unknown"
+DEFAULT="unknown"
+while getopts ":b:d:" FLAG; do
+    case $FLAG in
+        b ) BOB=${OPTARG}
+            ;;
+        d )
+            DEFAULT=${OPTARG}
+            ;;
+    esac
+done
+
+VERSION_FAILED="build-failed"
+
+env_file="$(pwd)/test-harness/aries-test-harness/allure/allure-results/environment.properties"
+declare -a env_array
+env_array+=("role.acme=$DEFAULT")
+env_array+=("acme.agent.version=$VERSION_FAILED")
+env_array+=("role.bob=$BOB")
+env_array+=("bob.agent.version=$VERSION_FAILED")
+env_array+=("role.faber=$DEFAULT")
+env_array+=("faber.agent.version=$VERSION_FAILED")
+env_array+=("role.mallory=$DEFAULT")
+env_array+=("mallory.agent.version=$VERSION_FAILED")
+printf "%s\n" "${env_array[@]}" > $env_file


### PR DESCRIPTION
It seems that the workflows seem to be succeeding even though building of the agent backchannel images would fail. My suggestion is that if the image building fails, the whole workflow would fail so that the errors could be easily noticed.

Suggested changes:
* fail workflow if image building fails
* run reporting step even though workflow fails
* generate environment file for reporting that indicates failed build

Signed-off-by: Laura Vuorenoja <laura.vuorenoja@op.fi>