### PR TITLE
fix(javascript): agent type error

### DIFF
--- a/aries-backchannels/javascript/server/src/TestHarnessConfig.ts
+++ b/aries-backchannels/javascript/server/src/TestHarnessConfig.ts
@@ -43,7 +43,7 @@ export class TestHarnessConfig {
     this._controllers.push(controller)
   }
 
-  public get agent(): Agent {
+  public get agent(): Agent<{}> {
     if (!this._agent) {
       throw new Error('Agent not initialized')
     }


### PR DESCRIPTION
This small typing workaround fixes the compilation issue that we are seeing since 0.3.0-alpha.40.
