### PR TITLE
GENESIS_URL Support for Connectionless proof request on and external ledger

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -946,12 +946,13 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
                 if operation == "create-request":
                     resp_json = json.loads(resp_text)
-                    resp_text = json.dumps(
-                        {
-                            "record": resp_json,
-                            "message": resp_json["presentation_request_dict"],
-                        }
-                    )
+                    if resp_status == 200:
+                        resp_text = json.dumps(
+                            {
+                                "record": resp_json,
+                                "message": resp_json["presentation_request_dict"],
+                            }
+                        )
                 return (resp_status, resp_text)
 
         # Handle out of band POST operations
@@ -1001,7 +1002,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 thread_id = attachment.get("~thread", {}).get("thid") or attachment.get(
                     "@id"
                 )
-
                 if message_type.endswith("/issue-credential/1.0/offer-credential"):
                     (_, resp_text) = await self.admin_GET(
                         "/issue-credential/records", params={"thread_id": thread_id}
@@ -1074,7 +1074,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         log_msg(
             f"Data translated by backchannel to send to agent for operation: {agent_operation}",
-            data,
+            json.dumps(data, indent=4)
         )
 
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
@@ -2264,7 +2264,20 @@ async def main(start_port: int, show_timing: bool = False, interactive: bool = T
 
         # start aca-py agent sub-process and listen for web hooks
         await agent.listen_webhooks(start_port + 3)
-        await agent.register_did()
+
+        # Check if "read-only-ledger" is true in the config file. If true, skip registering DID.
+        if "read-only-ledger" not in agent.get_agent_args() or "read-only-ledger" not in extra_args:
+            # Check if there is an AGENT_CONFIG_FILE and if "read-only-ledger" is present in the file.
+            agent_config_file = os.getenv("AGENT_CONFIG_FILE")
+            if agent_config_file is not None:
+                with open(agent_config_file) as  agent_config_file:
+                    #print the content of the opened text file
+                    agent_config_text_file = agent_config_file.read()
+                    print(agent_config_text_file)
+                    if "read-only-ledger" not in agent_config_text_file:
+                        await agent.register_did()
+            else:
+                await agent.register_did()
 
         await agent.start_process()
         agent.activate()

--- a/aries-backchannels/acapy/read_only_ledger_verifier_config.yaml
+++ b/aries-backchannels/acapy/read_only_ledger_verifier_config.yaml
@@ -1,0 +1,22 @@
+# see: https://pypi.org/project/ConfigArgParse/ for file format overview
+# this runs aca-py with a set of parameters for auto responding and with read only access to a ledger.
+# Read only access is for verifiers that do not need or cannot have write access to a ledger.
+# the following are quivalent to:
+#    ./bin/aca-py start ... --auto-accept-requests --auto-respond-messages --auto-respond-credential-proposal --auto-respond-credential-offer --auto-respond-credential-request --auto-respond-presentation-proposal --auto-respond-presentation-request
+# run as:
+#    ./bin/aca-py start --arg-file ./demo/demo-args.yaml
+auto-ping-connection: true
+auto-accept-invites: true
+auto-accept-requests: true
+auto-respond-messages: true
+auto-respond-credential-proposal: true
+auto-respond-credential-offer: true
+auto-respond-credential-request: true
+auto-respond-presentation-proposal: true
+auto-respond-presentation-request: true
+auto-store-credential: true
+auto-verify-presentation: true
+auto-accept-intro-invitation-requests: true
+monitor-revocation-notification: true
+notify-revocation: true
+read-only-ledger: true

--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -72,7 +72,6 @@ async def default_genesis_txns():
         elif RUN_MODE == "docker":
             async with ClientSession() as session:
                 ledger_url = get_ledger_url()
-                print("From ledger_url:", f"{ledger_url}/genesis")
                 async with session.get(f"{ledger_url}/genesis") as resp:
                     genesis = await resp.text()
         else:

--- a/manage
+++ b/manage
@@ -13,10 +13,12 @@ SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-aath}"
 export AGENT_TIMEOUT=30
 export LEDGER_TIMEOUT=60
-# these two can be overrode via env vars
+# these can be overridden via env vars
 export LEDGER_URL_CONFIG="${LEDGER_URL_CONFIG}"
 export TAILS_SERVER_URL_CONFIG="${TAILS_SERVER_URL_CONFIG}"
 export AGENT_CONFIG_FILE="${AGENT_CONFIG_FILE}"
+export GENESIS_URL="${GENESIS_URL}"
+export GENESIS_FILE="${GENESIS_FILE}"
 
 # these are derived from the above two
 LEDGER_URL_HOST="${LEDGER_URL_CONFIG:-http://localhost:9000}"
@@ -244,6 +246,29 @@ function initEnv() {
   export RUST_LOG=${RUST_LOG:-warning}
 }
 
+# setup the docker environment variables to be passed to containers
+setDockerEnv() {
+    # set variables that have a different name to what is being set for the container
+  DOCKER_ENV="-e AGENT_NAME=${NAME}"
+  if  [[ -n "$BACKCHANNEL_EXTRA_ARGS" ]]; then
+    DOCKER_ENV="${DOCKER_ENV} -e EXTRA_ARGS=${BACKCHANNEL_EXTRA_ARGS}"
+  fi
+  if  [[ -n "$LEDGER_URL_INTERNAL" ]]; then
+    DOCKER_ENV="${DOCKER_ENV} -e LEDGER_URL=${LEDGER_URL_INTERNAL}"
+  fi
+  if  [[ -n "$TAILS_SERVER_URL_INTERNAL" ]]; then
+    DOCKER_ENV="${DOCKER_ENV} -e TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}"
+  fi
+
+  # variables that have the same variable name as what is being set for the container
+  declare -a GENERAL_VARIABLES=("DOCKERHOST" "NGROK_NAME" "AIP_CONFIG" "AGENT_CONFIG_FILE" "GENESIS_URL" "GENESIS_FILE")
+  for var in "${GENERAL_VARIABLES[@]}"; do
+    if [[ -n "${!var}" ]]; then
+      DOCKER_ENV+=" -e ${var}=${!var}"
+    fi
+  done
+}
+
 # TODO: set up image builds so you don't need to use `./manage rebuild` to refresh remote source repo
 # - image Dockerfile has an ARG for the commit hash,
 # - build script grabs the HEAD commit hash from the agent's github repo
@@ -304,7 +329,7 @@ pingLedger(){
   ledger_url=${1}
 
   # ping ledger web browser for genesis txns
-  local rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null ${ledger_url}/genesis)
+  local rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null ${ledger_url})
   if (( ${rtnCd} == 200 )); then
     return 0
   else
@@ -314,12 +339,21 @@ pingLedger(){
 
 waitForLedger(){
   (
-    # Wait for ledger server to start ...
+    # Wait for ledger server to start or if remote wait for it to respond  ...
     local startTime=${SECONDS}
     local rtnCd=0
-    printf "waiting for ledger to start"
+
+    # Determine the ping URL based on the ledger variables
+    local pingUrl=""
+    if [[ -n "${GENESIS_URL}" ]]; then
+      pingUrl="${GENESIS_URL}"
+    else
+      pingUrl="${LEDGER_URL_HOST}/genesis"
+    fi
+
+    printf "waiting for ledger to start/respond"
     # use ledger URL from host
-    while ! pingLedger "$LEDGER_URL_HOST"; do
+    while ! pingLedger "${pingUrl}"; do
       printf "."
       local duration=$(($SECONDS - $startTime))
       if (( ${duration} >= ${LEDGER_TIMEOUT} )); then
@@ -493,14 +527,16 @@ startAgent() {
     else
       export NGROK_NAME=
     fi
+
     echo "Starting ${NAME} Agent using ${IMAGE_NAME} ..."
     export BACKCHANNEL_EXTRA_ARGS_NAME="BACKCHANNEL_EXTRA_${AGENT_NAME//-/_}"
     export BACKCHANNEL_EXTRA_ARGS=`echo ${!BACKCHANNEL_EXTRA_ARGS_NAME}`
-    if [[ -z ${AGENT_CONFIG_FILE} ]]; then
-      local container_id=$(docker run -dt --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${DATA_VOLUME_ARG} ${ENV_FILE_ARG} -e "NGROK_NAME=${NGROK_NAME}" -e "EXTRA_ARGS=${BACKCHANNEL_EXTRA_ARGS}" -e "DOCKERHOST=${DOCKERHOST}" -e "AGENT_NAME=${NAME}" -e "LEDGER_URL=${LEDGER_URL_INTERNAL}" -e "TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}"  -e "AIP_CONFIG=${AIP_CONFIG}" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
-    else
-      local container_id=$(docker run -dt --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${DATA_VOLUME_ARG} ${ENV_FILE_ARG} -e "AGENT_CONFIG_FILE=${AGENT_CONFIG_FILE}" -e "NGROK_NAME=${NGROK_NAME}" -e "EXTRA_ARGS=${BACKCHANNEL_EXTRA_ARGS}" -e "DOCKERHOST=${DOCKERHOST}" -e "AGENT_NAME=${NAME}" -e "LEDGER_URL=${LEDGER_URL_INTERNAL}" -e "TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}" -e "AIP_CONFIG=${AIP_CONFIG}" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
-    fi
+
+    # set the docker environment that needs to be passed to the test container
+    setDockerEnv
+
+    local container_id=$(docker run -dt --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${DATA_VOLUME_ARG} ${ENV_FILE_ARG} $DOCKER_ENV "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
+
     sleep 1
     if [[ "${USE_NGROK}" = "true" ]]; then
       docker network connect aath_network "${CONTAINER_NAME}"
@@ -586,7 +622,7 @@ startServices() {
   fi
 
   # if we're *not* using an external VON ledger, start the local one
-  if [[ -z ${LEDGER_URL_CONFIG} ]]; then
+  if [[ -z ${LEDGER_URL_CONFIG} && -z ${GENESIS_URL} && -z ${GENESIS_FILE} ]]; then
     if [[ -z `docker ps -q --filter="name=von_webserver_1"` ]] && [[ -z $(docker ps -q --filter="name=von-webserver-1") ]]; then
       echo "starting local von-network..."
       auxiliaryService von-network start

--- a/services/uniresolver/wrapper.sh
+++ b/services/uniresolver/wrapper.sh
@@ -3,7 +3,13 @@
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 COMMAND=${1}
 
-SOV_NETWORK="${LEDGER_URL_CONFIG:-http://localhost:9000}"
+# SOV_NETWORK should be set to one of LEDGER_URL_CONFIG or GENESIS_URL.
+# if neither is set, default to localhost:9000
+# if not GENESIS_URL then SOV_NETWORK should be ammended to include /genesis at the end
+SOV_NETWORK="${GENESIS_URL:-${LEDGER_URL_CONFIG:-http://localhost:9000}}"
+if [[ -z "${GENESIS_URL}" ]]; then
+	SOV_NETWORK="${SOV_NETWORK}/genesis"
+fi
 
 # ========================================================================================================
 # Check Docker Compose
@@ -21,7 +27,7 @@ echo "Using: ${dockerCompose}"
 startCommand() {
 	mkdir -p .build/sov-pool-config
 	rm -f .build/sov-pool-config/config.txt
-	curl $SOV_NETWORK/genesis --output .build/sov-pool-config/config.txt
+	curl $SOV_NETWORK --output .build/sov-pool-config/config.txt
 
 	${dockerCompose} up -d
 }


### PR DESCRIPTION
This PR adds GENESIS_URL support to the test harness. You can now use GENESIS_URL instead of LEDGER_URL_CONFIG when running tests or starting agents as a service. There are currently no test run sets that use the GENESIS_URL. 

### Use Case
The BC Wallet tests in Aries Mobile Test Harness uses AATH agents as a service to accomplish Issuer and Verifier roles with the wallet app tests. Some tests are using an issuer that is on the CANdy network. There was a need to a verifier to do a connectionless proof request with a credential from that issuer. The verifier agent needed to be started with the GENESIS_URL from the CANdy network, and the agent is started in read only mode since it does not need(could not get) write access to the ledger. If read only mode is set, then the ACA-Py agent does not register a did on the network.

There is a new yaml file aries-backchannels/acapy/read_only_ledger_verifier_config.yaml that can be used if anyone wants to start an agent with read only ledger access and with all the auto responding turned on. 

This allows us to do a command as follows to accomplish the use case. 
```
GENESIS_URL=https://whatever.genesis.url.you.want AGENT_CONFIG_FILE=/aries-backchannels/acapy/read_only_ledger_verifier_config.yaml ./manage start -b acapy-main
```

### Other Enhancements
To support the GENESIS_URL above I also refactored how environment variables were gathered and sent to the test containers. There is no longer multiple conditional calls to docker run based on what env vars are set. There is now one call. 

The uniresolver was hardcoded to use the LEDGER_URL. It now will use the GENESIS_URL if it is set. 

### Considerations

- This works for the ACA-Py agent/backchannel. There may need to be work done in other backchannels if they wish to use the GENESIS_URL in their workflows. 

- I tested this with a bunch of different run commands that are used in the interop regression tests. All seemed to be fine since they set the LEDGER_URL_CONFIG in the workflows. However, I did try a run command with no LEDGER_URL or GENESIS_URL. My expectation was that it would start a local ledger, then use that in the tests however there was an issue running a command like this, 
```
./manage run -d acapy-main -t @AcceptanceTest -t @AIP20 -t ~@wip -t @T004-RFC0211
```
The genesis transaction was setup and the agent started but would throw this error. 
```
2023-06-05 18:54:30,258 aries_cloudagent.commands.start ERROR Exception during startup:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/commands/start.py", line 72, in init
    await startup
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/commands/start.py", line 28, in start_app
    await conductor.setup()
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/core/conductor.py", line 185, in setup
    self.root_profile, self.setup_public_did and self.setup_public_did.did
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/config/ledger.py", line 136, in ledger_config
    async with ledger:
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/ledger/indy.py", line 318, in __aenter__
    await self.pool.context_open()
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/ledger/indy.py", line 239, in context_open
    await self.open()
  File "/usr/local/lib/python3.7/site-packages/aries_cloudagent/ledger/indy.py", line 204, in open
    self.handle = await indy.pool.open_pool_ledger(self.name, pool_config)
  File "/usr/local/lib/python3.7/site-packages/indy/pool.py", line 88, in open_pool_ledger
    open_pool_ledger.cb)
  File "/usr/local/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/local/lib/python3.7/asyncio/futures.py", line 176, in result
    raise CancelledError
concurrent.futures._base.CancelledError
2023-06-05 18:54:30,267 aries_cloudagent.indy.sdk.profile DEBUG Profile finalizer called; closing wallet
2023-06-05 18:54:30,324 asyncio ERROR Task exception was never retrieved
future: <Task finished coro=<run_loop.<locals>.done() done, defined at /usr/local/lib/python3.7/site-packages/aries_cloudagent/commands/start.py:77> exception=RuntimeError('cannot reuse already awaited coroutine')>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
RuntimeError: cannot reuse already awaited coroutine
```
I don't believe any of my changes would affect this and I ~~am assuming~~ have confirmed this issue existed before my changes. There are no workflows that use the test harness in this manner as far as I know, so it should not impact the interop regression test cycle.
