### PR TITLE
fix(javascript): missing supportRevocation parameter

### DIFF
--- a/aries-backchannels/javascript/server/package.json
+++ b/aries-backchannels/javascript/server/package.json
@@ -15,7 +15,6 @@
     "@aries-framework/anoncreds-rs": "alpha",
     "@aries-framework/askar": "alpha",
     "@aries-framework/core": "alpha",
-    "@aries-framework/indy-sdk": "alpha",
     "@aries-framework/indy-vdr": "alpha",
     "@aries-framework/node": "alpha",
     "@hyperledger/anoncreds-nodejs": "^0.1.0-dev.11",
@@ -30,7 +29,6 @@
     "body-parser": "1.19.0",
     "cross-env": "7.0.3",
     "express": "^4.17.1",
-    "indy-sdk": "^1.16.0-dev-1655",
     "minimist": "^1.2.5",
     "node-fetch": "^2.6.5",
     "rxjs": "^7.4.0"

--- a/aries-backchannels/javascript/server/src/TestHarnessConfig.ts
+++ b/aries-backchannels/javascript/server/src/TestHarnessConfig.ts
@@ -83,8 +83,6 @@ export class TestHarnessConfig {
     if (!agentArgs) {
       const agentName = process.env.AGENT_NAME ? `AFJ ${process.env.AGENT_NAME}` : `AFJ Agent (${this.agentPorts.http})`
 
-      const useLegacyIndySdk = Boolean(process.env.USE_LEGACY_INDY_SDK || false)
-
       // There are multiple ways to retrieve the genesis file
       // we account for all of them
       const genesisFile = process.env.GENESIS_FILE
@@ -99,7 +97,6 @@ export class TestHarnessConfig {
 
       agentArgs = {
         agentName,
-        useLegacyIndySdk,
         publicDidSeed,
         genesisPath,
       }

--- a/aries-backchannels/javascript/server/src/controllers/CredentialDefinitionController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/CredentialDefinitionController.ts
@@ -80,7 +80,7 @@ export class CredentialDefinitionController extends BaseController {
           issuerId,
           schemaId: schema.schemaId,
           tag: data.tag,
-        }, options: { didIndyNamespace: 'main-pool'}}) 
+        }, options: { supportRevocation: false, didIndyNamespace: 'main-pool'}}) 
 
       if (!credentialDefinitionState.credentialDefinition || !credentialDefinitionState.credentialDefinitionId) {
         throw new Error()

--- a/aries-backchannels/javascript/server/src/index.ts
+++ b/aries-backchannels/javascript/server/src/index.ts
@@ -4,7 +4,6 @@ import minimist from 'minimist'
 import { TestHarnessConfig } from './TestHarnessConfig'
 import { PlatformExpress } from '@tsed/platform-express'
 import { Server } from './Server'
-import * as indy from 'indy-sdk'
 
 async function startup() {
   const cliArguments = minimist(process.argv.slice(2), {
@@ -25,28 +24,7 @@ async function startup() {
 
   $log.level = 'debug'
 
-
   // TODO: Set up native logger for anoncreds, askar and indy-vdr
-  const $indyLogger = new Logger('Libindy')
-
-  // @ts-ignore
-  indy.setLogger(function (
-    level: string,
-    target: string,
-    message: string,
-    modulePath: string,
-    file: string,
-    line: string
-  ) {
-    $indyLogger.debug(`${level} ${target} ${message}`, {
-      modulePath,
-      file,
-      line,
-    })
-  })
-
-  // @ts-ignore
-  indy.setRuntimeConfig({ collect_backtrace: true })
 
   await testHarnessConfig.startAgent({ inboundTransports: ['http'], outboundTransports: ['http'] })
 


### PR DESCRIPTION
Fixing the compilation issue recently thrown as AFJ requires `supportRevocation` parameter to be present when creating credential definition.

Also removing any reference to indy-sdk, whose support in AFJ will be dropped very soon.