### PR TITLE
Adjust DID prefix check on responder call

### DIFF
--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -408,8 +408,8 @@ def step_impl(context, responder: str, requester: str):
             resp_json["my_did"].startswith("did:")
         ), f"my_did {resp_json['my_did']} for {responder} does not start with did:"
         assert (
-            resp_json["their_did"].startswith(context.peer_did_method)
-        ), f"their_did {resp_json['their_did']} for {requester} does not start with {context.peer_did_method}"
+            resp_json["their_did"].startswith("did:")
+        ), f"their_did {resp_json['their_did']} for {requester} does not start with did:"
         
 
 


### PR DESCRIPTION
This PR lightens a check that expected a specific type of Peer DID on the their_did property in the Responders response from a did-exchange/accept-request. For ACA-Py If the request is sent with a specific peer did method then the DIDs in this response with have that prefix. However I'm not checking that complete prefix here in case there are other frameworks that behave differently in this case. 