### PR TITLE
Fix ACA-Py backchannel to invoke the ACA-Py produced aca-py bin file

### DIFF
--- a/aries-backchannels/acapy/Dockerfile.acapy-main
+++ b/aries-backchannels/acapy/Dockerfile.acapy-main
@@ -22,8 +22,7 @@ COPY python python
 COPY acapy acapy
 COPY data ./
 
-# aca-py is no longer in /usr/local/bin. 
-# The Backchannel is looking for it in ./bin, copy file and create a link to it in ./bin
+# The Backchannel is looking for it in ./bin, copy a file that invokes the ACA-Py installed script in /usr/local/bin
 RUN mkdir -p ./bin
 COPY acapy/bin/aca-py ./bin/aca-py
 RUN chmod +x ./bin/aca-py

--- a/aries-backchannels/acapy/Dockerfile.acapy-redis
+++ b/aries-backchannels/acapy/Dockerfile.acapy-redis
@@ -24,8 +24,7 @@ COPY python python
 COPY acapy acapy
 COPY data ./
 
-# aca-py is no longer in /usr/local/bin. 
-# The Backchannel is looking for it in ./bin, copy file and create a link to it in ./bin
+# The Backchannel is looking for it in ./bin, copy a file that invokes the ACA-Py installed script in /usr/local/bin
 RUN mkdir -p ./bin
 COPY acapy/bin/aca-py ./bin/aca-py
 RUN chmod +x ./bin/aca-py

--- a/aries-backchannels/acapy/bin/aca-py
+++ b/aries-backchannels/acapy/bin/aca-py
@@ -1,10 +1,2 @@
-#!/bin/sh
-
-if [ -z "$PYTHON" ]; then
-    PYTHON=`command -v python3`
-    if [ -z "$PYTHON" ]; then
-        PYTHON=python
-    fi
-fi
-
-$PYTHON -m aries_cloudagent "$@"
+#!/bin/bash
+/usr/local/bin/aca-py "$@"


### PR DESCRIPTION
Tweaks the current implementation to invoke the ACA-Py produced script instead of bypassing it.  It's not clear to me why the ACA-Py generated script can't be linked from its location and executed through the link, but that doesn't work. Using this approach does seem to work.
