### PR TITLE
Increase timeout for restarting agents

### DIFF
--- a/.github/workflows/test-harness-acapy-afj.yml
+++ b/.github/workflows/test-harness-acapy-afj.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       LEDGER_URL_CONFIG: "http://localhost:9000"
       TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+      START_TIMEOUT: 120
     steps:
       - name: checkout-test-harness
         uses: actions/checkout@v4

--- a/manage
+++ b/manage
@@ -276,7 +276,7 @@ setDockerEnv() {
   fi
 
   # variables that have the same variable name as what is being set for the container
-  declare -a GENERAL_VARIABLES=("DOCKERHOST" "NGROK_NAME" "CONTAINER_NAME" "AIP_CONFIG" "AGENT_CONFIG_FILE" "GENESIS_URL" "GENESIS_FILE")
+  declare -a GENERAL_VARIABLES=("DOCKERHOST" "NGROK_NAME" "CONTAINER_NAME" "AIP_CONFIG" "AGENT_CONFIG_FILE" "GENESIS_URL" "GENESIS_FILE" "START_TIMEOUT")
   for var in "${GENERAL_VARIABLES[@]}"; do
     if [[ -n "${!var}" ]]; then
       DOCKER_ENV+=" -e ${var}=${!var}"


### PR DESCRIPTION
Increased the timeout for restarting agents mid feature run. This happens in the DIDTransport tests. This is an attempt to fix the failures in the ACA-Py and AFJ runset where sometimes running in the context of the interop test pipeline most tests will fail. It looks as if at some point in the DIDTransport tests the acapy agent either fails to start or the test is not waiting long enough for it to be started and make the `status` api call then continue the tests. This increases the wait time to check the status to see if it is just ACA-py taking a little more time to startup in that environment. 