### PR TITLE
[#530] Incorrect tests query results for specific AIP or RFC

### DIFF
--- a/aries-test-harness/features/0023-did-exchange.feature
+++ b/aries-test-harness/features/0023-did-exchange.feature
@@ -5,7 +5,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
    I want to use DID Exchange(RFC0023) and Out of Band(RFC0434) protocols to accomplish this.
 
 
-   @T001-RFC0023 @critical @AcceptanceTest
+   @T001-RFC0023 @RFC0023 @AIP20 @critical @AcceptanceTest
    Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation
       Given we have "2" agents
          | name | role      |
@@ -23,7 +23,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
    #@T002-RFC0023 @critical @AcceptanceTest @Deprecated
    #Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with role reversal
 
-   @T003-RFC0023 @normal @AcceptanceTest
+   @T003-RFC0023 @RFC0023 @AIP20 @normal @AcceptanceTest
    Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with a public DID
       Given we have "2" agents
          | name | role      |
@@ -41,7 +41,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
    #@T004-RFC0023 @normal @AcceptanceTest @Deprecated
    #Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation with a public DID with role reversal
 
-   @T005-RFC0023 @critical @AcceptanceTest
+   @T005-RFC0023 @RFC0023 @AIP20 @critical @AcceptanceTest
    Scenario: Establish a connection with DID Exchange between two agents with an implicit invitation
       Given we have "2" agents
          | name | role      |
@@ -61,7 +61,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
 
    # This test will give an expected failure when running with Aca-py with the --auto-accept-requests & --auto-respond-messages options.
    # Do not run this test with those flags on. It may also fail for other agents that do auto_responding depending on how the backchannel is implmented.
-   @T007-RFC0023 @normal @AcceptanceTest @NegativeTest @ExceptionTest
+   @T007-RFC0023 @RFC0023 @AIP20 @normal @AcceptanceTest @NegativeTest @ExceptionTest
    Scenario: Establish a connection with DID Exchange between two agents with attempt to continue after protocol is completed
       Given we have "2" agents
          | name | role      |
@@ -77,7 +77,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Bob" sends a response to "Acme" which produces a problem_report
       Then "Acme" and "Bob" still have a completed connection
 
-   @T008-RFC0023 @normal @AcceptanceTest @ExceptionTest @wip
+   @T008-RFC0023 @RFC0023 @AIP20 @normal @AcceptanceTest @ExceptionTest @wip
    Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation but invitation is rejected and connection process restarted
       Given we have "2" agents
          | name | role      |
@@ -89,7 +89,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Acme" restarts the connection process
       Then a successful connection can be established between "Acme" and "Bob"
 
-   @T009-RFC0023 @normal @AcceptanceTest @ExceptionTest @wip
+   @T009-RFC0023 @RFC0023 @AIP20 @normal @AcceptanceTest @ExceptionTest @wip
    Scenario: Establish a connection with DID Exchange between two agents with an explicit invitation but invitation is rejected and connection process abandoned
       Given we have "2" agents
          | name | role      |
@@ -101,7 +101,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
       And "Acme" abandons the connection process
       Then a connection can be established between "Acme" and "Bob" given that invitation
 
-   @T010-RFC0023 @normal @AcceptanceTest @ExceptionTest @NegativeTest @wip
+   @T010-RFC0023 @RFC0023 @AIP20 @normal @AcceptanceTest @ExceptionTest @NegativeTest @wip
    Scenario Outline: Establish a connection with DID Exchange and responder rejects the request
       Given we have "2" agents
          | name | role      |
@@ -126,7 +126,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
          | Missing reference to invitation         |
          | unknown processing error                |
 
-   @T011-RFC0023 @normal @AcceptanceTest @ExceptionTest @NegativeTest @wip
+   @T011-RFC0023 @RFC0023 @AIP20 @normal @AcceptanceTest @ExceptionTest @NegativeTest @wip
    Scenario Outline: Establish a connection with DID Exchange and requester rejects the response
       Given we have "2" agents
          | name | role      |
@@ -153,7 +153,7 @@ Feature: RFC 0023 Establishing Connections with DID Exchange
          | Invalid signature                       |
          | unknown processing error                |
 
-   @T012-RFC0023 @normal @DerivedFunctionalTest @wip
+   @T012-RFC0023 @RFC0023 @AIP20 @normal @DerivedFunctionalTest @wip
    Scenario: Attempt to Establish a connection with DID Exchange between two agents with an explicit invitation with connection reuse
       Given we have "2" agents
          | name | role      |

--- a/aries-test-harness/features/0025-didcomm-transports.feature
+++ b/aries-test-harness/features/0025-didcomm-transports.feature
@@ -1,10 +1,10 @@
-@RFC0025 @UsesCustomParameters @AIP10 @AIP20
+@RFC0025 @AIP10 @AIP20 @UsesCustomParameters
 Feature: RFC 0025 DIDComm Transports
   In order to communicate with other agents,
   As an Agent
   I want to create connections using different transport protocols.
 
-  @T001-RFC0025 @AcceptanceTest @DIDExchangeConnection
+  @T001-RFC0025 @RFC0025 @AIP10 @AIP20 @AcceptanceTest @DIDExchangeConnection
   Scenario Outline: Create DIDExchange connection between two agents with overlapping transports
     Given we have "2" agents
       | name | role      |
@@ -46,7 +46,7 @@ Feature: RFC 0025 DIDComm Transports
       | ["http"]                | ["ws", "http"]           | ["ws"]                 | ["ws", "http"]          |
       | ["ws"]                  | ["ws", "http"]           | ["http"]               | ["ws", "http"]          |
 
-  @T002-RFC0025 @AcceptanceTest @RFC0160
+  @T002-RFC0025 @RFC0025 @AIP10 @AIP20 @AcceptanceTest @RFC0160
   Scenario Outline: Create 0160 connection between two agents with overlapping transports
     Given we have "2" agents
       | name | role    |
@@ -88,7 +88,7 @@ Feature: RFC 0025 DIDComm Transports
       | ["http"]                | ["ws", "http"]           | ["ws"]                 | ["ws", "http"]          |
       | ["ws"]                  | ["ws", "http"]           | ["http"]               | ["ws", "http"]          |
 
-  @T003-RFC0025 @ExceptionTest @minor @DIDExchangeConnection
+  @T003-RFC0025 @RFC0025 @AIP10 @AIP20 @ExceptionTest @minor @DIDExchangeConnection
   Scenario Outline: Fail creating a connection between two agents that have mismatching transports configured
     Given we have "2" agents
       | name | role      |

--- a/aries-test-harness/features/0036-issue-credential.feature
+++ b/aries-test-harness/features/0036-issue-credential.feature
@@ -1,11 +1,11 @@
- @RFC0036
+@RFC0036
 Feature: RFC 0036 Aries agent issue credential
 
   Background: create a schema and credential definition in order to issue a credential
     Given "Acme" has a public did
     And "Acme" is ready to issue a credential
 
-  @T001-RFC0036 @AIP10 @critical @AcceptanceTest @Indy
+  @T001-RFC0036 @RFC0036 @AIP10 @critical @AcceptanceTest @Indy
   Scenario: Issue a credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
@@ -19,7 +19,7 @@ Feature: RFC 0036 Aries agent issue credential
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T001.1-RFC0036 @AIP20 @critical @AcceptanceTest @Indy @DIDExchangeConnection
+  @T001.1-RFC0036 @RFC0036 @AIP20 @critical @AcceptanceTest @Indy @DIDExchangeConnection
   Scenario: Issue a credential with the Holder beginning with a proposal with DID Exchange Connection
     Given "2" agents
       | name | role   |
@@ -33,7 +33,7 @@ Feature: RFC 0036 Aries agent issue credential
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T002-RFC0036 @AIP10 @normal @AcceptanceTest @Indy
+  @T002-RFC0036 @RFC0036 @AIP10 @normal @AcceptanceTest @Indy
   Scenario: Issue a credential with the Holder beginning with a proposal with negotiation
     Given "2" agents
       | name | role   |
@@ -49,7 +49,7 @@ Feature: RFC 0036 Aries agent issue credential
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T003-RFC0036 @AIP10 @critical @AcceptanceTest @Indy @MobileTest
+  @T003-RFC0036 @RFC0036 @AIP10 @critical @AcceptanceTest @Indy @MobileTest
   Scenario: Issue a credential with the Issuer beginning with an offer
     Given "2" agents
       | name | role   |
@@ -62,7 +62,7 @@ Feature: RFC 0036 Aries agent issue credential
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T004-RFC0036 @AIP10 @normal @AcceptanceTest @Indy
+  @T004-RFC0036 @RFC0036 @AIP10 @normal @AcceptanceTest @Indy
   Scenario: Issue a credential with the Issuer beginning with an offer with negotiation
     Given "2" agents
       | name | role   |
@@ -77,7 +77,7 @@ Feature: RFC 0036 Aries agent issue credential
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T005-RFC0036 @AIP10 @minor @wip @AcceptanceTest
+  @T005-RFC0036 @RFC0036 @AIP10 @minor @wip @AcceptanceTest
   Scenario: Issue a credential with negotiation beginning from a credential request
     Given "2" agents
       | name | role   |
@@ -92,7 +92,7 @@ Feature: RFC 0036 Aries agent issue credential
     And "Bob" acknowledges the credential issue
     Then "Bob" has the credential issued
 
-  @T006-RFC0036 @AIP10 @critical @wip @AcceptanceTest
+  @T006-RFC0036 @RFC0036 @AIP10 @critical @wip @AcceptanceTest
   Scenario: Issue a credential with the Holder beginning with a request and is accepted
     Given "2" agents
       | name | role   |

--- a/aries-test-harness/features/0037-present-proof.feature
+++ b/aries-test-harness/features/0037-present-proof.feature
@@ -1,7 +1,7 @@
 @RFC0037
 Feature: RFC 0037 Aries agent present proof
 
-   @T001-RFC0037 @AIP10 @critical @AcceptanceTest @Indy
+   @T001-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @Indy
    Scenario Outline: Present Proof where the prover does not propose a presentation of the proof and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -19,7 +19,7 @@ Feature: RFC 0037 Aries agent present proof
          | Acme   |
          | Faber  |
 
-   @T001.1-RFC0037 @AIP20 @critical @AcceptanceTest @Indy @DIDExchangeConnection
+   @T001.1-RFC0037 @RFC0037 @AIP20 @critical @AcceptanceTest @Indy @DIDExchangeConnection
    Scenario Outline: Present Proof where the prover does not propose a presentation of the proof and is acknowledged with a DID Exchange Connection
       Given "2" agents
          | name  | role     |
@@ -37,7 +37,7 @@ Feature: RFC 0037 Aries agent present proof
          | Acme   |
          | Faber  |
 
-   @T001.2-RFC0037 @AIP10 @critical @AcceptanceTest @Schema_DriversLicense @Indy
+   @T001.2-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @Schema_DriversLicense @Indy
    Scenario Outline: Present Proof of specific types and proof is acknowledged with a Drivers License credential type
       Given "2" agents
          | name  | role     |
@@ -56,7 +56,7 @@ Feature: RFC 0037 Aries agent present proof
          | Faber  | Data_DL_MinValues | proof_request_DL_age_over_19 | presentation_DL_age_over_19 |
 
 
-   @T001.3-RFC0037 @AIP10 @critical @AcceptanceTest @Schema_Biological_Indicators @Indy
+   @T001.3-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @Schema_Biological_Indicators @Indy
    Scenario Outline: Present Proof of specific types and proof is acknowledged with a Biological Indicators credential type
       Given "2" agents
          | name  | role     |
@@ -73,7 +73,7 @@ Feature: RFC 0037 Aries agent present proof
          | issuer | credential_data          | request for proof                    | presentation                        |
          | Acme   | Data_BI_NormalizedValues | proof_request_biological_indicator_a | presentation_biological_indicator_a |
 
-   @T001.4-RFC0037 @AIP10 @critical @AcceptanceTest @Schema_Biological_Indicators @Schema_Health_Consent @Indy
+   @T001.4-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @Schema_Biological_Indicators @Schema_Health_Consent @Indy
    Scenario Outline: Present Proof of specific types and proof is acknowledged with multiple credential types
       Given "2" agents
          | name  | role     |
@@ -91,7 +91,7 @@ Feature: RFC 0037 Aries agent present proof
          | Faber  | Data_BI_HealthValues | proof_request_health_consent | presentation_health_consent |
 
 
-   @T001.5-RFC0037 @AIP10 @critical @AcceptanceTest @MobileTest
+   @T001.5-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @MobileTest
    Scenario Outline: Present Proof where the prover does not propose a presentation of the proof and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -109,7 +109,7 @@ Feature: RFC 0037 Aries agent present proof
          | Acme   |
          | Faber  |
 
-   @T003-RFC0037 @AIP10 @critical @AcceptanceTest @Schema_DriversLicense @Indy @ProofProposal
+   @T003-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @Schema_DriversLicense @Indy @ProofProposal
    Scenario Outline: Present Proof where the prover has proposed the presentation of proof in response to a presentation request and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -130,7 +130,7 @@ Feature: RFC 0037 Aries agent present proof
          | Faber  | Data_DL_MinValues | proof_request_DL_age_over_19 | proposal_DL_address     | proof_request_DL_address         | presentation_DL_address     |
 
 
-   @T003.1-RFC0037 @AIP10 @critical @AcceptanceTest @Schema_DriversLicense @Schema_Health_ID @Indy @ProofProposal
+   @T003.1-RFC0037 @RFC0037 @AIP10 @critical @AcceptanceTest @Schema_DriversLicense @Schema_Health_ID @Indy @ProofProposal
    Scenario Outline: Present Proof where the prover has proposed the presentation of proof from a different credential in response to a presentation request and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -151,7 +151,7 @@ Feature: RFC 0037 Aries agent present proof
          | Faber  | Data_HealthID_NormalizedValues | proof_request_Health_ID_Num | proposal_DL_address    | proof_request_DL_address         | presentation_DL_address    |
 
    # See issue #90 for when work on this test will resume - https://app.zenhub.com/workspaces/von---verifiable-organization-network-5adf53987ccbaa70597dbec0/issues/bcgov/aries-agent-test-harness/90
-   @T004-RFC0037 @AIP10 @wip @critical @AcceptanceTest @NeedsReview
+   @T004-RFC0037 @RFC0037 @AIP10 @wip @critical @AcceptanceTest @NeedsReview
    Scenario Outline: Present Proof where the verifier and prover are connectionless, prover has proposed the presentation of proof, and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -171,7 +171,7 @@ Feature: RFC 0037 Aries agent present proof
          | Acme   |
          | Faber  |
 
-   @T005-RFC0037 @AIP10 @wip @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense @Indy @NeedsReview
+   @T005-RFC0037 @RFC0037 @AIP10 @wip @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense @Indy @NeedsReview
    Scenario Outline: Present Proof where the verifier rejects the presentation of the proof
       Given "2" agents
          | name  | role     |
@@ -188,7 +188,7 @@ Feature: RFC 0037 Aries agent present proof
          | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_incorrect_address |
 
 
-   @T006-RFC0037 @AIP10 @minor @AcceptanceTest @Schema_Health_ID @Indy @ProofProposal
+   @T006-RFC0037 @RFC0037 @AIP10 @minor @AcceptanceTest @Schema_Health_ID @Indy @ProofProposal
    Scenario Outline: Present Proof where the prover starts with a proposal the presentation of proof and is acknowledged
       Given "2" agents
          | name  | role     |

--- a/aries-test-harness/features/0044-mime-types.feature
+++ b/aries-test-harness/features/0044-mime-types.feature
@@ -1,7 +1,7 @@
 @RFC0044 @AIP20 @UsesCustomParameters
 Feature: RFC0044 didcomm mime types
 
-   @T001-RFC0044
+   @T001-RFC0044 @RFC0044 @AIP20
    Scenario Outline: Perform DID Exchange between two agents that have the same default envelope media profile
       Given we have "2" agents
          | name | role      |
@@ -23,7 +23,7 @@ Feature: RFC0044 didcomm mime types
          | "didcomm/aip2;env=rfc19"  |
          | "didcomm/aip2;env=rfc587" |
 
-   @T002-RFC0044
+   @T002-RFC0044 @RFC0044 @AIP20
    Scenario Outline: Perform DID Exchange between two permissive agents that have different default envelope media profiles
       Given we have "2" agents
          | name | role      |
@@ -45,7 +45,7 @@ Feature: RFC0044 didcomm mime types
          | "didcomm/aip2;env=rfc19"  | "didcomm/aip2;env=rfc587" |
          | "didcomm/aip2;env=rfc587" | "didcomm/aip2;env=rfc19"  |
 
-   @T003-RFC0044 @ExceptionTest
+   @T003-RFC0044 @RFC0044 @AIP20 @ExceptionTest
    Scenario Outline: Fail DID Exchange between two agents with mismatching media profiles
       Given we have "2" agents
          | name | role      |
@@ -61,7 +61,7 @@ Feature: RFC0044 didcomm mime types
          | "didcomm/aip2;env=rfc19"  | "didcomm/aip2;env=rfc587" |
          | "didcomm/aip2;env=rfc587" | "didcomm/aip2;env=rfc19"  |
 
-   @T004-RFC0044
+   @T004-RFC0044 @RFC0044 @AIP20
    Scenario Outline: Perform DID Exchange with OOB media type handshake, with one accept parameter
       Given we have "2" agents
          | name | role      |
@@ -83,7 +83,7 @@ Feature: RFC0044 didcomm mime types
          | "didcomm/aip2;env=rfc19"  | "didcomm/aip2;env=rfc587" |
          | "didcomm/aip2;env=rfc587" | "didcomm/aip2;env=rfc19"  |
 
-   @T005-RFC0044
+   @T005-RFC0044 @RFC0044 @AIP20
    Scenario Outline: Perform DID Exchange with OOB media type handshake, with two accept parameters
       Given we have "2" agents
          | name | role      |
@@ -105,7 +105,7 @@ Feature: RFC0044 didcomm mime types
          | "didcomm/aip2;env=rfc19"  | "didcomm/aip2;env=rfc587" |
          | "didcomm/aip2;env=rfc587" | "didcomm/aip2;env=rfc19"  |
 
-   @T006-RFC0044 @ExceptionTest
+   @T006-RFC0044 @RFC0044 @AIP20 @ExceptionTest
    Scenario Outline: Fail DID Exchange between two agents with explicit oob accept parameter, with no matching profiles
       Given we have "2" agents
          | name | role      |

--- a/aries-test-harness/features/0160-connection.feature
+++ b/aries-test-harness/features/0160-connection.feature
@@ -1,7 +1,7 @@
 @RFC0160 @AIP10
 Feature: RFC 0160 Aries agent connection functions
 
-   @T001-RFC0160 @critical @AcceptanceTest @MobileTest
+   @T001-RFC0160 @RFC0160 @AIP10 @critical @AcceptanceTest @MobileTest
    Scenario Outline: establish a connection between two agents
       Given we have "2" agents
          | name  | role    |
@@ -26,7 +26,7 @@ Feature: RFC 0160 Aries agent connection functions
    #@T001.2-RFC0160 @critical @AcceptanceTest @Deprecated
    #Scenario Outline: establish a connection between two agents with role reversal
 
-   @T002-RFC0160 @critical @AcceptanceTest
+   @T002-RFC0160 @RFC0160 @AIP10 @critical @AcceptanceTest
    Scenario Outline: Connection established between two agents but inviter sends next message to establish full connection state
       Given we have "2" agents
          | name  | role    |
@@ -48,7 +48,7 @@ Feature: RFC 0160 Aries agent connection functions
                         # implemented trustping which is not part of the AIP 1.0. The acks is removed here in favor of trustping until the RFC is changed or
                         # the agents under test implement acks.
 
-   @T003-RFC0160 @normal @SingleUseInvite @ExceptionTest @allure.issue:https://github.com/hyperledger/aries-cloudagent-python/issues/418
+   @T003-RFC0160 @RFC0160 @AIP10 @normal @SingleUseInvite @ExceptionTest @allure.issue:https://github.com/hyperledger/aries-cloudagent-python/issues/418
    Scenario: Inviter Sends invitation for one agent second agent tries after connection
       Given we have "3" agents
          | name    | role              |
@@ -65,7 +65,7 @@ Feature: RFC 0160 Aries agent connection functions
       When "Mallory" sends a connection request to "Acme" based on the connection invitation
       Then "Acme" sends a request_not_accepted error
 
-   @T004-RFC0160 @normal @SingleUseInvite @ExceptionTest @allure.issue:https://github.com/hyperledger/aries-cloudagent-python/issues/418
+   @T004-RFC0160 @RFC0160 @AIP10 @normal @SingleUseInvite @ExceptionTest @allure.issue:https://github.com/hyperledger/aries-cloudagent-python/issues/418
    Scenario: Inviter Sends invitation for one agent second agent tries during first share phase
       Given we have "3" agents
          | name    | role              |
@@ -78,7 +78,7 @@ Feature: RFC 0160 Aries agent connection functions
       When "Mallory" sends a connection request to "Acme" based on the connection invitation
       Then "Acme" sends a request_not_accepted error
 
-   @T005-RFC0160 @wip @minor @MultiUseInvite @DerivedFunctionalTest @NeedsReview
+   @T005-RFC0160 @RFC0160 @AIP10 @wip @minor @MultiUseInvite @DerivedFunctionalTest @NeedsReview
    Scenario: Inviter Sends invitation for multiple agents
       Given we have "3" agents
          | name    | role              |
@@ -95,7 +95,7 @@ Feature: RFC 0160 Aries agent connection functions
    #And "Acme" and "Bob" are able to complete the connection
    #And "Acme" and "Mallory" are able to complete the connection
 
-   @T006-RFC0160 @trivial @DerivedFunctionalTest
+   @T006-RFC0160 @RFC0160 @AIP10 @trivial @DerivedFunctionalTest
    Scenario: Establish a connection between two agents who already have a connection initiated from invitee
       Given we have "2" agents
          | name  | role    |
@@ -106,7 +106,7 @@ Feature: RFC 0160 Aries agent connection functions
       And "Bob" and "Acme" complete the connection process
       Then "Acme" and "Bob" have another connection
 
-   @T007-RFC0160 @wip @normal @ExceptionTest @SingleTryOnException @NeedsReview
+   @T007-RFC0160 @RFC0160 @AIP10 @wip @normal @ExceptionTest @SingleTryOnException @NeedsReview
    Scenario Outline: Establish a connection between two agents but gets a request not accepted report problem message
       Given we have "2" agents
          | name  | role    |

--- a/aries-test-harness/features/0183-revocation.feature
+++ b/aries-test-harness/features/0183-revocation.feature
@@ -1,11 +1,11 @@
-@revocation @AIP20
+@RFC0183 @AIP20 @revocation
 Feature: RFC 0183 Aries agent credential revocation and revocation notification
 
    Background: create a schema and credential definition in order to issue a credential
       Given "Acme" has a public did
       And "Acme" is ready to issue a credential
 
-   @T001-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
+   @T001-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked
       Given "2" agents
          | name  | role     |
@@ -23,7 +23,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T001.1-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @DIDExchangeConnection @RFC0441
+   @T001.1-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @DIDExchangeConnection @RFC0441
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked with a DID Exchange connection
       Given "2" agents
          | name  | role     |
@@ -41,7 +41,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T001.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @RFC0441
+   @T001.2-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @RFC0441
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked
       Given "2" agents
          | name  | role     |
@@ -59,7 +59,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T002-HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
+   @T002-HIPE0011 @RFC0183 @AIP20 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with timesstamp
       Given "2" agents
          | name  | role     |
@@ -78,7 +78,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | new_credential_data | timeframe | request_for_proof              | presentation                       |
          | Acme   | Data_DL_MinValues | Data_DL_MaxValues   | now:now   | proof_request_DL_revoc_address | presentation_DL_revoc_address_w_ts |
 
-   @T002.1-HIPE0011 @normal @wip @NegativeTest @AcceptanceTest @Schema_Health_Consent_Revoc @Indy
+   @T002.1-HIPE0011 @RFC0183 @AIP20 @normal @wip @NegativeTest @AcceptanceTest @Schema_Health_Consent_Revoc @Indy
    Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with no timestamp
       Given "2" agents
          | name  | role     |
@@ -97,7 +97,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data      | new_credential_data          | request_for_proof                         | presentation                             |
          | Acme   | Data_BI_HealthValues | Data_BI_HealthValues_Reissue | proof_request_health_consent_revoc_expiry | presentation_health_consent_revoc_expiry |
 
-   @T003-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
+   @T003-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Proof in process while Issuer revokes credential before presentation and the verifier doesn't care about revocation status
       Given "2" agents
          | name  | role     |
@@ -115,7 +115,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T004-HIPE0011 @normal @wip @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy @delete_cred_from_wallet
+   @T004-HIPE0011 @RFC0183 @AIP20 @normal @wip @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy @delete_cred_from_wallet
    Scenario Outline: Credential revoked and replaced with a new updated credential, get possible credentials from agent wallet
       Given "2" agents
          | name  | role     |
@@ -134,7 +134,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | new_credential_data | timeframe | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MinValues | Data_DL_MaxValues   | now:now   | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T005-HIPE0011 @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy
+   @T005-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy
    Scenario Outline: Credential is revoked inside the non-revocation interval
       Given "2" agents
          | name  | role     |
@@ -154,7 +154,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MinValues | -604800:now     | proof_request_DL_revoc_address | presentation_DL_revoc_address |
          | Acme   | Data_DL_MinValues | -604800:+604800 | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T006-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
+   @T006-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Credential is revoked before the non-revocation instant
       Given "2" agents
          | name  | role     |
@@ -175,7 +175,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MinValues | +604800:+604800 | proof_request_DL_revoc_address | presentation_DL_revoc_address |
          | Acme   | Data_DL_MinValues | -1:-1           | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T006.1-HIPE0011 @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy
+   @T006.1-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @ExceptionTest @Schema_DriversLicense_Revoc @Indy
    Scenario Outline: Credential is revoked before the non-revocation interval
       Given "2" agents
          | name  | role     |
@@ -194,7 +194,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MaxValues | 0:+86400   | proof_request_DL_revoc_address | presentation_DL_revoc_address |
          | Acme   | Data_DL_MinValues | -1:+604800 | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T006.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @RFC0441
+   @T006.2-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @RFC0441
    Scenario Outline: Credential is revoked before the non-revocation instant
       Given "2" agents
          | name  | role     |
@@ -216,7 +216,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MinValues | -1:-1           | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
-   @T007-HIPE0011 @normal @wip @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
+   @T007-HIPE0011 @RFC0183 @AIP20 @normal @wip @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
    Scenario Outline: Credential is revoked after the non-revocation instant
       Given "2" agents
          | name  | role     |
@@ -236,7 +236,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MaxValues | -604800:-604800 | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
-   @T008-HIPE0011 @normal @wip @DerivedTest @Schema_DriversLicense_Revoc @Indy
+   @T008-HIPE0011 @RFC0183 @AIP20 @normal @wip @DerivedTest @Schema_DriversLicense_Revoc @Indy
    Scenario Outline: Credential is revoked during a timeframe with an open ended FROM or TO date
       Given "2" agents
          | name  | role     |
@@ -256,7 +256,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MinValues | now:      | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
-   @T009-HIPE0011 @wip @DerivedTest @NegativeTest @Schema_DriversLicense_Revoc @NeedsReview
+   @T009-HIPE0011 @RFC0183 @AIP20 @wip @DerivedTest @NegativeTest @Schema_DriversLicense_Revoc @NeedsReview
    Scenario Outline: Revoke attempt be done by the holder or a verifier
       Given "3" agents
          | name  | role     |
@@ -275,7 +275,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MaxValues | verifier | proof_request_DL_address | presentation_DL_address |
 
 
-   @T010-HIPE0011 @wip @DerivedTest @NegativeTest @Schema_DriversLicense @NeedsReview
+   @T010-HIPE0011 @RFC0183 @AIP20 @wip @DerivedTest @NegativeTest @Schema_DriversLicense @NeedsReview
    Scenario Outline: Attempt to revoke an unrevokable credential.
       Given "3" agents
          | name  | role     |
@@ -293,7 +293,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MinValues | proof_request_DL_address | presentation_DL_address |
 
 
-   @T011-HIPE0011 @wip @AcceptanceTest @Schema_DriversLicense_Revoc @NeedsReview
+   @T011-HIPE0011 @RFC0183 @AIP20 @wip @AcceptanceTest @Schema_DriversLicense_Revoc @NeedsReview
    Scenario Outline: Issuer revokes multiple credentials in the same transaction
       Given "3" agents
          | name  | role     |
@@ -312,7 +312,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof        | presentation            |
          | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_address |
 
-   @T012-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @RFC0441
+   @T012-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @RFC0441
    Scenario Outline: Revocable Credential not revoked and Holder attempts to prove without a non-revocation interval
       Given "2" agents
          | name  | role     |
@@ -329,7 +329,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   @T013-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense @Indy @RFC0441
+   @T013-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense @Indy @RFC0441
    Scenario Outline: Non-revocable Credential, not revoked, and holder proves claims with the credential with timesstamp
       Given "2" agents
          | name  | role     |
@@ -346,7 +346,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | timeframe | request_for_proof        | presentation                 |
          | Acme   | Data_DL_MinValues | now:now   | proof_request_DL_address | presentation_DL_address_w_ts |
 
-   @T014-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
+   @T014-HIPE0011 @RFC0183 @AIP20 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Revocable Credential, not revoked, and holder proves claims with the credential with timesstamp
       Given "2" agents
          | name  | role     |
@@ -364,7 +364,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MinValues | now:now   | proof_request_DL_revoc_address | presentation_DL_revoc_address_w_ts |
 
 
-   @T001-RFC0183 @RFC0183 @HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @RFC0441
+   @T001-RFC0183 @RFC0183 @AIP20 @HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @RFC0441
    Scenario Outline: Issuer revokes a credential and sends a v1 revocation notification
       Given "2" agents
          | name  | role     |

--- a/aries-test-harness/features/0211-coordinate-mediation.feature
+++ b/aries-test-harness/features/0211-coordinate-mediation.feature
@@ -4,7 +4,7 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
   As a recipient,
   I want to use the Coordinate Mediation (RFC0211) protocol to accomplish this.
 
-  @T001-RFC0211 @critical @AcceptanceTest
+  @T001-RFC0211 @RFC0211 @AIP20 @critical @AcceptanceTest
   Scenario Outline: Request mediation with the mediator accepting the mediation request
     Given we have "2" agents
       | name | role      |
@@ -25,7 +25,7 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
       | connection |
       | 0160       |
 
-  @T002-RFC0211 @critical @AcceptanceTest
+  @T002-RFC0211 @RFC0211 @AIP20 @critical @AcceptanceTest
   Scenario Outline: Request mediation with the mediator accepting the mediation request and creating a connection using the mediator
     Given we have "2" agents
       | name  | role      |
@@ -52,7 +52,7 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
   # For agents without an endpoint to request mediation, the mediation needs to be automatically granted using return routing
   # Otherwise the mediator agent has no endpoint to send the mediation grant message to. However this means we can't test for
   # mediation deny, as the grant is automatically send. For now testing agents without inbound endpoint is more important
-  @T003-RFC0211 @critical @AcceptanceTest @wip
+  @T003-RFC0211 @RFC0211 @AIP20 @critical @AcceptanceTest @wip
   Scenario Outline: Request mediation with the mediator denying the mediation request
     Given we have "2" agents
       | name | role      |
@@ -73,7 +73,7 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
       | connection |
       | 0160       |
 
-  @T004-RFC0211 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @normal @AcceptanceTest
+  @T004-RFC0211 @RFC0211 @AIP20 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @normal @AcceptanceTest
   Scenario Outline: Two agents creating a connection using a mediator without having inbound transports
     Given we have "2" agents
       | name  | role      |
@@ -111,7 +111,7 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
       | []                      | ["ws", "http"]           | ["ws", "http"]         | ["ws", "http"]          | []                       | ["ws", "http"]            |
 
   # Not all agents support being started without inbound transports. So this tests uses mediation, but with inbound transports
-  @T005-RFC0211 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @critical @AcceptanceTest
+  @T005-RFC0211 @RFC0211 @AIP20 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @critical @AcceptanceTest
   Scenario Outline: Two agents creating a connection using a mediator with overlapping transports
     Given we have "2" agents
       | name  | role      |

--- a/aries-test-harness/features/0434-out-of-band.feature
+++ b/aries-test-harness/features/0434-out-of-band.feature
@@ -5,7 +5,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
    I want to use Out of Band(RFC0434) protocols to accomplish this.
 
 
-   @T001-RFC0434 @RFC0036 @critical @AcceptanceTest
+   @T001-RFC0434 @RFC0434 @AIP20 @RFC0036 @critical @AcceptanceTest
    Scenario: Issue a v1 indy credential using connectionless out of band invitation
       Given we have "2" agents
          | name | role   |
@@ -21,7 +21,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
       Then "Bob" has the credential issued
 
 
-   @T002-RFC0434 @RFC0453 @critical @AcceptanceTest @Schema_DriversLicense_v2
+   @T002-RFC0434 @RFC0434 @AIP20 @RFC0453 @critical @AcceptanceTest @Schema_DriversLicense_v2
    Scenario Outline: Issue a v2 credential using connectionless out of band invitation
       Given we have "2" agents
          | name | role   |
@@ -46,7 +46,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
          | credential_data   |
          | Data_DL_MaxValues |
 
-   @T003-RFC0434 @RFC0037 @critical @AcceptanceTest
+   @T003-RFC0434 @RFC0434 @AIP20 @RFC0037 @critical @AcceptanceTest
    Scenario: Present a v1 indy proof using connectionless out of band invitation
       Given we have "2" agents
          | name  | role     |
@@ -60,7 +60,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
       And "Faber" acknowledges the proof
       Then "Bob" has the proof verified
 
-   @T004-RFC0434 @RFC0454 @critical @AcceptanceTest @Schema_DriversLicense_v2 @CredProposalStart
+   @T004-RFC0434 @RFC0434 @AIP20 @RFC0454 @critical @AcceptanceTest @Schema_DriversLicense_v2 @CredProposalStart
    Scenario Outline: Present a v2 proof using connectionless out of band invitation
       Given we have "2" agents
          | name  | role     |

--- a/aries-test-harness/features/0453-issue-credential-v2.feature
+++ b/aries-test-harness/features/0453-issue-credential-v2.feature
@@ -1,7 +1,7 @@
 @RFC0453 @AIP20
 Feature: RFC 0453 Aries Agent Issue Credential v2
 
-  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @CredFormat_Indy @Schema_DriversLicense_v2
+  @T001-RFC0453 @RFC0453 @AIP20 @RFC0592 @critical @AcceptanceTest @CredFormat_Indy @Schema_DriversLicense_v2
   Scenario Outline: Issue a Indy credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
@@ -27,7 +27,7 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
       | credential_data   |
       | Data_DL_MaxValues |
 
-  @T001.1-RFC0453 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2
+  @T001.1-RFC0453 @RFC0453 @AIP20 @RFC0593 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_DriversLicense_v2
   Scenario Outline: Issue a JSON-LD credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |
@@ -67,7 +67,7 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
       | credential_data   |
       | Data_DL_MaxValues |
 
-  @T002-RFC0453 @normal @wip @AcceptanceTest @DIDExchangeConnection @CredFormat_Indy @Schema_DriversLicense_v2
+  @T002-RFC0453 @RFC0453 @AIP20 @normal @wip @AcceptanceTest @DIDExchangeConnection @CredFormat_Indy @Schema_DriversLicense_v2
   Scenario Outline: Issue a credential with the Holder beginning with a proposal with negotiation
     Given "2" agents
       | name | role   |
@@ -89,7 +89,7 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
       | credential_data   | updated_credential_data  |
       | Data_DL_MaxValues | Data_DL_NormalizedValues |
 
-  # @T003-RFC0453 @critical @wip @AcceptanceTest
+  # @T003-RFC0453 @RFC0453 @AIP20 @critical @wip @AcceptanceTest
   # Scenario: Issue a credential with the Issuer beginning with an offer
   #   Given "2" agents
   #     | name | role   |
@@ -102,7 +102,7 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
   #   And "Bob" acknowledges the credential issue
   #   Then "Bob" has the credential issued
 
-  # @T004-RFC0453 @normal @wip @AcceptanceTest
+  # @T004-RFC0453 @RFC0453 @AIP20 @normal @wip @AcceptanceTest
   # Scenario: Issue a credential with the Issuer beginning with an offer with negotiation
   #   Given "2" agents
   #     | name | role   |
@@ -117,7 +117,7 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
   #   And "Bob" acknowledges the credential issue
   #   Then "Bob" has the credential issued
 
-  # @T005-RFC0453 @minor @wip @AcceptanceTest
+  # @T005-RFC0453 @RFC0453 @AIP20 @minor @wip @AcceptanceTest
   # Scenario: Issue a credential with negotiation beginning from a credential request
   #   Given "2" agents
   #     | name | role   |
@@ -132,7 +132,7 @@ Feature: RFC 0453 Aries Agent Issue Credential v2
   #   And "Bob" acknowledges the credential issue
   #   Then "Bob" has the credential issued
 
-  # @T006-RFC0453 @critical @wip @AcceptanceTest
+  # @T006-RFC0453 @RFC0453 @AIP20 @critical @wip @AcceptanceTest
   # Scenario: Issue a credential with the Holder beginning with a request and is accepted
   #   Given "2" agents
   #     | name | role   |

--- a/aries-test-harness/features/0454-present-proof-v2.feature
+++ b/aries-test-harness/features/0454-present-proof-v2.feature
@@ -1,7 +1,7 @@
 @RFC0454 @AIP20
 Feature: RFC 0454 Aries agent present proof v2
 
-   @T001-RFC0454 @critical @AcceptanceTest @DIDExchangeConnection
+   @T001-RFC0454 @RFC0454 @AIP20 @critical @AcceptanceTest @DIDExchangeConnection
    Scenario Outline: Present Proof of specific types and proof is acknowledged with a Drivers License credential type with a DID Exchange Connection
       Given "2" agents
          | name  | role     |
@@ -46,7 +46,7 @@ Feature: RFC 0454 Aries agent present proof v2
          | Acme   | Data_DL_MaxValues | proof_request_DL_address_v2_dif_pe | presentation_DL_address_v2_dif_pe |
 
 
-   @T002-RFC0454 @RFC0510 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_Citizenship_Context @CredProposalStart
+   @T002-RFC0454 @RFC0454 @AIP20 @RFC0510 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_Citizenship_Context @CredProposalStart
    Scenario Outline: Present Proof of specific types and proof is acknowledged with a Citizenship credential type with a DID Exchange Connection
       Given "2" agents
          | name  | role     |

--- a/aries-test-harness/features/issue-credential-v3.feature
+++ b/aries-test-harness/features/issue-credential-v3.feature
@@ -1,7 +1,7 @@
-@DIDComm-V2 @WACI @IssueCredentialV3
+@IssueCredentialV3 @DIDComm-V2 @WACI
 Feature: WACI Issuance
 
-  @T001-IssueCredentialV3 @DIDExchangeConnection @DidMethod_orb
+  @T001-IssueCredentialV3 @IssueCredentialV3 @DIDComm-V2 @DIDExchangeConnection @DidMethod_orb
   Scenario: WACI issuance flow
     Given "2" agents
       | name | role   |

--- a/aries-test-harness/features/oob-v2.feature
+++ b/aries-test-harness/features/oob-v2.feature
@@ -1,7 +1,7 @@
-@DIDComm-V2 @OobV2 @UsesCustomParameters
+@OobV2 @DIDComm-V2 @UsesCustomParameters
 Feature: DIDComm V2 Establishing Connections
 
-   @T001-OobV2
+   @T001-OobV2 @OobV2 @DIDComm-V2 
    Scenario: Establish a connection between two agents using DIDComm V2
       Given we have "2" agents
          | name | role     |

--- a/aries-test-harness/features/present-proof-v3.feature
+++ b/aries-test-harness/features/present-proof-v3.feature
@@ -1,7 +1,7 @@
 @PresentProofV3 @DIDComm-V2 @UsesCustomParameters
 Feature: Aries agent present proof v3
 
-   @T001-PresentProofV3 @RFC0510 @WACI @CredFormat_JSON-LD @Schema_Citizenship_Context @CredProposalStart
+   @T001-PresentProofV3 @PresentProofV3 @DIDComm-V2 @RFC0510 @WACI @CredFormat_JSON-LD @Schema_Citizenship_Context @CredProposalStart
    Scenario Outline: Present Proof of specific types and proof is acknowledged with a Citizenship credential type with a DID Exchange Connection
       Given "2" agents
          | name  | role     |


### PR DESCRIPTION
This PR generally adds the @RFC and @AIP tags from the "Feature" to the nested "Scenarios"

I assume that this doe not affect test selection - not sure however, if this is true?