### PR TITLE
Issue #579 - Creating project before uploading allure results

### DIFF
--- a/aries-test-harness/allure/send_results_secure.sh
+++ b/aries-test-harness/allure/send_results_secure.sh
@@ -194,6 +194,13 @@ echo "------------------EXTRACTING-CSRF-ACCESS-TOKEN------------------"
 CRSF_ACCESS_TOKEN_VALUE=$(cat cookiesFile | grep -o 'csrf_access_token.*' | cut -f2)
 echo "csrf_access_token value: $CRSF_ACCESS_TOKEN_VALUE"
 
+echo "------------------CREATE-PROJECT------------------"
+curl -X POST "$ALLURE_SERVER/allure-docker-service/projects" \
+  -H 'Content-Type: application/json' \
+  -H "X-CSRF-TOKEN: $CRSF_ACCESS_TOKEN_VALUE" \
+  -d "{
+    "\""id"\"": "\""$PROJECT_ID"\""
+}" -b cookiesFile -ik
 
 echo "------------------CLEANING-RESULTS------------------"
 curl -X GET "$ALLURE_SERVER/allure-docker-service/clean-results?project_id=$PROJECT_ID" -H  "accept: */*" -b cookiesFile -ik


### PR DESCRIPTION
Signed-off-by: Patrick St-Louis <patrick.st-louis@idlab.org>

This PR adds a call to the `/allure-docker-service/projects` api endpoint before uploading the results. If the project already exists, it will simply upload the results to the existing project.