### PR TITLE
Reverted to manage run instead of manage test

### DIFF
--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -37,12 +37,8 @@ runs:
       run: ./manage build ${{ inputs.BUILD_AGENTS }}
       shell: bash
       working-directory: test-harness
-    - name: start-harness-agents
-      run: ./manage start ${{ inputs.TEST_AGENTS }}
-      shell: bash
-      working-directory: test-harness
     - name: run-test-harness-acapy
-      run: PROJECT_ID=${{inputs.REPORT_PROJECT}} ./manage test ${{ inputs.TEST_AGENTS }} ${{ inputs.REPORTING }} ${{ inputs.OTHER_PARAMS }} ${{ inputs.TEST_SCOPE }}
+      run: PROJECT_ID=${{inputs.REPORT_PROJECT}} ./manage run ${{ inputs.TEST_AGENTS }} ${{ inputs.REPORTING }} ${{ inputs.OTHER_PARAMS }} ${{ inputs.TEST_SCOPE }}
       shell: bash
       env:
         NO_TTY: "1"


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR reverts the 'manage test' in the run test action to 'manage run'. This is required to properly generate the environment.properties for reporting and interoperability summary processing. We could add this to the `test` command, but it wasn't really the intent of that command to run on nightly builds - There could be other side effects. 

@lauravuo-techlab if this has an effect on the agent log archiving, then we will have to think of another solution. 