### PR TITLE
Remove Universal Resolver plugin for ACA-Py Test agents

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -285,8 +285,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-mime-type"))
 
-        result.append(("--plugin", "universal_resolver"))
-        result.append(("--plugin-config", "/data-mount/plugin-config.yml"))
+        result.append(("--universal-resolver"))
 
         result.append(("--plugin", "redis_queue.v1_0.events"))
         result.append(("--plugin-config", "/data-mount/plugin-config.yml"))

--- a/aries-backchannels/acapy/plugin-config.template
+++ b/aries-backchannels/acapy/plugin-config.template
@@ -1,11 +1,5 @@
 version: '2'
 
-http_uniresolver:
-  endpoint:
-    http://REPLACE_WITH_DOCKERHOST:8080/1.0/identifiers
-  methods:
-    # - sov
-    - orb
 
 redis_queue:
   connection: 

--- a/aries-backchannels/acapy/requirements-latest.txt
+++ b/aries-backchannels/acapy/requirements-latest.txt
@@ -1,1 +1,1 @@
-aries-cloudagent
+aries-cloudagent[indy, bbs, askar]

--- a/aries-backchannels/acapy/requirements-main.txt
+++ b/aries-backchannels/acapy/requirements-main.txt
@@ -1,2 +1,1 @@
 aries-cloudagent[indy, bbs, askar]@git+https://github.com/hyperledger/aries-cloudagent-python@main
-acapy-resolver-universal@git+https://github.com/sicpa-dlab/acapy-resolver-universal.git@v0.1.0


### PR DESCRIPTION
This PR closes #781 

This has removed the universal resolver plugin from the ACA-Py test agents and the test agents now default to using the `--universal-resolver` option when starting which uses the public `https://dev.uniresolver.io`.  My opinion is that this keeps the test harness simpler as long as this public universal resolver is maintained. If the reviewers believe this is a bad choice, I'll have to move this PR to Draft and create a local universal resolver. 

This PR does not remove the usage of the plugin nor the creation of the service in the manage script. This is because there are frameworks (afgo) that are using it. I don't know the state of that framework and its relationship to this uni-resolver. I think it is safer to leave in at this point. 

I've executed the following runsets to check for side effects of these changes. The executions were identical to the executions existing in the interop test pipeline.
```
./manage runset acapy -r
```
```
./manage start orb
./manage runset afgo -r
```

This PR also adds some libraries to the requirement to the released version of the acapy agent to fix the askar error we are getting when using the release acapy. It just mimics what acapy-main is doing. 