### PR TITLE
Remove unsupported tests from aca-py suite

### DIFF
--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -41,7 +41,8 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main"
           TEST_AGENTS: "-d acapy-main"
-          REPORT_PROJECT: acapy  
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb"
+          REPORT_PROJECT: acapy
         continue-on-error: true
       - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Remove tests relating to DID method orb and agents with no inbound transports
