### PR TITLE
fix(javascript): adapt to AFJ 0.3.0 API

### DIFF
--- a/aries-backchannels/javascript/server/src/TestAgent.ts
+++ b/aries-backchannels/javascript/server/src/TestAgent.ts
@@ -28,6 +28,7 @@ export async function createAgent({
     indyLedgers: [
       {
         id: 'main-pool',
+        indyNamespace: 'main-pool',
         isProduction: false,
         genesisPath,
       },
@@ -40,7 +41,7 @@ export async function createAgent({
     logger: new TsedLogger($log),
   }
 
-  const agent = new Agent(agentConfig, agentDependencies)
+  const agent = new Agent({ config: agentConfig, dependencies: agentDependencies })
 
   for (const it of transport.inboundTransports) {
     agent.registerInboundTransport(it)

--- a/aries-backchannels/javascript/server/src/controllers/CredentialDefinitionController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/CredentialDefinitionController.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, PathParams, Post, BodyParams } from '@tsed/common'
 import { InternalServerError, NotFound } from '@tsed/exceptions'
-import { Agent, IndySdkError } from '@aries-framework/core'
+import { IndyLedgerService, IndySdkError } from '@aries-framework/core'
 import { LedgerNotFoundError } from '@aries-framework/core/build/modules/ledger/error/LedgerNotFoundError'
 import type * as Indy from 'indy-sdk'
 import { isIndyError } from '@aries-framework/core/build/utils/indyError'
@@ -55,12 +55,16 @@ export class CredentialDefinitionController extends BaseController {
     try {
       const schema = await this.agent.ledger.getSchema(data.schema_id)
 
-      const credentialDefinition = await this.agent.ledger.registerCredentialDefinition({
+      // FIXME: Use Agent's Ledger API (cannot use as is because it throws an exception if the credential definition is already registered)
+      const ledgerService = this.agent.injectionContainer.resolve(IndyLedgerService)
+
+      const credentialDefinition = await ledgerService.registerCredentialDefinition(this.agent.context, this.agent.context.wallet.publicDid!.did, 
+        {
         schema,
         supportRevocation: data.support_revocation,
         tag: data.tag,
+        signatureType: 'CL',
       })
-
       return {
         credential_definition_id: credentialDefinition.id,
         credential_definition: credentialDefinition,

--- a/aries-backchannels/javascript/server/src/utils/CredentialUtils.ts
+++ b/aries-backchannels/javascript/server/src/utils/CredentialUtils.ts
@@ -5,12 +5,12 @@ import { IndyHolderService } from '@aries-framework/core/build/modules/indy/serv
 export class CredentialUtils {
   public static async getCredentialByThreadId(agent: Agent, threadId: string) {
     const credentialRepository = agent.injectionContainer.resolve(CredentialRepository)
-    return credentialRepository.getSingleByQuery({ threadId })
+    return credentialRepository.getSingleByQuery(agent.context, { threadId })
   }
 
   public static async getIndyCredentialById(agent: Agent, credentialId: string): Promise<Indy.IndyCredentialInfo> {
     const holderService = agent.injectionContainer.resolve(IndyHolderService)
-    const indyCredential = await holderService.getCredential(credentialId)
+    const indyCredential = await holderService.getCredential(agent.context, credentialId)
 
     return indyCredential
   }

--- a/aries-backchannels/javascript/server/src/utils/ProofUtils.ts
+++ b/aries-backchannels/javascript/server/src/utils/ProofUtils.ts
@@ -3,6 +3,6 @@ import { Agent, ProofRepository } from '@aries-framework/core'
 export class ProofUtils {
   public static async getProofByThreadId(agent: Agent, threadId: string) {
     const proofRepository = agent.injectionContainer.resolve(ProofRepository)
-    return proofRepository.getSingleByQuery({ threadId })
+    return proofRepository.getSingleByQuery(agent.context, { threadId })
   }
 }


### PR DESCRIPTION
After yesterday's first alpha release of aries-framework-javascript 0.3.0, javascript backchannel stopped working due to some changes in the API (mostly related to agent constructor and Present Proof module).

This PR attempts to adapt the backchannel to be able to run again and show us real problems rather than compilation issues :-).

Signed-off-by: Ariel Gentile <gentilester@gmail.com>