### PR TITLE
Remove redis plugin install from acapy-main container

### DIFF
--- a/aries-backchannels/acapy/Dockerfile.acapy-redis
+++ b/aries-backchannels/acapy/Dockerfile.acapy-redis
@@ -17,7 +17,7 @@ COPY python/requirements.txt python/
 COPY acapy/requirements-main.txt acapy/
 
 RUN pip install -r python/requirements.txt -r acapy/requirements-main.txt
-RUN pip install git+https://github.com/bcgov/aries-acapy-plugin-redis-events.git
+RUN pip install git+https://github.com/hyperledger/aries-acapy-plugins@main#subdirectory=redis_events
 
 # Copy the necessary files from the AATH Backchannel sub-folders
 COPY python python

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -287,7 +287,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         result.append(("--universal-resolver"))
 
-        #result.append(("--plugin", "redis_queue.v1_0.events"))
         result.append(("--plugin", "redis_events.v1_0.redis_queue.events"))
         result.append(("--plugin-config", "/data-mount/plugin-config.yml"))
         

--- a/aries-backchannels/acapy/requirements-main.txt
+++ b/aries-backchannels/acapy/requirements-main.txt
@@ -1,2 +1,1 @@
 aries-cloudagent[indy, bbs, askar]@git+https://github.com/hyperledger/aries-cloudagent-python@main
-git+https://github.com/hyperledger/aries-acapy-plugins@main#subdirectory=redis_events


### PR DESCRIPTION
This PR removes the redis queue plugin from being installed in the acapy-main container. It is now as it was before which is only used if someone builds the acapy-redis container. 

This should solve the recent acapy test failures in the AATH Interop test pipeline.