### PR TITLE
Upgrade actions to latest versions.

### DIFF
--- a/.github/workflows/generate-summary-results.yml
+++ b/.github/workflows/generate-summary-results.yml
@@ -10,7 +10,7 @@ jobs:
     if: ((success() || failure()) && ((github.event_name != 'pull_request' && github.repository == 'hyperledger/aries-agent-test-harness')))
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: generate-summary-results

--- a/.github/workflows/skip-test-harness-verity-afj.yml
+++ b/.github/workflows/skip-test-harness-verity-afj.yml
@@ -35,7 +35,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-indy-tails-server

--- a/.github/workflows/skip-test-harness-verity-dotnet.yml
+++ b/.github/workflows/skip-test-harness-verity-dotnet.yml
@@ -34,7 +34,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-indy-tails-server

--- a/.github/workflows/test-harness-acapy-afgo.yml
+++ b/.github/workflows/test-harness-acapy-afgo.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -30,7 +30,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-aip10.yml
+++ b/.github/workflows/test-harness-acapy-aip10.yml
@@ -28,7 +28,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-aip20.yml
+++ b/.github/workflows/test-harness-acapy-aip20.yml
@@ -28,7 +28,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-ariesvcx.yml
+++ b/.github/workflows/test-harness-acapy-ariesvcx.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: Docker Login

--- a/.github/workflows/test-harness-acapy-dotnet-javascript.yml
+++ b/.github/workflows/test-harness-acapy-dotnet-javascript.yml
@@ -33,7 +33,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-dotnet.yml
+++ b/.github/workflows/test-harness-acapy-dotnet.yml
@@ -32,7 +32,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-findy.yml
+++ b/.github/workflows/test-harness-acapy-findy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-acapy-verity.yml
+++ b/.github/workflows/test-harness-acapy-verity.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-indy-tails-server

--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-afgo-acapy.yml
+++ b/.github/workflows/test-harness-afgo-acapy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -28,7 +28,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-afj-acapy.yml
+++ b/.github/workflows/test-harness-afj-acapy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-afj-dotnet.yml
+++ b/.github/workflows/test-harness-afj-dotnet.yml
@@ -33,7 +33,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-afj-findy.yml
+++ b/.github/workflows/test-harness-afj-findy.yml
@@ -30,7 +30,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-afj.yml
+++ b/.github/workflows/test-harness-afj.yml
@@ -28,7 +28,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-ariesvcx-acapy.yml
+++ b/.github/workflows/test-harness-ariesvcx-acapy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: Docker Login

--- a/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
+++ b/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: Docker Login

--- a/.github/workflows/test-harness-ariesvcx-javascript.yml
+++ b/.github/workflows/test-harness-ariesvcx-javascript.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: Docker Login

--- a/.github/workflows/test-harness-dotnet-acapy.yml
+++ b/.github/workflows/test-harness-dotnet-acapy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-dotnet-findy.yml
+++ b/.github/workflows/test-harness-dotnet-findy.yml
@@ -31,7 +31,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-dotnet-javascript.yml
+++ b/.github/workflows/test-harness-dotnet-javascript.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-dotnet.yml
+++ b/.github/workflows/test-harness-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-findy-acapy.yml
+++ b/.github/workflows/test-harness-findy-acapy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-findy-dotnet.yml
+++ b/.github/workflows/test-harness-findy-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-findy-javascript-dotnet.yml
+++ b/.github/workflows/test-harness-findy-javascript-dotnet.yml
@@ -31,7 +31,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-findy-javascript.yml
+++ b/.github/workflows/test-harness-findy-javascript.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-findy.yml
+++ b/.github/workflows/test-harness-findy.yml
@@ -29,7 +29,7 @@ jobs:
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: run-von-network

--- a/.github/workflows/test-harness-javascript-ariesvcx.yml
+++ b/.github/workflows/test-harness-javascript-ariesvcx.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-test-harness
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: test-harness
       - name: Docker Login

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           repository="${{github.repository}}"
           name=$(echo ${repository##*/})
-          echo "::set-output name=name::${name}"
+          echo "name=${name}" >> $GITHUB_OUTPUT
 
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get File List
         id: get-file-list
@@ -61,7 +61,7 @@ jobs:
       - name: ${{ matrix.test-workflow }}
         timeout-minutes: 60
         if: success() || failure()
-        uses: convictional/trigger-workflow-and-wait@v1.6.0
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           workflow_file_name: ${{ matrix.test-workflow }}
           owner: ${{ github.repository_owner }}
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: generate-summary-results.yml
-        uses: convictional/trigger-workflow-and-wait@v1.6.0
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           workflow_file_name: generate-summary-results.yml
           owner: ${{ github.repository_owner }}


### PR DESCRIPTION
Signed-off-by: Wade Barnes <wade@neoterictech.ca>

This PR upgrades the GitHub Actions used to eliminate a number of deprecation warning, however it does not eliminate them all.  The `the-coding-turtle/ga-file-list` action does not have a release that fixes the node.js 12 warning and it also contains the older `set-output` syntax.