### PR TITLE
Calibrate qualified peer did tests to acapy PR 2862

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -399,7 +399,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             # This is a did-exchange message based on a Public DID non-invitation
             request_id = message["request_id"]
             push_resource(request_id, "didexchange-msg", message)
-        elif message["connection_protocol"] == "didexchange/1.0":
+        elif message["connection_protocol"] == "didexchange/1.0" or message["connection_protocol"] == "didexchange/1.1":
             # This is an did-exchange message based on a Non-Public DID invitation
             invitation_id = message["invitation_msg_id"]
             push_resource(invitation_id, "didexchange-msg", message)
@@ -1027,6 +1027,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             attachments = data.get("attachments", [])
             handshake_protocols = data.get("handshake_protocols", None)
             formatted_attachments = []
+            use_did_method = data.get("use_did_method", None)
+            use_did = data.get("use_did", None)
 
             for attachment in attachments:
                 message_type = attachment["@type"]
@@ -1080,6 +1082,12 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 ]
             else:
                 data["handshake_protocols"] = handshake_protocols or []
+
+            if use_did_method:
+                data["use_did_method"] = use_did_method
+
+            if use_did:
+                data["use_did"] = use_did
 
             # If mediator_connection_id is included we should use that as the mediator for this connection
             if mediation_id:
@@ -1170,6 +1178,11 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 command, message_name="didexchange-msg"
             )
             return (wh_status, wh_text)
+
+        # If data is not none and contains use_did_method, add it to the agent operation
+        if data and "use_did_method" in data:
+            agent_operation += f"?use_did_method={data['use_did_method']}"
+            data.pop("use_did_method")
 
         (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
         if resp_status == 200:
@@ -2181,7 +2194,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             if topic == "connection":
                 # if the response contains didexchange/1.0, swap out the connection states for the did exchange states
                 # if "didexchange/1.0" in resp_json["connection_protocol"]:
-                if "didexchange/1.0" in data:
+                if "didexchange/1.0" in data or "didexchange/1.1" in data:
                     data = replace_state_values(
                         data,
                         old_state=agent_state,

--- a/aries-test-harness/features/0793-peer-did.feature
+++ b/aries-test-harness/features/0793-peer-did.feature
@@ -1,6 +1,6 @@
 # https://github.com/hyperledger/aries-rfcs/tree/main/features/0793-unqualfied-dids-transition
 
-@QualifiedDIDs @RFC0793 @UsesCustomParameters @Anoncreds
+@QualifiedDIDs @RFC0793 @Anoncreds
 Feature: Qualified DID - Unqualified DID Transition
    In order to more effectivley interoperate with other Aries Agents
    as an Aries Framework
@@ -10,12 +10,12 @@ Feature: Qualified DID - Unqualified DID Transition
    @T001-RFC0793 @critical @AcceptanceTest
    Scenario Outline: Establish a connection with DID Exchange between two agents utilizing qualified did:peer DIDs
       Given we have "2" agents
-         | name | role      | start_parameters   |
-         | Acme | requester | <start_parameters> |
-         | Bob  | responder | <start_parameters> |
+         | name | role      |
+         | Acme | requester |
+         | Bob  | responder |
       When "Bob" sends an invitation to "Acme" with <peer_did_method>
-         | use_public_did |
-         | True           |
+         | use_public_did | handshake_protocols                 |
+         | False          | https://didcomm.org/didexchange/1.1 |
       And "Acme" receives the invitation
       And "Acme" sends the request to "Bob"
       And "Bob" receives the request
@@ -25,62 +25,48 @@ Feature: Qualified DID - Unqualified DID Transition
       Then "Acme" and "Bob" have a connection
 
       Examples:
-         | peer_did_method | start_parameters                                               |
-         | unqualified     | use_running_agent                                              |
-         #| did:peer:1      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-1"]} |
-         | did:peer:2      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-2"]} |
-         #| did:peer:3      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-3"]} |
-         | did:peer:4      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-4"]} |
+         | peer_did_method |
+         | unqualified     |
+         #| did:peer:1      |
+         | did:peer:2      |
+         #| did:peer:3      |
+         | did:peer:4      |
 
 
    @T002-RFC0793 @critical @AcceptanceTest
    Scenario Outline: Establish a connection with DID Exchange between two agents utilizing qualified did:peer DIDs with responder not set to send qualified Peer DIDs
       Given we have "2" agents
-         | name | role      | start_parameters   |
-         | Acme | requester | <start_parameters> |
-         | Bob  | responder | use_running_agent  |
+         | name | role      |
+         | Acme | requester |
+         | Bob  | responder |
       When "Bob" sends an invitation to "Acme" with <peer_did_method>
-         | use_public_did |
-         | True           |
+         | use_public_did | handshake_protocols                 |
+         | False          | https://didcomm.org/didexchange/1.1 |
       And "Acme" receives the invitation
-      And "Acme" sends the request to "Bob"
+      And "Acme" sends the request to "Bob" with <requester_peer_did_method>
       And "Bob" receives the request
       And "Bob" sends a response to "Acme"
       And "Acme" receives the response
       And "Acme" sends complete to "Bob"
       Then "Acme" and "Bob" have a connection
 
-      # These Sceanrio Examples can onlu be used if we run the these did:peer tests in its own runset.
-      # This will rely on the wallet type being used on the ./manage start command.
-      # For example the EXTRA_ARGS environment variable or passing an ACA-Py config file like issuer_anoncreds.yaml with the AGENT_CONFIG_FILE environment variable.
-      # Examples:
-      #    | peer_did_method | start_parameters                                               |
-      #    | did:peer:1      | {"flags":["emit-did-peer-1"]} |
-      #    | did:peer:2      | {"flags":["emit-did-peer-2"]} |
-      #    | did:peer:3      | {"flags":["emit-did-peer-3"]} |
-      #    | did:peer:4      | {"flags":["emit-did-peer-4"]} |
-
-      # These Sceanrio Examples can be used if we run the these did:peer tests in the same runset as the unqualified did:peer tests.
-      # This will restart acapy with a different wallet type.
       Examples:
-         | peer_did_method | start_parameters                                               |
-         #| did:peer:1      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-1"]} |
-         | did:peer:2      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-2"]} |
-         #| did:peer:3      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-3"]} |
-         | did:peer:4      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-4"]} |
+         | peer_did_method | requester_peer_did_method |
+         | unqualified     | did:peer:2                |
+         | unqualified     | did:peer:4                |
 
 
    @T003-RFC0793 @critical @AcceptanceTest
    Scenario Outline: Establish a connection with DID Exchange between two agents utilizing qualified did:peer DIDs with responder set to send a different Peer DID method
       Given we have "2" agents
-         | name | role      | start_parameters             |
-         | Acme | requester | <start_parameters>           |
-         | Bob  | responder | <responder_start_parameters> |
+         | name | role      |
+         | Acme | requester |
+         | Bob  | responder |
       When "Bob" sends an invitation to "Acme" with <peer_did_method>
-         | use_public_did |
-         | True           |
+         | use_public_did | handshake_protocols                 |
+         | False          | https://didcomm.org/didexchange/1.1 |
       And "Acme" receives the invitation
-      And "Acme" sends the request to "Bob"
+      And "Acme" sends the request to "Bob" with <requester_peer_did_method>
       And "Bob" receives the request
       And "Bob" sends a response to "Acme"
       And "Acme" receives the response
@@ -88,9 +74,7 @@ Feature: Qualified DID - Unqualified DID Transition
       Then "Acme" and "Bob" have a connection
 
       Examples:
-         | peer_did_method | start_parameters                                               | responder_start_parameters                                     |
-         #| did:peer:1      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-1"]} | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-3"]} |
-         | did:peer:2      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-2"]} | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-4"]} |
-         #| did:peer:3      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-3"]} | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-1"]} |
-         | did:peer:4      | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-4"]} | {"wallet-type":"askar-anoncreds", "flags":["emit-did-peer-2"]} |
+         | peer_did_method | requester_peer_did_method |
+         | did:peer:2      | did:peer:4                |
+         | did:peer:4      | did:peer:2                |
 

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -51,12 +51,19 @@ def step_impl(context, responder: str, requester: str, peer_did_method: str = No
                 data = {"use_public_did": True}
             else:
                 data = {"use_public_did": False}
+            # get handshake_protocols value from the table and add it to an array in the data
+            if row["handshake_protocols"]:
+                data["handshake_protocols"] = row["handshake_protocols"].split(", ")
+                
+            
     else:
         data = {"use_public_did": False}
 
     # if peer_did_method is set, then save it to the context for validation later in the tests
-    if peer_did_method:
+    if peer_did_method and peer_did_method != "unqualified":
         context.peer_did_method = peer_did_method
+        # append use_did_method to the data
+        data["use_did_method"] = peer_did_method
 
     # If mediator is set for the current connection, set the mediator_connection_id
     mediator = context.mediator_dict.get(responder)
@@ -254,26 +261,47 @@ def step_impl(context, requester):
                 "connection_id"
             ]
 
-
+@when('"{requester}" sends the request to "{responder}" with {requester_peer_did_method}')
 @when('"{requester}" sends the request to "{responder}"')
-def step_impl(context, requester, responder):
+def step_impl(context, requester, responder, requester_peer_did_method=None):
     requester_url: str = context.config.userdata.get(requester)
     requester_connection_id = context.connection_id_dict[requester][responder]
+
+    # if peer_did_method is set, then add it to the data
+    data = {}
+    # passed in requester_peer_did_method takes presedence over the context.peer_did_method
+    if requester_peer_did_method:
+        if requester_peer_did_method != "unqualified":
+            data["use_did_method"] = requester_peer_did_method
+    else:
+        if hasattr(context, 'peer_did_method') and context.peer_did_method != "unqualified":
+            data["use_did_method"] = context.peer_did_method
+        # if use_did is set, then add it to the data
+        if hasattr(context, 'use_did') and context.use_did:
+            data["use_did"] = context.use_did
 
     (resp_status, resp_text) = agent_backchannel_POST(
         requester_url + "/agent/command/",
         "did-exchange",
         operation="send-request",
         id=requester_connection_id,
+        data=data,
     )
     assert resp_status == 200, f"resp_status {resp_status} is not 200; {resp_text}"
 
     # Check for peer did prefix in the request response
-    if hasattr(context, 'peer_did_method') and context.peer_did_method != "unqualified":
-        resp_json = json.loads(resp_text)
-        assert (
-            resp_json["my_did"].startswith(context.peer_did_method)
-        ), f"my_did {resp_json['my_did']} does not start with {context.peer_did_method}"
+    if requester_peer_did_method:
+        if requester_peer_did_method != "unqualified":
+            resp_json = json.loads(resp_text)
+            assert (
+                resp_json["my_did"].startswith(requester_peer_did_method)
+            ), f"my_did {resp_json['my_did']} does not start with {requester_peer_did_method}"
+    else:
+        if hasattr(context, 'peer_did_method') and context.peer_did_method != "unqualified":
+            resp_json = json.loads(resp_text)
+            assert (
+                resp_json["my_did"].startswith(context.peer_did_method)
+            ), f"my_did {resp_json['my_did']} does not start with {context.peer_did_method}"
 
 
 @then('"{responder}" does not receive the request')


### PR DESCRIPTION
This PR accounts for the ACA-Py qualified peer did updates made in PR 2862, https://github.com/hyperledger/aries-cloudagent-python/pull/2862

The biggest change here is that we no longer need to restart the agents with different did peer methods as a command line option. Peer did method is now on the API calls themselves. I'm leaving in the code that restarts agents just in case other frameworks require a restart to work with a new peer did method. 

Note that test T003-RFC0793 will fail until ACA-Py PR 2891 is merged. https://github.com/hyperledger/aries-cloudagent-python/pull/2891