### PR TITLE
Included hidden files when saving logs

### DIFF
--- a/actions/run-test-harness-wo-reports/action.yml
+++ b/actions/run-test-harness-wo-reports/action.yml
@@ -59,6 +59,7 @@ runs:
         name: container-logs
         path: .logs
         retention-days: 14
+        include-hidden-files: true
     - name: archive agent logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
@@ -66,6 +67,7 @@ runs:
         name: agent-logs
         path: ./test-harness/.logs
         retention-days: 14
+        include-hidden-files: true
 branding:
   icon: "mic"
   color: "purple"


### PR DESCRIPTION
3 weeks ago there was a change to `actions/upload-artifact` which removed support for hidden files by default. You now have to explicitly set include hidden files when using the action. Since we store our log in .logs the upload wasn't working. This PR adds the include hidden to our workflow.