### PR TITLE
fix-646: Implemented Re-try failed scenarios

### DIFF
--- a/RETRY-FAILED-SCENARIOS.md
+++ b/RETRY-FAILED-SCENARIOS.md
@@ -1,0 +1,46 @@
+# Retry Failed Test Scenarios
+
+This feature introduces the ability to retry failed test scenarios in your test runs. It provides flexibility in managing the number of retry attempts for scenarios that fail during testing.
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Changes Made](#changes-made)
+- [How to Run](#how-to-run)
+  - [Using behave.ini](#1-using-behaveini)
+  - [Using Environment Variable](#2-using-environment-variable)
+
+## Introduction
+
+This feature addresses the issue of retrying failed test scenarios. It implements a mechanism to automatically rerun failed scenarios to improve the stability of test results.
+
+## Changes Made
+
+The following changes have been made to implement the retry functionality:
+
+- Added a `before_feature` hook in `\features\environment.py` to handle retrying failed scenarios.
+- Passed the overriding variable `TEST_RETRY_ATTEMPTS_OVERRIDE` via `manage.py` to the Docker environment.
+
+## How to Run
+
+There are two ways to override the number of attempts for retrying failed scenarios:
+
+### 1. Using `behave.ini`
+
+Add the following variable to the `[behave.userdata]` section of the `behave.ini` file:
+
+```ini
+[behave.userdata]
+test_retry_attempts = 2
+```
+
+### 2. Using Environment Variable
+
+Pass the `TEST_RETRY_ATTEMPTS_OVERRIDE` variable as an environment variable while running tests or through deployment YAML files.
+
+Example:
+```bash
+TEST_RETRY_ATTEMPTS_OVERRIDE=2 ./manage run -d acapy -b javascript -t @AcceptanceTest
+```
+
+### Feedback and Contributions
+Your feedback and contributions are welcome! If you encounter any issues or have suggestions for improvement, please feel free to open an issue or submit a pull request.

--- a/manage
+++ b/manage
@@ -263,6 +263,9 @@ setDockerEnv() {
   if  [[ -n "$TAILS_SERVER_URL_INTERNAL" ]]; then
     DOCKER_ENV="${DOCKER_ENV} -e TAILS_SERVER_URL=${TAILS_SERVER_URL_INTERNAL}"
   fi
+  if ! [ -z "$TEST_RETRY_ATTEMPTS_OVERRIDE" ]; then
+    DOCKER_ENV="${DOCKER_ENV} -e TEST_RETRY_ATTEMPTS_OVERRIDE=${TEST_RETRY_ATTEMPTS_OVERRIDE}"
+  fi
 
   # variables that have the same variable name as what is being set for the container
   declare -a GENERAL_VARIABLES=("DOCKERHOST" "NGROK_NAME" "AIP_CONFIG" "AGENT_CONFIG_FILE" "GENESIS_URL" "GENESIS_FILE")
@@ -952,12 +955,12 @@ runTests() {
 
   if [[ "${REPORT}" = "allure" && "${COMMAND}" != "dry-run" ]]; then
       echo "Executing tests with Allure Reports."
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/aries-test-harness/allure/allure-results:/aries-test-harness/allure/allure-results/" aries-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/aries-test-harness/allure/allure-results:/aries-test-harness/allure/allure-results/" $DOCKER_ENV aries-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
   elif [[ "${COMMAND}" = "dry-run" ]]; then
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050 |\
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini $DOCKER_ENV aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050 |\
         grep "Feature:\|Scenario Outline\|\@" | sed "/n(u/d"
   else
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" $DOCKER_ENV aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
   fi
   local docker_result=$?
   rm ${BEHAVE_INI_TMP}


### PR DESCRIPTION
Fix for the [issue ](https://github.com/hyperledger/aries-agent-test-harness/issues/646)

Changes made
1) Added a before_feature hook to implement retry failed scenarios.
2) Passing the overriding variable TEST_RETRY_ATTEMPTS_OVERRIDE via manage.py to docker environment

Note : Found $DOCKER_ENV is not passed to the docker run command on runTests() function. So adding that too.

How to run:
There are two ways to overide the no of attempts for re-try failed scenarios

1) Add the variable **test_retry_attempts** in the **behave.ini** like below

> test_retry_attempts = 2

2) Pass the variable **TEST_RETRY_ATTEMPTS_OVERRIDE** as environment variable while running test or through deployment yaml files.

> eg: TEST_RETRY_ATTEMPTS_OVERRIDE=2 ./manage run -d acapy -b javascript -t @AcceptanceTest

Screenshots

![image](https://github.com/hyperledger/aries-agent-test-harness/assets/79985154/6742443e-4260-46cc-8017-46ec3264dc6c)
![image](https://github.com/hyperledger/aries-agent-test-harness/assets/79985154/650ce2cd-d041-4c82-bb3a-5246d06a1b3d)
![image](https://github.com/hyperledger/aries-agent-test-harness/assets/79985154/c0abf141-7400-4b3e-b9cd-eeab3061fa65)
![image](https://github.com/hyperledger/aries-agent-test-harness/assets/79985154/c35a3f08-400b-4a83-9fbf-3dbf99c2f770)


