### PR TITLE
auto-detect ARM based MACs and set Docker Platform

### DIFF
--- a/manage
+++ b/manage
@@ -72,6 +72,14 @@ if [ "${PWD_HOST_FQDN}" != "" ]; then
   fi
 fi
 
+# Set default platform to linux/amd64 when running on Arm based MAC since there are no arm based images available currently.
+if [[ $OSTYPE == 'darwin'* ]]; then
+  architecture=$(uname -m)
+  if [[ "${architecture}" == 'arm'* ]] || [[ "${architecture}" == 'aarch'* ]]; then
+    export DOCKER_DEFAULT_PLATFORM=linux/amd64
+  fi
+fi
+
 # ========================================================================================================
 # Check Docker Compose
 # --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is the same fix that has went into other docker related management scripts. Detects ARM based Macs and set DOCKER_DEFAULT_PLATFORM. 
Closes #713 
Closes #554 