### PR TITLE
Poetry PR related fix for Issue 2459

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,14 +168,14 @@ The URLs for issuer and verifier are pointers to the backchannel controllers for
 You can pass backchannel-specific parameters as follows:
 
 ```bash
-BACKCHANNEL_EXTRA_acapy_main="{\"wallet-type\":\"askar\"}" ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip
+BACKCHANNEL_EXTRA_acapy_main="{\"wallet-type\":\"indy\"}" ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip
 ```
 
 The environment variable name is of the format `-<agent_name>`, where `<agent_name>` is the name of the agent (e.g. `acapy-main`) with hyphens replaced with underscores (i.e. `acapy_main`).
 
 The contents of the environment variable are backchannel-specific. For aca-py it is a JSON structure containing parameters to use for agent startup.
 
-The above example runs all the tests using the `askar` wallet type (vs `indy`, which is the default).
+The above example runs all the tests using the `indy` wallet type (vs `askar`, which is the default).
 
 ## Custom Configurations for Agents
   Alternatively to the Extra Backchannel-Specific Parameters above, you can also pass a configuration file through to your agent when it starts (only works if your agent is started by your backchannel). The AATH tests have a predefined set of options needed for the test flow to function properly so, adding this configuration to AATH test execution may have side effects causing the interop tests to fail. However, this is helpful when using the agents as services outside of AATH tests like with Mobile Wallet tests in Aries Mobile Test Harness, where the agents usually will benefit from having auto options turned on. You can pass through your config file using the environment variable AGENT_CONFIG_FILE as follows:

--- a/aries-backchannels/acapy/Dockerfile.acapy-main
+++ b/aries-backchannels/acapy/Dockerfile.acapy-main
@@ -22,9 +22,11 @@ COPY python python
 COPY acapy acapy
 COPY data ./
 
-# aca-py is in /usr/local/bin. The Backchannel is looking for it in ./bin, create a link to it in ./bin
+# aca-py is no longer in /usr/local/bin. 
+# The Backchannel is looking for it in ./bin, copy file and create a link to it in ./bin
 RUN mkdir -p ./bin
-RUN ln -s /usr/local/bin/aca-py ./bin/aca-py
+COPY acapy/bin/aca-py ./bin/aca-py
+RUN chmod +x ./bin/aca-py
 
 ENV PYTHONPATH=/aries-backchannels
 ENV RUNMODE=docker

--- a/aries-backchannels/acapy/Dockerfile.acapy-redis
+++ b/aries-backchannels/acapy/Dockerfile.acapy-redis
@@ -24,9 +24,11 @@ COPY python python
 COPY acapy acapy
 COPY data ./
 
-# aca-py is in /usr/local/bin. The Backchannel is looking for it in ./bin, create a link to it in ./bin
+# aca-py is no longer in /usr/local/bin. 
+# The Backchannel is looking for it in ./bin, copy file and create a link to it in ./bin
 RUN mkdir -p ./bin
-RUN ln -s /usr/local/bin/aca-py ./bin/aca-py
+COPY acapy/bin/aca-py ./bin/aca-py
+RUN chmod +x ./bin/aca-py
 
 ENV PYTHONPATH=/aries-backchannels
 ENV RUNMODE=docker

--- a/aries-backchannels/acapy/acapy-main.env
+++ b/aries-backchannels/acapy/acapy-main.env
@@ -1,2 +1,3 @@
 
 LOG_LEVEL=DEBUG
+RUST_LOG=warn

--- a/aries-backchannels/acapy/bin/aca-py
+++ b/aries-backchannels/acapy/bin/aca-py
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ -z "$PYTHON" ]; then
+    PYTHON=`command -v python3`
+    if [ -z "$PYTHON" ]; then
+        PYTHON=python
+    fi
+fi
+
+$PYTHON -m aries_cloudagent "$@"

--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -126,9 +126,9 @@ class AgentBackchannel:
 
         self.admin_url = f"http://{self.internal_host}:" + str(agent_ports["admin"])
 
-        self.storage_type = "indy"
+        self.storage_type = "askar"
         self.wallet_type = (
-            extra_args.get("wallet-type") if extra_args.get("wallet-type") else "indy"
+            extra_args.get("wallet-type") if extra_args.get("wallet-type") else "askar"
         )
         self.wallet_name = self.ident.lower().replace(" ", "") + rand_name
         self.wallet_key = self.ident + rand_name


### PR DESCRIPTION
### ACA-PY [Issue 2459](https://github.com/hyperledger/aries-cloudagent-python/issues/2459) - tests failing

Addressing the failing tests in AATH after the move to `poetry` (see [PR 2436](https://github.com/hyperledger/aries-cloudagent-python/pull/2436)). The issue is not `poetry` or the set of depedency changes, but rather the elimination of `bin/acapy` shell script and it's removal from the dependency installation (using `pip` or `poetry`). The script is no longer needed in the base images and `acapy` is started by other means. However, AATH is expecting that script and references it directly in the backchannel.

I decided to leave AATH as close to original as is (ie. not using `poetry` to install ACA-Py) and addressed the issue by adding the `bin/acapy` script to this repo and having AATH add it to its image.

### ACA-Py [Issue 2460](https://github.com/hyperledger/aries-cloudagent-python/issues/2460) - default to `askar`

Also in this PR I am including the update to make `askar` the default storage/wallet type. Was simple enough and simplified running the tests.  I touched the documentation in case someone needs to revert to `indy`.