### PR TITLE
Refactored ngrok support with necessary AuthToken

### DIFF
--- a/MOBILE_AGENT_TESTING.md
+++ b/MOBILE_AGENT_TESTING.md
@@ -14,7 +14,7 @@ Remember to build any other Test Agents you are going to run with the mobile tes
 
 There are several options to the `./manage run` script that must be used when testing a mobile wallet:
 
-- use the `-n` option tells the `./manage` script to start ngrok services for each agent (issuer, verifier) to provide the mobile app an Internet accessible endpoint for each of those agents
+- use the `-n` option tells the `./manage` script to start ngrok services for each agent (issuer, verifier) to provide the mobile app an Internet accessible endpoint for each of those agents. You will need to provide an ngrok AuthToken, either free or paid to use this feature. Pass it as an environment variable when calling `manage` like `NGROK_AUTHTOKEN=YourAuthTokenHere ./manage ...` 
 - use the `-b mobile` option to use the mobile Test Agent for the `Bob` role (the only one that makes sense for a mobile app)
 - use the `-t @MobileTest` option to run only the tests that have been tagged as "working" with the mobile test agent
   - as new test scenarios are found to (or made to) work with the mobile Test Agent, the `@MobileTest` tag should be added to those test scenarios
@@ -30,7 +30,7 @@ and if necessary, you must use the wallet app settings to use the "BCovrin Test"
 Put together, that gives us the following command to test a mobile wallet with Aries Cloud Agent Python (main branch) running in all other roles.
 
 ```bash
-LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -b mobile -n -t @MobileTest
+NGROK_AUTHTOKEN=2ZrwpFakeAuthToken_W4VDBxavAzdB5K3wsDGz LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -b mobile -n -t @MobileTest
 ```
 
 The mobile agent is in "proof-of-concept" status and some tests are not 100% reliable with all mobile agents. If things don't work, take a look at the

--- a/MOBILE_AGENT_TESTING.md
+++ b/MOBILE_AGENT_TESTING.md
@@ -14,7 +14,7 @@ Remember to build any other Test Agents you are going to run with the mobile tes
 
 There are several options to the `./manage run` script that must be used when testing a mobile wallet:
 
-- use the `-n` option tells the `./manage` script to start ngrok services for each agent (issuer, verifier) to provide the mobile app an Internet accessible endpoint for each of those agents. You will need to provide an ngrok AuthToken, either free or paid to use this feature. Pass it as an environment variable when calling `manage` like `NGROK_AUTHTOKEN=YourAuthTokenHere ./manage ...` 
+- using the `-n` option tells the `./manage` script to start ngrok services for each agent (issuer, verifier) to provide the mobile app an Internet accessible endpoint for each of those agents. You will need to provide an ngrok AuthToken, either free or paid to use this feature. Pass it as an environment variable when calling `manage` like `NGROK_AUTHTOKEN=YourAuthTokenHere ./manage ...` 
 - use the `-b mobile` option to use the mobile Test Agent for the `Bob` role (the only one that makes sense for a mobile app)
 - use the `-t @MobileTest` option to run only the tests that have been tagged as "working" with the mobile test agent
   - as new test scenarios are found to (or made to) work with the mobile Test Agent, the `@MobileTest` tag should be added to those test scenarios

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You may have the need to utilize the agents and their controller/backchannels se
 ```
 The command above will only start Acme as ACA-py. No other agents (Bob, Faber, etc.) will be started. 
 ```
-LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -a afgo-interop -b acapy-main -n
+NGROK_AUTHTOKEN=2ZrwpFakeAuthToken_W4VDBxavAzdB5K3wsDGz LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -a afgo-interop -b acapy-main -n
 ```
 The second command above, will start Acme as AFGO, and Bob as ACA-py, utilizing an external Ledger and Tails Server, with a custom configuration to start ACA-py with. It will also start ngrok which is usually needed for mobile testing in AMTH. 
 
@@ -180,7 +180,7 @@ The above example runs all the tests using the `indy` wallet type (vs `askar`, w
 ## Custom Configurations for Agents
   Alternatively to the Extra Backchannel-Specific Parameters above, you can also pass a configuration file through to your agent when it starts (only works if your agent is started by your backchannel). The AATH tests have a predefined set of options needed for the test flow to function properly so, adding this configuration to AATH test execution may have side effects causing the interop tests to fail. However, this is helpful when using the agents as services outside of AATH tests like with Mobile Wallet tests in Aries Mobile Test Harness, where the agents usually will benefit from having auto options turned on. You can pass through your config file using the environment variable AGENT_CONFIG_FILE as follows:
   ```
-  LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -b acapy-main -n
+  NGROK_AUTHTOKEN=2ZrwpFakeAuthToken_W4VDBxavAzdB5K3wsDGz LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -b acapy-main -n
   ```
 The config file should live in the `aries-backchannels/<agent>` folder so it gets copied into the agent container automatically. Currently only the acapy backchannel supports this custom configuration in this manner. 
 
@@ -189,7 +189,7 @@ The config file should live in the `aries-backchannels/<agent>` folder so it get
 When using AATH agents as a service for AMTH, these agent services will need to be started with differet or extra parameters on the agents than AATH starts them with by default. Mobile test issuers and verifiers may need the auto parameters turned on, like `--auto-accept-requests`, `--auto-respond-credential-proposal`, etc. The only way to do this when using the AATH agents is through using this configuration file handling. There is an existing file in `aries-backchannels/acapy` called auto_isser_config.yaml that is there to support this requirement for the BC wallet. This works in BC Wallet as follows;
 From within aries-agent-test-harness
 ```
-LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -a acapy-main -b acapy-main -n
+NGROK_AUTHTOKEN=2ZrwpFakeAuthToken_W4VDBxavAzdB5K3wsDGz LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -a acapy-main -b acapy-main -n
 ```
 From within aries-mobile-test-harness
 ```

--- a/aath_ngrok_config.yml
+++ b/aath_ngrok_config.yml
@@ -1,0 +1,20 @@
+version: 2
+web_addr: agents-ngrok:4040
+
+tunnels:
+  acme_agent_ngrok:
+    addr: acme_agent:9021
+    proto: http  
+
+  bob_agent_ngrok:
+    addr: bob_agent:9031
+    proto: http  
+
+  faber_agent_ngrok:
+    addr: faber_agent:9041
+    proto: http  
+
+  # free version of ngrok only allows 3 tunnels at a time.
+  # malory_agent_ngrok:
+  #   addr: malory_agent:9051
+  #   proto: http  

--- a/aries-backchannels/acapy/ngrok-wait.sh
+++ b/aries-backchannels/acapy/ngrok-wait.sh
@@ -8,9 +8,9 @@ if [[ ! "${NGROK_NAME}" = "" ]]; then
     NGROK_ENDPOINT=null
     while [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]
     do
-        echo "Fetching end point from ngrok service"
-        NGROK_ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r '.tunnels[] | select(.proto=="https") | .public_url')
-
+        echo "Fetching end point from ngrok service [$NGROK_NAME] for [$CONTAINER_NAME] ..."
+        NGROK_ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r --arg CONTAINER_NAME "$CONTAINER_NAME" 'first(.tunnels[] | select(.proto=="https" and (.name | index($CONTAINER_NAME))) | .public_url)')
+        
         if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
             echo "ngrok not ready, sleeping 5 seconds...."
             sleep 5

--- a/aries-backchannels/dotnet/ngrok-wait.sh
+++ b/aries-backchannels/dotnet/ngrok-wait.sh
@@ -8,8 +8,8 @@ if [[ ! "${NGROK_NAME}" = "" ]]; then
     NGROK_ENDPOINT=null
     while [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]
     do
-        echo "Fetching end point from ngrok service"
-        NGROK_ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r '.tunnels[] | select(.proto=="https") | .public_url')
+        echo "Fetching end point from ngrok service [$NGROK_NAME] for [$CONTAINER_NAME] ..."
+        NGROK_ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r --arg CONTAINER_NAME "$CONTAINER_NAME" 'first(.tunnels[] | select(.proto=="https" and (.name | index($CONTAINER_NAME))) | .public_url)')
 
         if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
             echo "ngrok not ready, sleeping 5 seconds...."

--- a/aries-backchannels/javascript/ngrok-wait.sh
+++ b/aries-backchannels/javascript/ngrok-wait.sh
@@ -8,8 +8,10 @@ if [[ ! "${NGROK_NAME}" = "" ]]; then
     NGROK_ENDPOINT=null
     while [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]
     do
-        echo "Fetching end point from ngrok service"
-        NGROK_ENDPOINT=$(curl -s $NGROK_NAME:4040/api/tunnels/command_line | grep -o "https:\/\/.*\.ngrok\.io")
+        # original get endpoint 
+        #NGROK_ENDPOINT=$(curl -s $NGROK_NAME:4040/api/tunnels/command_line | grep -o "https:\/\/.*\.ngrok\.io")
+        echo "Fetching end point from ngrok service [$NGROK_NAME] for [$CONTAINER_NAME] ..."
+        NGROK_ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r --arg CONTAINER_NAME "$CONTAINER_NAME" 'first(.tunnels[] | select(.proto=="https" and (.name | index($CONTAINER_NAME))) | .public_url)')
 
         if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
             echo "ngrok not ready, sleeping 5 seconds...."

--- a/aries-backchannels/mobile/Dockerfile.mobile
+++ b/aries-backchannels/mobile/Dockerfile.mobile
@@ -1,8 +1,11 @@
-FROM python:3.7-buster
+FROM python:3.9-slim-bullseye
+
 RUN mkdir -p /aries-backchannels
 WORKDIR /aries-backchannels
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
+RUN apt-get update \
+   && apt-get install -y git gnupg2 software-properties-common curl \
+   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
    && apt-get update \
    && apt-get install -y software-properties-common \
    && apt-get update

--- a/manage
+++ b/manage
@@ -268,7 +268,7 @@ setDockerEnv() {
   fi
 
   # variables that have the same variable name as what is being set for the container
-  declare -a GENERAL_VARIABLES=("DOCKERHOST" "NGROK_NAME" "AIP_CONFIG" "AGENT_CONFIG_FILE" "GENESIS_URL" "GENESIS_FILE")
+  declare -a GENERAL_VARIABLES=("DOCKERHOST" "NGROK_NAME" "CONTAINER_NAME" "AIP_CONFIG" "AGENT_CONFIG_FILE" "GENESIS_URL" "GENESIS_FILE")
   for var in "${GENERAL_VARIABLES[@]}"; do
     if [[ -n "${!var}" ]]; then
       DOCKER_ENV+=" -e ${var}=${!var}"
@@ -555,17 +555,16 @@ startAgent() {
 
   if [ ! "$(docker ps -q -f name=$CONTAINER_NAME)" ]; then
     if [[ "${USE_NGROK}" = "true" ]]; then
-      echo "Starting ngrok for ${NAME} Agent ..."
-      if [[ "${IMAGE_NAME}" = "dotnet-agent-backchannel" ]]; then
-        docker run -d --rm --name "${CONTAINER_NAME}-ngrok" ngrok/ngrok http "${CONTAINER_NAME}:${BACKCHANNEL_PORT}" --log stdout > /dev/null
-      else
-        docker run -d --rm --name "${CONTAINER_NAME}-ngrok" ngrok/ngrok http "${CONTAINER_NAME}:${AGENT_ENDPOINT_PORT}" --log stdout > /dev/null
-      fi
-      sleep 1
-      export NGROK_NAME="${CONTAINER_NAME}-ngrok"
-      docker network connect aath_network "${CONTAINER_NAME}-ngrok"
-    else
-      export NGROK_NAME=
+      # Turning off the starting of each ngrok tunnel for each agent. All tunnels are started when the ngrok service starts.
+      # There was an attempt to just start the service and then only start the tunnels when the agent was started, but 
+      # That is not working. When we call start below, we get an error on the web_addr port in the config file. 
+      # If this can be solved in the future we can re-enable this code, and make sure the ngrok service starts with the --none flag.
+      # echo "Starting ngrok for ${NAME} Agent ... on port ${AGENT_ENDPOINT_PORT}"
+      # # call the ngrok container to start the tunnel for the agent
+      # docker exec "${NGROK_NAME}" ngrok start --config /etc/ngrok.yml "${CONTAINER_NAME}_ngrok"
+
+      # if we are using ngrok we will have to export the CONTAINER_NAME to be used by the ngrok_wait script
+      export CONTAINER_NAME="${CONTAINER_NAME}"
     fi
 
     echo "Starting ${NAME} Agent using ${IMAGE_NAME} ..."
@@ -794,6 +793,25 @@ startHarness(){
   dockerhost_url_templates
 
   export AIP_CONFIG=${AIP_CONFIG:-10}
+
+  # Standup the ngrok container if we are using ngrok
+  if [[ "${USE_NGROK}" = "true" ]]; then
+    echo "Starting ngrok service for test harness ..."
+    if  [[ -n "$NGROK_AUTHTOKEN" ]]; then
+      NGROK_AUTHTOKEN="${NGROK_AUTHTOKEN}"
+    else
+      NGROK_AUTHTOKEN="harness_${NGROK_AUTHTOKEN}"
+    fi
+    # start the ngrok container but don't start the tunnels in the config yml file. We will start them later as needed for each agent.
+    docker run -d --rm -v $(pwd)/aath_ngrok_config.yml:/etc/ngrok.yml -e NGROK_CONFIG=/etc/ngrok.yml -e NGROK_AUTHTOKEN="${NGROK_AUTHTOKEN}" --name agents-ngrok --network aath_network -p 4040:4040 ngrok/ngrok start --all
+    
+    export NGROK_NAME="agents-ngrok"
+  else
+    # if NGROK_NAME is populated then don't export it to null.
+    if [[ -z "$NGROK_NAME" ]]; then
+      export NGROK_NAME=
+    fi
+  fi
 
   # Only start agents that are asked for in the ./manage start command
   if [[ "$ACME" != "none" ]]; then
@@ -1027,6 +1045,8 @@ stopHarness(){
 
   printf "StopServices: ${stop_option}\n"
   stopServices ${stop_option}
+
+  stopIfExists agents-ngrok
 
   cleanupNetwork
 


### PR DESCRIPTION
This PR refactors ngrok support in AATH. As of Dec 26 2023, AATH stopped working with ngrok because of the enforcement of an AuthToken to start ngrok services. Users that need to use ngrok support in AATH will need to acquire, either free or paid for, an AuthToken from ngrok. 

At this point forward, if you are using the `-n` option on the manage script, you will also have to set an `NGROK_AUTHTOKEN` environment variable. This can be done like this for example;
```
NGROK_AUTHTOKEN=2ZrwpFakeAuthToken_W4VDBxavAzdB5K3wsDGz LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -a acapy-main -b acapy-main -n
```

Behavioural changes in this PR are as follows:
- There is now one ngrok container started instead of one for every Aries agent. 
- This ngrok container starts all the tunnels needed.  Note, if you have a free ngrok account and associated AuthToken then you will only be able to start 3 tunnels in the ngrok container. This shouldn't be a problem since we have not come into a use case where more than 2 are needed. 

Closes #757 