### PR TITLE
use alpine instead of debian for ngrok

### DIFF
--- a/manage
+++ b/manage
@@ -811,7 +811,7 @@ startHarness(){
       NGROK_AUTHTOKEN="harness_${NGROK_AUTHTOKEN}"
     fi
     # start the ngrok container but don't start the tunnels in the config yml file. We will start them later as needed for each agent.
-    docker run -d --rm -v $(pwd)/aath_ngrok_config.yml:/etc/ngrok.yml -e NGROK_CONFIG=/etc/ngrok.yml -e NGROK_AUTHTOKEN="${NGROK_AUTHTOKEN}" --name agents-ngrok --network aath_network -p 4040:4040 ngrok/ngrok start --all
+    docker run -d --rm -v $(pwd)/aath_ngrok_config.yml:/etc/ngrok.yml -e NGROK_CONFIG=/etc/ngrok.yml -e NGROK_AUTHTOKEN="${NGROK_AUTHTOKEN}" --name agents-ngrok --network aath_network -p 4040:4040 ngrok/ngrok:alpine start --all
     
     export NGROK_NAME="agents-ngrok"
   else


### PR DESCRIPTION
This PR is an attempt to deal with cancelled mobile wallet test jobs when the ngrok containers are used with test agents and the GitHub pipeline is using standard runners. 
The default ngrok/ngrok container which is debian has been replaced with an alpine lightweight ngrok container. Hopefully this will make the difference and solve the job cancellation issue.