### PR TITLE
JSON-LD tests adding credentialSubject.id

### DIFF
--- a/aries-test-harness/agent_test_utils.py
+++ b/aries-test-harness/agent_test_utils.py
@@ -56,10 +56,10 @@ def get_relative_timestamp_to_epoch(timestamp):
 
 
 def format_cred_proposal_by_aip_version(
-    context, aip_version, cred_data, connection_id: Optional[str] = None, filters=None
+    context, aip_version, cred_data, connection_id: Optional[str] = None, filters=None, did_for_id=None
 ):
     if aip_version == "AIP20":
-        filters = amend_filters_with_runtime_data(context, filters)
+        filters = amend_filters_with_runtime_data(context, filters, did_for_id)
         credential_proposal = {
             "credential_preview": {
                 "@type": "issue-credential/2.0/credential-preview",
@@ -80,7 +80,7 @@ def get_schema_name(context):
         return context.schema["schema_name"]
 
 
-def amend_filters_with_runtime_data(context, filters):
+def amend_filters_with_runtime_data(context, filters, did_for_id=None):
     schema_name = get_schema_name(context)
     # This method will need comdification as new types of filters are used. Intially "indy" is used.
     if "indy" in filters:
@@ -131,6 +131,9 @@ def amend_filters_with_runtime_data(context, filters):
                 + "Z"
             )
             credential["issuanceDate"] = created_datetime
+        # Check if "credentialSubject" is in json_ld and then check if "id" is not already in "credentialSubject"
+        if did_for_id and "credentialSubject" in json_ld["credential"] and "id" not in json_ld["credential"]["credentialSubject"]:
+            json_ld["credential"]["credentialSubject"]["id"] = did_for_id
 
     return filters
 

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -354,10 +354,8 @@ def step_impl(context, verifier):
     resp_json = json.loads(resp_text)
     assert resp_json["state"] == "done"
 
-    # FIXME: why do we only store the verified property if support_revocation is enabled?
-    if context.support_revocation:
-        verified = resp_json["verified"] == True or resp_json["verified"] == "true"
-        context.credential_verification_dict[context.presentation_thread_id] = verified
+    verified = resp_json["verified"] == True or resp_json["verified"] == "true"
+    context.credential_verification_dict[context.presentation_thread_id] = verified
 
 
 @then('"{prover}" has the proof verified')

--- a/aries-test-harness/features/steps/0454-present-proof-v2-v3.py
+++ b/aries-test-harness/features/steps/0454-present-proof-v2-v3.py
@@ -379,11 +379,10 @@ def step_impl(context, verifier):
     resp_json = json.loads(resp_text)
     assert resp_json["state"] == "done"
 
-    if context.support_revocation:
-        # Add the verified property returned to the credential verification dictionary to check in subsequent steps. Key by presentation thread id
-        context.credential_verification_dict[
-            context.presentation_thread_id
-        ] = strtobool(resp_json["verified"])
+    # Add the verified property returned to the credential verification dictionary to check in subsequent steps. Key by presentation thread id
+    context.credential_verification_dict[
+        context.presentation_thread_id
+    ] = strtobool(resp_json["verified"])
 
 
 @then('"{prover}" has the proof with formats verified')


### PR DESCRIPTION
This PR fixes a check on for the verification of a proof where it was only getting checked for revokable credentials. 

It also fixes the failure of JSON-LD tests that, once the fix above where made, failed to be verified. As recommended by ACAPy maintainers the credentialSubject.id was added to the credential when issued. This id is a did created by the holder. 

ACA-Py runsets have been executed to check for side effects of these changes.