### PR TITLE
fix(afj): connection controller after oob

### DIFF
--- a/aries-backchannels/javascript/server/src/controllers/IssueCredentialController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/IssueCredentialController.ts
@@ -99,7 +99,6 @@ export class IssueCredentialController extends BaseController {
       const { id, credentialAttributes } = await CredentialUtils.getCredentialByThreadId(this.agent, threadId)
       credentialRecord = await this.agent.credentials.acceptProposal({
         credentialRecordId: id,
-        protocolVersion: CredentialProtocolVersion.V1,
         credentialFormats: {
           indy: {
             // FIXME: shouldn't be required

--- a/aries-backchannels/javascript/server/src/controllers/MediationController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/MediationController.ts
@@ -4,7 +4,6 @@ import {
   MediationRecord,
   MediationState,
   MediationRole,
-  MediationRepository,
   RoutingEventTypes,
   MediationStateChangedEvent,
 } from '@aries-framework/core'
@@ -58,11 +57,6 @@ export class MediationController extends BaseController {
     }
 
     const mediationRecord = await this.agent.mediationRecipient.requestMediation(connection)
-
-    // FIXME: temporary until https://github.com/hyperledger/aries-framework-javascript/pull/661 is merged
-    mediationRecord.role = MediationRole.Recipient
-    const mediationRepository = this.agent.injectionContainer.resolve(MediationRepository)
-    await mediationRepository.update(mediationRecord)
 
     return this.mapMediationRecord(mediationRecord)
   }

--- a/aries-test-harness/features/steps/0160-connection.py
+++ b/aries-test-harness/features/steps/0160-connection.py
@@ -185,14 +185,6 @@ def step_impl(context, invitee):
         context.invitee_url = invitee_url
         context.invitee_name = invitee
 
-    # get connection and verify status
-    assert expected_agent_state(
-        invitee_url,
-        "connection",
-        context.connection_id_dict[invitee][context.inviter_name],
-        "invited",
-    )
-
 
 @when('"{inviter}" sends a connection response to "{invitee}"')
 @given('"{inviter}" sends a connection response to "{invitee}"')


### PR DESCRIPTION
This updates the AFJ backchannel to resolve the issues from the breaking changes introduced after merging oob/didexchange support. I haven't had time to fully check if everything works, but this should at least fix the issue of AFJ not building at all.

Fixes #497 