### PR TITLE
Change parallelism to 1 in GHA runs

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'schedule' && github.repository == 'hyperledger/aries-agent-test-harness') || (github.event_name != 'schedule')
     strategy:
-      max-parallel: 4
+      max-parallel: 1
       matrix:
         test-workflow: ${{ fromJson(needs.get-test-harnesses.outputs.harnesses) }}
       fail-fast: false


### PR DESCRIPTION
Attempts to address #835 .  We don’t really care how long the runs take, but we would like the results to be accurate.