### PR TITLE
Avoid starting local ledger needlessly

### DIFF
--- a/manage
+++ b/manage
@@ -611,7 +611,7 @@ startServices() {
 
   # if we're *not* using an external indy tails server, start the local one
   if [[ -z ${TAILS_SERVER_URL_CONFIG} ]]; then
-    if [[ -z `docker ps -q --filter="name=docker_tails-server_1"` ]]; then
+    if [[ -z `docker ps -q --filter="name=docker_tails-server_1"` ]] && [[ -z $(docker ps -q --filter="name=docker-tails-server-1") ]]; then
       echo "starting local indy-tails-server..."
       auxiliaryService indy-tails start
       if [[ $AUTO_CLEANUP ]]; then

--- a/manage
+++ b/manage
@@ -587,7 +587,7 @@ startServices() {
 
   # if we're *not* using an external VON ledger, start the local one
   if [[ -z ${LEDGER_URL_CONFIG} ]]; then
-    if [[ -z `docker ps -q --filter="name=von_webserver_1"` ]]; then
+    if [[ -z `docker ps -q --filter="name=von_webserver_1"` ]] && [[ -z $(docker ps -q --filter="name=von-webserver-1") ]]; then
       echo "starting local von-network..."
       auxiliaryService von-network start
       if [[ $AUTO_CLEANUP ]]; then


### PR DESCRIPTION
It seems the container names created by docker compose are sometimes formed with dash '-' instead of underscore 
'_'. Try to search for both formats before relaunching von-network/tails server.