### PR TITLE
added debug statements to action to find logs

### DIFF
--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -52,6 +52,15 @@ runs:
       uses: jwalton/gh-docker-logs@v2
       with:
         dest: "./.logs/docker-logs"
+    - name: Debug List docker log files
+      run: ls -l ./.logs/docker-logs
+      shell: bash
+    - name: Debug List agent log files
+      run: ls -l ./.logs
+      shell: bash
+    - name: Debug List agent log files in AATH folder
+      run: ls -l /aries-agent-test-harness/.logs
+      shell: bash
     - name: archive logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The last PR did not pick up the agent logs. Added debug statements to the action to list the folders in questions to find the logs in the agent containers. 

To test this we should only need to run one of the acapy runsets in the GitHub pipeline.