### PR TITLE
Fix for revocation-related tests

### DIFF
--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main"
           TEST_AGENTS: "-d acapy-main"
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound"
           REPORT_PROJECT: acapy
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -233,6 +233,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             ("--wallet-name", self.wallet_name),
             ("--wallet-key", self.wallet_key),
             "--monitor-revocation-notification",
+            "--notify-revocation",
             "--open-mediation",
             "--enable-undelivered-queue",
         ]

--- a/aries-test-harness/features/steps/0011-0183-revocation.py
+++ b/aries-test-harness/features/steps/0011-0183-revocation.py
@@ -38,9 +38,10 @@ def step_impl(context, issuer: str):
         "publish_immediately": True,
     }
 
-    if context.step.name.endswith("with a revocation notification"):
-        connection_id = context.connection_id_dict[issuer][context.holder_name]
-        credential_revocation["notify_connection_id"] = connection_id
+    # always do this regardless
+    # if context.step.name.endswith("with a revocation notification"):
+    connection_id = context.connection_id_dict[issuer][context.holder_name]
+    credential_revocation["notify_connection_id"] = connection_id
 
     (resp_status, resp_text) = agent_backchannel_POST(
         issuer_url + "/agent/command/",


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

... also filter out another class of tests not supported by aca-py (tests with no http inbound transport, since the acapy backchannel does't support webhooks over ws)

Note in combination with aca-py PR https://github.com/hyperledger/aries-cloudagent-python/pull/1897 gets us down to one failing test ...
