### PR TITLE
Remove Rev Notification test from credo-acapy runset

### DIFF
--- a/.github/workflows/test-harness-acapy-credo.yml
+++ b/.github/workflows/test-harness-acapy-credo.yml
@@ -8,7 +8,7 @@ name: test-harness-acapy-credo
 # This runset uses the current main branch of ACA-Py for all of the agents except Bob (holder),
 # which uses the master branch of Credo TS. The runset covers all of the AIP 1.0 tests
 # except those that are known **not** to work with the Credo TS as the holder,
-# notably those that involve revocation.
+# notably those that involve revocation notification v1.
 #
 # Current
 #
@@ -43,7 +43,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a credo"
           TEST_AGENTS: "-d acapy-main -b credo"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
           REPORT_PROJECT: acapy-b-credo
       - name: run-send-gen-test-results-secure
         if: ${{ always() }}


### PR DESCRIPTION
There was a revocation notification test running in the credo-d-acapy runset. It was erroring on the retrieval of the notification by Bob/Holder/Credo. This PR removes that test from the runset. As Credo has no support for the thread_id used by ACA-Py in the revocation notification v1 protocol. 

See
https://credo.js.org/guides/features/aries#divergence-from-aries-rfcs

Quote:

> Revocation Notification v1 uses a different thread_id format ( indy::<revocation_registry_id>::<credential_revocation_id>) than specified in the Aries RFC | Any agents adhering to the revocation notification v1 RFC will not be interoperable with Credo. However, revocation notification is considered an optional portion of revocation, therefore this will not break core revocation behavior. Ideally agents should use and implement revocation notification v2. | Actual implementations (ACA-Py) of revocation notification v1 so far have implemented this different format, so this format change was made to remain interoperable.
> 		
> Revocation Notification v1 uses a different thread_id format ( indy::<revocation_registry_id>::<credential_revocation_id>) than specified in the Aries RFC	Any agents adhering to the [revocation notification v1 RFC](https://github.com/hyperledger/aries-rfcs/tree/main/features/0183-revocation-notification) will not be interoperable with Credo. However, revocation notification is considered an optional portion of revocation, therefore this will not break core revocation behavior. Ideally agents should use and implement revocation notification v2.	Actual implementations (ACA-Py) of revocation notification v1 so far have implemented this different format, so this format change was made to remain interoperable.
> 