### PR TITLE
[hyperledger #560] Change the order of the connection steps to improve mobile testing flow

### DIFF
--- a/aries-test-harness/features/0037-present-proof.feature
+++ b/aries-test-harness/features/0037-present-proof.feature
@@ -97,8 +97,8 @@ Feature: RFC 0037 Aries agent present proof
          | name  | role     |
          | Faber | verifier |
          | Bob   | prover   |
-      And "Faber" and "Bob" have an existing connection
       And "Bob" has an issued credential from <issuer>
+      And "Faber" and "Bob" have an existing connection
       When "Faber" sends a request for proof presentation to "Bob"
       And "Bob" makes the presentation of the proof
       And "Faber" acknowledges the proof

--- a/aries-test-harness/features/0160-connection.feature
+++ b/aries-test-harness/features/0160-connection.feature
@@ -2,7 +2,7 @@
 Feature: RFC 0160 Aries agent connection functions
 
    @T001-RFC0160 @critical @AcceptanceTest @MobileTest
-   Scenario Outline: establish a connection between two agents
+   Scenario Outline: Establish a connection between two agents
       Given we have "2" agents
          | name  | role    |
          | Acme  | inviter |

--- a/aries-test-harness/features/0183-revocation.feature
+++ b/aries-test-harness/features/0183-revocation.feature
@@ -47,9 +47,9 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | name  | role     |
          | Bob   | prover   |
          | Faber | verifier |
-      And "Faber" and "Bob" have an existing connection
       And "Bob" has an issued credential from <issuer> with <credential_data>
       When <issuer> revokes the credential
+      And "Faber" and "Bob" have an existing connection
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof
       And "Faber" acknowledges the proof
@@ -200,9 +200,9 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | name  | role     |
          | Bob   | prover   |
          | Faber | verifier |
-      And "Faber" and "Bob" have an existing connection
       And "Bob" has an issued credential from <issuer> with <credential_data>
       And <issuer> has revoked the credential before <timeframe>
+      And "Faber" and "Bob" have an existing connection
       When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity before <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof

--- a/aries-test-harness/features/steps/0160-connection.py
+++ b/aries-test-harness/features/steps/0160-connection.py
@@ -382,6 +382,7 @@ def step_impl(context, sender, receiver):
         )
 
 
+@when('"{sender}" and "{receiver}" have an existing connection')
 @given('"{sender}" and "{receiver}" have an existing connection')
 def step_impl(context, sender, receiver):
     if "DIDExchangeConnection" in context.tags:


### PR DESCRIPTION
This partially resolves issue 560 more specifically the second task listed.

I was able to run a combination of mobile tests with acapy/javascript as backchannels without issue.

Signed-off-by: Patrick St-Louis <patrick.st-louis@idlab.org>