### PR TITLE
Move ngrok container to v3

### DIFF
--- a/manage
+++ b/manage
@@ -483,9 +483,9 @@ startAgent() {
     if [[ "${USE_NGROK}" = "true" ]]; then
       echo "Starting ngrok for ${NAME} Agent ..."
       if [[ "${IMAGE_NAME}" = "dotnet-agent-backchannel" ]]; then
-        docker run -d --rm --name "${CONTAINER_NAME}-ngrok" wernight/ngrok ngrok http "${CONTAINER_NAME}:${BACKCHANNEL_PORT}" --log stdout > /dev/null
+        docker run -d --rm --name "${CONTAINER_NAME}-ngrok" ngrok/ngrok http "${CONTAINER_NAME}:${BACKCHANNEL_PORT}" --log stdout > /dev/null
       else
-        docker run -d --rm --name "${CONTAINER_NAME}-ngrok" wernight/ngrok ngrok http "${CONTAINER_NAME}:${AGENT_ENDPOINT_PORT}" --log stdout > /dev/null
+        docker run -d --rm --name "${CONTAINER_NAME}-ngrok" ngrok/ngrok http "${CONTAINER_NAME}:${AGENT_ENDPOINT_PORT}" --log stdout > /dev/null
       fi
       sleep 1
       export NGROK_NAME="${CONTAINER_NAME}-ngrok"

--- a/services/indy-tails/docker-compose.yml
+++ b/services/indy-tails/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "3"
 services:
   ngrok-tails-server:
-    image: wernight/ngrok
+    image: ngrok/ngrok
     networks:
       - tails-server
     ports:
       - 4044:4040
-    command: ngrok http tails-server:6543 --log stdout
+    command: http tails-server:6543 --log stdout
   tails-server:
     image: ghcr.io/bcgov/tails-server:1.0.0
     ports:


### PR DESCRIPTION
This PR fixes the issue that started on May 17th when the ngrok containers would start giving the following message then shutting down. 
```
Your ngrok agent version "2" is no longer supported. Only the most recent version of the ngrok agent is supported without an account.
Update to a newer version with `ngrok update` or by downloading from https://ngrok.com/download.
Sign up for an account to avoid forced version upgrades: https://ngrok.com/signup.

ERR_NGROK_120
```
Instead of using the wernight/ngrok container, we will now use the official ngrok/ngrok container which is at v3. 