### PR TITLE
pinned allure-behave at working 2.13.3

### DIFF
--- a/aries-test-harness/requirements.txt
+++ b/aries-test-harness/requirements.txt
@@ -1,2 +1,2 @@
 behave
-allure-behave
+allure-behave==2.13.3


### PR DESCRIPTION
There is an integration problem with allure-behave 2.13.4. This PR pins to the working version 2.13.3.