### PR TITLE
Add anoncred support

### DIFF
--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -1,16 +1,15 @@
 import json
 import logging
 import os
-import traceback
 import random
-
-from typing_extensions import TypedDict, Literal
-from typing import Any, Optional, Tuple
+import traceback
 from dataclasses import dataclass
+from typing import Any, Optional, Tuple
 
-from aiohttp import web, ClientSession
-from aiohttp.typedefs import Handler
 import ptvsd
+from aiohttp import ClientSession, web
+from aiohttp.typedefs import Handler
+from typing_extensions import Literal, TypedDict
 
 from .utils import log_msg
 
@@ -59,6 +58,7 @@ class BackchannelCommand:
     operation: Optional[str]
     record_id: Optional[str]
     data: Optional[Any]
+    anoncreds: Optional[bool] = False
 
 
 async def default_genesis_txns():
@@ -225,6 +225,11 @@ class AgentBackchannel:
         record_id = request.match_info.get("id", None)
         operation = request.match_info.get("operation", None)
         topic = request.match_info.get("topic", None)
+        anoncreds = request.query.get("anoncreds", False)
+        
+        if anoncreds == 'True':
+            anoncreds = True
+            
         method = request.method
 
         if not topic:
@@ -248,6 +253,7 @@ class AgentBackchannel:
             topic=topic,
             method=method,
             data=data,
+            anoncreds=anoncreds
         )
 
     def not_found_response(self, data: Any):

--- a/aries-test-harness/agent_test_utils.py
+++ b/aries-test-harness/agent_test_utils.py
@@ -1,5 +1,5 @@
-import time
 import datetime
+import time
 from typing import Optional
 
 
@@ -73,45 +73,44 @@ def format_cred_proposal_by_aip_version(
 
     return credential_proposal
 
+def get_schema_name(context):
+    if context.anoncreds:
+        return context.schema["schema"]["name"]
+    else:
+        return context.schema["schema_name"]
+
 
 def amend_filters_with_runtime_data(context, filters):
+    schema_name = get_schema_name(context)
     # This method will need comdification as new types of filters are used. Intially "indy" is used.
     if "indy" in filters:
         if (
             "schema_issuer_did" in filters["indy"]
             and filters["indy"]["schema_issuer_did"] == "replace_me"
         ):
-            filters["indy"]["schema_issuer_did"] = context.issuer_did_dict[
-                context.schema["schema_name"]
-            ]
+            filters["indy"]["schema_issuer_did"] = context.issuer_did_dict[schema_name]
         if (
             "issuer_did" in filters["indy"]
             and filters["indy"]["issuer_did"] == "replace_me"
         ):
-            filters["indy"]["issuer_did"] = context.issuer_did_dict[
-                context.schema["schema_name"]
-            ]
+            filters["indy"]["issuer_did"] = context.issuer_did_dict[schema_name]
         if (
             "cred_def_id" in filters["indy"]
             and filters["indy"]["cred_def_id"] == "replace_me"
         ):
-            filters["indy"]["cred_def_id"] = context.issuer_credential_definition_dict[
-                context.schema["schema_name"]
-            ]["id"]
+            filters["indy"]["cred_def_id"] = context.issuer_credential_definition_dict[schema_name]["id"]
         if (
             "schema_id" in filters["indy"]
             and filters["indy"]["schema_id"] == "replace_me"
         ):
-            filters["indy"]["schema_id"] = context.issuer_schema_dict[
-                context.schema["schema_name"]
-            ]["id"]
+            filters["indy"]["schema_id"] = context.issuer_schema_dict[schema_name]["id"]
 
     if "json-ld" in filters:
         json_ld = filters.get("json-ld")
         credential = json_ld.get("credential")
         options = json_ld.get("options")
 
-        issuer = context.issuer_did_dict[context.schema["schema_name"]]
+        issuer = context.issuer_did_dict[schema_name]
 
         if "issuer" in credential:
             # "issuer": "replace_me"

--- a/aries-test-harness/features/0434-out-of-band.feature
+++ b/aries-test-harness/features/0434-out-of-band.feature
@@ -21,7 +21,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
       Then "Bob" has the credential issued
 
 
-   @T002-RFC0434 @RFC0453 @critical @AcceptanceTest @Schema_DriversLicense_v2
+   @T002-RFC0434 @RFC0453 @critical @AcceptanceTest @Schema_DriversLicense_v2 
    Scenario Outline: Issue a v2 credential using connectionless out of band invitation
       Given we have "2" agents
          | name | role   |
@@ -36,7 +36,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
       And "Bob" acknowledges the "indy" credential issue
       Then "Bob" has the "indy" credential issued
 
-      @CredFormat_Indy @RFC0592
+      @CredFormat_Indy @RFC0592 @Anoncreds
       Examples:
          | credential_data   |
          | Data_DL_MaxValues |
@@ -74,7 +74,7 @@ Feature: RFC 0434 Intiating exchange using the Out of Band protocol
       And "Faber" acknowledges the proof with formats
       Then "Bob" has the proof with formats verified
 
-      @CredFormat_Indy @RFC0592
+      @CredFormat_Indy @RFC0592 @Anoncreds
       Examples:
          | credential_data   | request_for_proof           | presentation               |
          | Data_DL_MaxValues | proof_request_DL_address_v2 | presentation_DL_address_v2 |

--- a/aries-test-harness/features/0453-issue-credential-v2.feature
+++ b/aries-test-harness/features/0453-issue-credential-v2.feature
@@ -1,7 +1,7 @@
 @RFC0453 @AIP20
 Feature: RFC 0453 Aries Agent Issue Credential v2
 
-  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @CredFormat_Indy @Schema_DriversLicense_v2
+  @T001-RFC0453 @RFC0592 @critical @AcceptanceTest @CredFormat_Indy @Schema_DriversLicense_v2 @Anoncreds
   Scenario Outline: Issue a Indy credential with the Holder beginning with a proposal
     Given "2" agents
       | name | role   |

--- a/aries-test-harness/features/0454-present-proof-v2.feature
+++ b/aries-test-harness/features/0454-present-proof-v2.feature
@@ -14,7 +14,7 @@ Feature: RFC 0454 Aries agent present proof v2
       And "Faber" acknowledges the proof with formats
       Then "Bob" has the proof with formats verified
 
-      @CredFormat_Indy @RFC0592 @Schema_DriversLicense_v2 @CredProposalStart
+      @CredFormat_Indy @RFC0592 @Schema_DriversLicense_v2 @CredProposalStart @Anoncreds
       Examples:
          | issuer | credential_data   | request_for_proof               | presentation                   |
          | Acme   | Data_DL_MaxValues | proof_request_DL_address_v2     | presentation_DL_address_v2     |

--- a/aries-test-harness/features/data/anoncreds_schema_driverslicense_v2.json
+++ b/aries-test-harness/features/data/anoncreds_schema_driverslicense_v2.json
@@ -1,0 +1,16 @@
+{
+   "schema":{
+      "schema": {
+         "name":"Schema_DriversLicense_v2",
+         "version":"1.0.1",
+         "attrNames":[
+            "address",
+            "DL_number",
+            "expiry",
+            "age"
+         ]
+      },
+      "options":{}
+   },
+   "cred_def_support_revocation":false
+}

--- a/aries-test-harness/features/data/cred_data_anoncreds_schema_driverslicense_v2.json
+++ b/aries-test-harness/features/data/cred_data_anoncreds_schema_driverslicense_v2.json
@@ -1,0 +1,59 @@
+{
+   "Data_DL_MaxValues":{
+      "cred_name":"Data_DriversLicense_v2_MaxValues",
+      "schema_name":"Schema_DriversLicense_v2",
+      "schema_version":"1.0.1",
+      "attributes":[
+         {
+            "name":"address",
+            "value":"947 this street, Kingston Ontario Canada, K9O 3R5"
+         },
+         {
+            "name":"DL_number",
+            "value":"09385029529385"
+         },
+         {
+            "name":"expiry",
+            "value":"10/12/2022"
+         },
+         {
+            "name":"age",
+            "value":"30"
+         }
+      ],
+      "filters": {
+         "indy": {
+            "cred_def_id": "replace_me"
+         },
+         "json-ld": {
+            "credential": {
+               "@context": [
+                  "https://www.w3.org/2018/credentials/v1", 
+                  "https://w3id.org/security/bbs/v1",
+                  {
+                     "dl": "http://example.com/drivers-license#",
+                     "AATHDriversLicense": "dl:AATHDriversLicense",
+                     "address": "dl:address",
+                     "DL_number": "dl:DL_number",
+                     "expiry": "dl:expiry",
+                     "age": "dl:age"
+                   }
+               ],
+               "type": ["VerifiableCredential", "AATHDriversLicense"],
+               "issuer": "replace_me",
+               "issuanceDate": "2010-01-01T19:73:24Z",
+               "credentialSubject": {
+                  "address": "947 this street, Kingston Ontario Canada, K9O 3R5",
+                  "DL_number": "09385029529385",
+                  "expiry": "10/12/2022",
+                  "age": "30"
+               }
+            },
+            "options": {
+               "proofType": "replace_me"
+            }
+            
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/environment.py
+++ b/aries-test-harness/features/environment.py
@@ -5,12 +5,14 @@
 # https://behave.readthedocs.io/en/latest/tutorial.html#environmental-controls
 #
 # -----------------------------------------------------------
-import os
 import json
+import os
 from collections import defaultdict
-from behave.runner import Context
-from behave.model import Scenario, Feature
+
 from behave.contrib.scenario_autoretry import patch_scenario_with_autoretry
+from behave.model import Feature, Scenario
+from behave.runner import Context
+
 
 def before_step(context: Context, step):
     context.step = step
@@ -61,6 +63,8 @@ def before_scenario(context: Context, scenario: Scenario):
                 context.did_method = tag.split("DidMethod_")[1]
             if "Schema_" in tag:
                 # Get and assign the schema to the context
+                if context.anoncreds:
+                    tag = tag.replace("Schema_", "Anoncreds_Schema_")
                 try:
                     schema_json_file = open("features/data/" + tag.lower() + ".json")
                     schema_json = json.load(schema_json_file)
@@ -441,6 +445,17 @@ def setup_scenario_context(context: Context, scenario: Scenario):
     #   "Faber": "Acme"
     # }
     context.mediator_dict = {}
+
+    def is_anoncreds():
+        try: 
+            return json.loads(os.environ["EXTRA_ARGS"])['wallet-type'] == "askar-anoncreds"
+        except Exception:
+            return False
+
+    # Feature run with askar-anoncreds wallet
+    #
+    # context.anoncreds = True
+    context.anoncreds = is_anoncreds()
 
 def before_feature(context, feature):
     # retry failed tests 


### PR DESCRIPTION
This allows the `askar-anoncreds` wallet and endpoints to be tested in the test harness by running the command `BACKCHANNEL_EXTRA_acapy_main="{\"wallet-type\":\"askar-anoncreds\"}" ./manage run -d acapy-main -t @Anoncreds`

- has an anoncreds context that is set based on the extras env variable.
- It adds a schema and cred def in the anoncred format and passes a anoncred param to the backchannel where the endpoints are changed.
- Adds tags to the tests that are expected to pass. I only added a few tests. `v1` tests are still not passing. I figure if they should then another ticket could build off of this. Along with any other tests we feel are important to work with anoncreds.

Some imports and formatting was changed due to my ruff formatting extension. Not sure if anyone cares. 

Note: This was based off of my acapy fork which includes the recent anoncred endpoint changes. They have been merged to acapy but for some reason acapy main wasn't getting updated with the latest code for me when I was developing.