### PR TITLE
Deal with the new 'deleted' state

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -120,6 +120,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             "credential_issued": "credential-issued",
             "credential_received": "credential-received",
             "credential_acked": "done",
+            "deleted": "done",
         }
 
         # AATH API : Acapy Admin API
@@ -417,30 +418,42 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         push_resource(thread_id, "revocation-notification-msg", message)
 
     async def handle_issue_credential(self, message: Mapping[str, Any]):
-        thread_id = message["thread_id"]
-        push_resource(thread_id, "credential-msg", message)
         log_msg("Received Issue Credential Webhook message: " + json.dumps(message))
+        thread_id = message["thread_id"]
+        if "state" in message and message["state"] == "deleted":
+            # ignore "deleted" state
+            return
+        push_resource(thread_id, "credential-msg", message)
         if "revocation_id" in message:  # also push as a revocation message
             push_resource(thread_id, "revocation-registry-msg", message)
             log_msg("Issue Credential Webhook message contains revocation info")
 
     async def handle_issue_credential_v2_0(self, message: Mapping[str, Any]):
-        thread_id = message["thread_id"]
-        push_resource(thread_id, "credential-msg", message)
         log_msg("Received Issue Credential v2 Webhook message: " + json.dumps(message))
+        thread_id = message["thread_id"]
+        if "state" in message and message["state"] == "deleted":
+            # ignore "deleted" state
+            return
+        push_resource(thread_id, "credential-msg", message)
         if "revocation_id" in message:  # also push as a revocation message
             push_resource(thread_id, "revocation-registry-msg", message)
             log_msg("Issue Credential Webhook message contains revocation info")
 
     async def handle_present_proof_v2_0(self, message: Mapping[str, Any]):
-        thread_id = message["thread_id"]
-        push_resource(thread_id, "presentation-msg", message)
         log_msg("Received a Present Proof v2 Webhook message: " + json.dumps(message))
+        thread_id = message["thread_id"]
+        if "state" in message and message["state"] == "deleted":
+            # ignore "deleted" state
+            return
+        push_resource(thread_id, "presentation-msg", message)
 
     async def handle_present_proof(self, message: Mapping[str, Any]):
-        thread_id = message["thread_id"]
-        push_resource(thread_id, "presentation-msg", message)
         log_msg("Received a Present Proof Webhook message: " + json.dumps(message))
+        thread_id = message["thread_id"]
+        if "state" in message and message["state"] == "deleted":
+            # ignore "deleted" state
+            return
+        push_resource(thread_id, "presentation-msg", message)
 
     async def handle_revocation_registry(self, message: Mapping[str, Any]):
         # No thread id in the webhook for revocation registry messages


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Not sure if this is optimal ...  ignore the new "deleted" state and/or treat it as a successful credential issue

The alternative (I think) is to turn off "auto delete" for AATH tests so we never delete the cred exchange records (and therefore should never encounter a "deleted" state)
