### PR TITLE
Remove upload logs because action is failing

### DIFF
--- a/.github/workflows/test-harness-acapy-ariesvcx.yml
+++ b/.github/workflows/test-harness-acapy-ariesvcx.yml
@@ -44,10 +44,6 @@ jobs:
           TEST_AGENTS: "-d acapy-main -b aries-vcx"
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@RFC0793 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws"
           REPORT_PROJECT: acapy-b-aries-vcx
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-logs
-          path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
         if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-ariesvcx-acapy.yml
+++ b/.github/workflows/test-harness-ariesvcx-acapy.yml
@@ -48,10 +48,6 @@ jobs:
           TEST_AGENTS: "-d aries-vcx -b acapy-main"
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@RFC0793 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws"
           REPORT_PROJECT: aries-vcx-b-acapy
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-logs
-          path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
         if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
+++ b/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
@@ -44,10 +44,6 @@ jobs:
           TEST_AGENTS: "-d aries-vcx"
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@RFC0023,@RFC0793 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws"
           REPORT_PROJECT: aries-vcx
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-logs
-          path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
         if: ${{ always() }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure

--- a/.github/workflows/test-harness-ariesvcx-javascript.yml
+++ b/.github/workflows/test-harness-ariesvcx-javascript.yml
@@ -37,10 +37,6 @@ jobs:
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@revocation -t ~@T005-HIPE0011 -t ~@T006.1-HIPE0011 -t ~@RFC0025 -t ~@RFC0183 -t ~@RFC0211 -t ~@RFC0434 -t ~@RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
           REPORT_PROJECT: aries-vcx-b-javascript
         continue-on-error: true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-logs
-          path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:

--- a/.github/workflows/test-harness-javascript-ariesvcx.yml
+++ b/.github/workflows/test-harness-javascript-ariesvcx.yml
@@ -37,11 +37,6 @@ jobs:
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160 -t ~@T003-RFC0160 -t ~@T004-RFC0160 -t ~@revocation -t ~@RFC0025 -t ~@RFC0183 -t ~@RFC0211 -t ~@RFC0434 -t ~@RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
           REPORT_PROJECT: javascript-b-aries-vcx
         continue-on-error: true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-logs
-          path: ./test-harness/.logs/
-      - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: javascript-b-aries-vcx

--- a/.github/workflows/test-harness-javascript-ariesvcx.yml
+++ b/.github/workflows/test-harness-javascript-ariesvcx.yml
@@ -37,6 +37,7 @@ jobs:
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160 -t ~@T003-RFC0160 -t ~@T004-RFC0160 -t ~@revocation -t ~@RFC0025 -t ~@RFC0183 -t ~@RFC0211 -t ~@RFC0434 -t ~@RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
           REPORT_PROJECT: javascript-b-aries-vcx
         continue-on-error: true
+      - name: run-send-gen-test-results-secure
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: javascript-b-aries-vcx


### PR DESCRIPTION
Removes the action in the Aries VCX jobs to upload the log files because the job is failing.

Not sure why the error is happening, but this action is not part of any other job -- others
are welcome to investigate (I may as well, but I just want the jobs working right now).

Hmmm...seems like just changing the `overwrite` to true might solve it. But are the logs
used at all?

Error:

```
Run actions/upload-artifact@v4
  with:
    name: agent-logs
    path: ./test-harness/.logs/
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
  env:
    DOCKER_CONFIG: /home/runner/work/_temp/docker_login_1724463587634
With the provided path, there will be 5 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```


Signed-off-by: Stephen Curran <swcurran@gmail.com>
