### PR TITLE
Fix acapy back channel builds.

### DIFF
--- a/aries-backchannels/acapy/Dockerfile.acapy
+++ b/aries-backchannels/acapy/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \

--- a/aries-backchannels/acapy/Dockerfile.acapy-main
+++ b/aries-backchannels/acapy/Dockerfile.acapy-main
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \


### PR DESCRIPTION
- Explicitly use python:3.7-slim-bullseye.  python:3.7-slim is now based on bookworm, and there are no Indy SDK packages for that release.