### PR TITLE
Upgrade python to 3.12 in acapy-main backchannel

### DIFF
--- a/aries-backchannels/acapy/Dockerfile.acapy-main
+++ b/aries-backchannels/acapy/Dockerfile.acapy-main
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \


### PR DESCRIPTION
ACA-Py recently upgraded to python version 3.12. Having the docker image be 3.9-slim-bullseye caused compatibility issues with the libraries. Possibly using a different image would have more success figuring out libraries and allow acapy to install via a 3.9 image. 

I think it's acceptable to require a 3.12 image to use acapy with a 3.12 dependency and hence the change here.