### PR TITLE
feat(afj): add v2 credential controller

### DIFF
--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a javascript"
           TEST_AGENTS: "-d acapy-main -b javascript"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211"
           REPORT_PROJECT: acapy-b-javascript
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-afj-acapy.yml
+++ b/.github/workflows/test-harness-afj-acapy.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a javascript -a acapy-main"
           TEST_AGENTS: "-d javascript -b acapy-main"
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection"
           REPORT_PROJECT: javascript-b-acapy
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/javascript/Dockerfile.javascript-branch
+++ b/aries-backchannels/javascript/Dockerfile.javascript-branch
@@ -1,0 +1,56 @@
+FROM ubuntu:18.04 as base
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y && apt-get install -y \
+    software-properties-common \
+    apt-transport-https \
+    curl \
+    git \
+    # Only needed to build indy-sdk
+    build-essential 
+
+# libindy
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
+RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+
+# nodejs
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
+
+# yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# install depdencies
+RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
+    libindy \
+    nodejs
+
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+RUN apt-get install -y --no-install-recommends yarn
+
+FROM base as final
+
+WORKDIR /dependencies
+
+RUN git clone https://github.com/TimoGlastra/aries-framework-javascript && cd aries-framework-javascript && git checkout fix/credential-preview-type && yarn install && yarn build
+
+WORKDIR /src
+ENV RUN_MODE="docker"
+
+COPY javascript/server/package.json package.json
+
+RUN yarn add file:/dependencies/aries-framework-javascript/packages/core
+RUN yarn add file:/dependencies/aries-framework-javascript/packages/node
+
+# Run install after copying only depdendency file
+# to make use of docker layer caching
+RUN yarn install
+
+# Copy other depedencies
+COPY javascript/server .
+COPY javascript/ngrok-wait.sh ./ngrok-wait.sh
+
+# For now we use ts-node. Compiling with typescript
+# doesn't work because indy-sdk types are not exported
+ENTRYPOINT [ "bash", "ngrok-wait.sh"]

--- a/aries-backchannels/javascript/server/src/controllers/IssueCredentialV2Controller.ts
+++ b/aries-backchannels/javascript/server/src/controllers/IssueCredentialV2Controller.ts
@@ -1,0 +1,210 @@
+import { BodyParams, Controller, Get, PathParams, Post } from '@tsed/common'
+import { BadRequest, NotFound } from '@tsed/exceptions'
+import {
+  CredentialEventTypes,
+  CredentialExchangeRecord,
+  CredentialState,
+  CredentialStateChangedEvent,
+  JsonTransformer,
+  V1CredentialPreview,
+} from '@aries-framework/core'
+import { CredentialUtils } from '../utils/CredentialUtils'
+import { filter, firstValueFrom, ReplaySubject, timeout } from 'rxjs'
+import { BaseController } from '../BaseController'
+import { TestHarnessConfig } from '../TestHarnessConfig'
+import { ConnectionUtils } from '../utils/ConnectionUtils'
+
+const afjFormatToAathFormatMapping: Record<string, string> = {
+  indy: 'indy',
+}
+
+@Controller('/agent/command/issue-credential-v2')
+export class IssueCredentialV2Controller extends BaseController {
+  private subject = new ReplaySubject<CredentialStateChangedEvent>()
+
+  public constructor(testHarnessConfig: TestHarnessConfig) {
+    super(testHarnessConfig)
+  }
+
+  public onStartup() {
+    this.subject = new ReplaySubject<CredentialStateChangedEvent>()
+    // Catch all events in replay subject for later use
+    this.agent.events
+      .observable<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged)
+      .subscribe(this.subject)
+  }
+
+  @Get('/:threadId')
+  async getCredentialByThreadId(@PathParams('threadId') threadId: string) {
+    const credential = await CredentialUtils.getCredentialByThreadId(this.agent, threadId)
+    if (!credential) {
+      throw new NotFound(`credential for thead id "${threadId}" not found.`)
+    }
+    return this.mapCredential(credential)
+  }
+
+  @Get('/')
+  async getAllCredentials() {
+    const credentials = await this.agent.credentials.getAll()
+
+    return credentials.map((cred) => this.mapCredential(cred))
+  }
+
+  @Post('/send-proposal')
+  async sendProposal(
+    @BodyParams('data')
+    data: {
+      connection_id: string
+      filter: {
+        indy: {
+          schema_issuer_did?: string
+          issuer_did?: string
+          schema_name?: string
+          cred_def_id?: string
+          schema_version?: string
+          schema_id?: string
+        }
+      }
+      credential_preview: any
+    }
+  ) {
+    const preview = JsonTransformer.fromJSON(data.credential_preview, V1CredentialPreview)
+    const connection = await ConnectionUtils.getConnectionByConnectionIdOrOutOfBandId(this.agent, data.connection_id)
+    const credentialRecord = await this.agent.credentials.proposeCredential({
+      connectionId: connection.id,
+      protocolVersion: 'v2',
+      credentialFormats: {
+        indy: {
+          attributes: preview.attributes,
+          schemaIssuerDid: data.filter.indy.schema_issuer_did,
+          issuerDid: data.filter.indy.issuer_did,
+          schemaName: data.filter.indy.schema_name,
+          credentialDefinitionId: data.filter.indy.cred_def_id,
+          schemaVersion: data.filter.indy.schema_version,
+          schemaId: data.filter.indy.schema_id,
+        },
+      },
+    })
+
+    return this.mapCredential(credentialRecord)
+  }
+
+  @Post('/send-offer')
+  async sendOffer(
+    @BodyParams('id') threadId?: string,
+    @BodyParams('data')
+    data?: {
+      connection_id: string
+      filter: {
+        indy: {
+          schema_issuer_did?: string
+          issuer_did?: string
+          schema_name?: string
+          cred_def_id?: string
+          schema_version?: string
+          schema_id?: string
+        }
+      }
+      credential_preview: any
+    }
+  ) {
+    let credentialRecord: CredentialExchangeRecord
+
+    this.agent.config.logger.info('Sending credential offer', data)
+
+    if (threadId) {
+      await this.waitForState(threadId, CredentialState.ProposalReceived)
+      let credentialRecord = await CredentialUtils.getCredentialByThreadId(this.agent, threadId)
+
+      this.agent.config.logger.info('Replying to credential proposal')
+
+      credentialRecord = await this.agent.credentials.acceptProposal({
+        credentialRecordId: credentialRecord.id,
+      })
+      return this.mapCredential(credentialRecord)
+    } else if (data) {
+      const preview = JsonTransformer.fromJSON(data.credential_preview, V1CredentialPreview)
+      const connection = await ConnectionUtils.getConnectionByConnectionIdOrOutOfBandId(this.agent, data.connection_id)
+
+      if (!data.filter.indy.cred_def_id) {
+        throw new BadRequest('data.filter.indy.cred_def_id is required')
+      }
+
+      credentialRecord = await this.agent.credentials.offerCredential({
+        connectionId: connection.id,
+        protocolVersion: 'v2',
+        credentialFormats: {
+          indy: {
+            attributes: preview.attributes,
+            credentialDefinitionId: data.filter.indy.cred_def_id,
+          },
+        },
+      })
+      return this.mapCredential(credentialRecord)
+    } else {
+      throw new BadRequest(`Missing both id and data properties`)
+    }
+  }
+
+  @Post('/send-request')
+  async sendRequest(@BodyParams('id') threadId: string) {
+    await this.waitForState(threadId, CredentialState.OfferReceived)
+    let { id } = await CredentialUtils.getCredentialByThreadId(this.agent, threadId)
+
+    const credentialRecord = await this.agent.credentials.acceptOffer({
+      credentialRecordId: id,
+    })
+    return this.mapCredential(credentialRecord)
+  }
+
+  @Post('/issue')
+  async acceptRequest(@BodyParams('id') threadId: string, @BodyParams('data') data?: { comment?: string }) {
+    await this.waitForState(threadId, CredentialState.RequestReceived)
+    const { id } = await CredentialUtils.getCredentialByThreadId(this.agent, threadId)
+
+    const credentialRecord = await this.agent.credentials.acceptRequest({
+      credentialRecordId: id,
+      comment: data?.comment,
+    })
+    return this.mapCredential(credentialRecord)
+  }
+
+  @Post('/store')
+  async storeCredential(@BodyParams('id') threadId: string) {
+    await this.waitForState(threadId, CredentialState.CredentialReceived)
+    let { id } = await CredentialUtils.getCredentialByThreadId(this.agent, threadId)
+    const credentialRecord = await this.agent.credentials.acceptCredential({ credentialRecordId: id })
+
+    return this.mapCredential(credentialRecord)
+  }
+
+  private async waitForState(threadId: string, state: CredentialState) {
+    return await firstValueFrom(
+      this.subject.pipe(
+        filter((c) => c.payload.credentialRecord.threadId === threadId),
+        filter((c) => c.payload.credentialRecord.state === state),
+        timeout(20000)
+      )
+    )
+  }
+
+  private mapCredential(credentialRecord: CredentialExchangeRecord) {
+    let returnModel = {
+      state: credentialRecord.state,
+      thread_id: credentialRecord.threadId,
+    }
+
+    for (const credential of credentialRecord.credentials) {
+      const key = afjFormatToAathFormatMapping[credential.credentialRecordType]
+
+      returnModel = {
+        ...returnModel,
+        [key]: {
+          credential_id: credential.credentialRecordId,
+        },
+      }
+    }
+
+    return returnModel
+  }
+}

--- a/aries-test-harness/features/0453-issue-credential-v2.feature
+++ b/aries-test-harness/features/0453-issue-credential-v2.feature
@@ -1,7 +1,7 @@
 @RFC0453 @AIP20
 Feature: RFC 0453 Aries Agent Issue Credential v2
 
-  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_Indy @Schema_DriversLicense_v2
+  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @CredFormat_Indy @Schema_DriversLicense_v2
   Scenario Outline: Issue a Indy credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
@@ -17,6 +17,12 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
     And "Bob" acknowledges the "indy" credential issue
     Then "Bob" has the "indy" credential issued
 
+    @RFC0160
+    Examples:
+      | credential_data   |
+      | Data_DL_MaxValues |
+
+    @DIDExchangeConnection
     Examples:
       | credential_data   |
       | Data_DL_MaxValues |

--- a/docs/assets/openapi-spec.yml
+++ b/docs/assets/openapi-spec.yml
@@ -819,6 +819,27 @@ paths:
                       state:
                         example: done
 
+  /agent/command/issue-credential-v2/{credentialExchangeThreadId}:
+    get:
+      tags:
+        - Issue Credential V2
+      summary: Get credential exchange v2 record by thread id
+      operationId: IssueCredentialV2GetByThreadId
+      parameters:
+        - in: path
+          name: credentialExchangeThreadId
+          required: true
+          schema:
+            $ref: "#/components/schemas/ThreadId"
+      responses:
+        200:
+          description: Credential Exchange v2
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IssueCredentialOperationResponse"
+        404:
+          description: Credential exchange record not found
   /agent/command/issue-credential-v2/prepare-json-ld:
     post:
       tags:
@@ -3054,36 +3075,19 @@ components:
         }
     IssueCredentialV2AttachFormatIndyCredFilter:
       type: object
-      example:
-        {
-          "credential":
-            {
-              "@context":
-                [
-                  "https://www.w3.org/2018/credentials/v1",
-                  "https://w3id.org/security/bbs/v1",
-                  {
-                    "dl": "http://example.com/drivers-license#",
-                    "AATHDriversLicense": "dl:AATHDriversLicense",
-                    "address": "dl:address",
-                    "DL_number": "dl:DL_number",
-                    "expiry": "dl:expiry",
-                    "age": "dl:age",
-                  },
-                ],
-              "type": ["VerifiableCredential", "AATHDriversLicense"],
-              "issuer": "did:key:z6MkfZfsiVsAy6CgQht7vQVk1dWBnztivjbhxRiKTtTi62PB",
-              "issuanceDate": "2010-01-01T19:73:24Z",
-              "credentialSubject":
-                {
-                  "address": "947 this street, Kingston Ontario Canada, K9O 3R5",
-                  "DL_number": "09385029529385",
-                  "expiry": "10/12/2022",
-                  "age": "30",
-                },
-            },
-          "options": { "proofType": "Ed25519Signature2018" },
-        }
+      properties:
+        schema_issuer_did:
+          $ref: "#/components/schemas/Did"
+        schema_id:
+          $ref: "#/components/schemas/SchemaId"
+        schema_name:
+          $ref: "#/components/schemas/SchemaName"
+        schema_version:
+          $ref: "#/components/schemas/SchemaVersion"
+        cred_def_id:
+          $ref: "#/components/schemas/CredentialDefinitionId"
+        issuer_did:
+          $ref: "#/components/schemas/Did"
     IssueCredentialV2CredentialProposalFilter:
       title: Issue Credential V2 Credential Proposal Filter
       properties:


### PR DESCRIPTION
Add issue credential v2 tests for AFJ and also adds tests for ICv2 interop between AFJ <-> ACA-Py.

Had to extend the ICv2 tests a bit to support using 0160 connections as we don't have didexchange tests yet