### PR TITLE
Fix agent logs in pipeline

### DIFF
--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -58,8 +58,9 @@ runs:
         pwd
         ls -ltr
         ls -l /
-        ls -l /aries-test-harness
-        ls -l /aries-agent-test-harness
+        ls -l ./test-harness
+        ls -l ./test-harness/.logs
+        ls -l ./test-harness/logs
       shell: bash
     - name: archive logs
       if: ${{ always() }}
@@ -73,7 +74,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: agent-logs
-        path: /aries-test-harness/.logs
+        path: ./test-harness/.logs
         retention-days: 14
 branding:
   icon: "mic"

--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -52,16 +52,6 @@ runs:
       uses: jwalton/gh-docker-logs@v2
       with:
         dest: "./.logs/docker-logs"
-    - name: Debug where are we
-      run: |
-        set -x
-        pwd
-        ls -ltr
-        ls -l /
-        ls -l ./test-harness
-        ls -l ./test-harness/.logs
-        ls -l ./test-harness/logs
-      shell: bash
     - name: archive logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This should be the last PR in relation to gathering the agent logs for each runset.  This has been tested in my working branch and is successful. 
There will be two zipped artifacts at the end of each run, one will be the container-logs that have the logs to all the supporting services of the tests. The second artifact will be agent-logs which will contain all the logs for acme to mallory, along with a request log that captures test harness to backchannel communications.