### PR TITLE
Update generate-summary-results.yml

### DIFF
--- a/.github/workflows/generate-summary-results.yml
+++ b/.github/workflows/generate-summary-results.yml
@@ -4,6 +4,10 @@ on:
 defaults:
   run:
     shell: bash
+
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update permissions on the generate-summary-job, presumably because of some change to the GitHub token handling.  Not certain this will work -- seemed to work in some other repos with an issue like this, not in other.