### PR TITLE
Temporary fix to lock the acapy-resolver to a specific version to enable building the acapy-main test agent

### DIFF
--- a/aries-backchannels/acapy/requirements-main.txt
+++ b/aries-backchannels/acapy/requirements-main.txt
@@ -1,2 +1,2 @@
 aries-cloudagent[indy, bbs, askar]@git+https://github.com/hyperledger/aries-cloudagent-python@main
-acapy-resolver-universal@git+https://github.com/sicpa-dlab/acapy-resolver-universal.git@main
+acapy-resolver-universal@git+https://github.com/sicpa-dlab/acapy-resolver-universal.git@260aab1fe5c1d709b927dfea8973ab2d859c8002


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>
