### PR TITLE
added more permissions to workflow

### DIFF
--- a/.github/workflows/generate-summary-results.yml
+++ b/.github/workflows/generate-summary-results.yml
@@ -7,6 +7,8 @@ defaults:
 
 permissions:
   contents: write
+  pull-requests: read
+  statuses: write
 
 jobs:
   test:


### PR DESCRIPTION
This PR is an attempt to fix the `Error: Resource not accessible by integration` issue happening for the last few interop pipeline runs in the generate summary results workflow. If may or may not solve the issue. 