### PR TITLE
Feature: Remote Agent support in OATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The following diagram provides an overview of the architecture of the AATH.
 - The `./manage` script also supports running the services needed by the tests, such as a [von-network](https://github.com/bcgov/von-network) Indy instance, an [Indy tails service](https://github.com/bcgov/indy-tails-server), a universal resolver and a `did:orb` instance.
   - Environment variables can also be used to configure a test run to use public services, such as the BCovrin test Indy instance. You'll find examples of using environment variables to use those services in various documentation files in this repo.
 - A special Test Agent called `mobile` can be used in the `Bob` role to test mobile wallet apps on phones. See [this document](./MOBILE_AGENT_TESTING.md) for details.
+- OATH has the ability to include remote agents in other/external environments into an interop test run. 
+This allows the verification of agents unmanaged by the test harness with other agents. See [this document](./REMOTE_AGENT_TESTING.md) for more details on the `remote` option. 
 
 ## Aries Agent Test Harness Terminology
 

--- a/REMOTE_AGENT_TESTING.md
+++ b/REMOTE_AGENT_TESTING.md
@@ -1,0 +1,76 @@
+# Remote Agent Testing in OATH
+
+OWL Agent Test Harness is a powerful tool for running verifiable credential and decentralized identity interoperability tests. It supports a variety of agent configurations, including running agents locally that are test harness managed, or remotely, unmanaged by the test harness. This guide covers the **remote** option, allowing you to execute interoperability tests with agents running on remote servers in development, test, staging, or production environments, communicating with other remote agents or test harness managed agents.
+
+## Prerequisites
+
+Before using the `remote` option, make sure you have:
+
+- A running remote instance of an agent you want to connect to and test with.
+- The agent(s) controller has implemented the test api (backchannel api) for the protocols desired to be tested.
+- OATH is cloned and set up locally or on a machine with network access to your remote agent(s).
+- The remote agent(s) are configured with the same ledgers or tails server that OATH is configured with.
+- Valid configuration URLs for remote agents, including public endpoints to the test api in the agent controller.
+
+## Command Structure
+
+When running the test harness with remote agents, the basic command structure for setting remote agents is as follows:
+
+```bash
+./manage run -a remote --aep <acme_endpoint> -b remote --bep <bob_endpoint> -f remote --fep <faber_endpoint> -m remote --mep <mallory_endpoint> 
+```
+
+For any of the agent flags, `-a`, `-b`, `-f`, `-m`, if the agent is set to `remote` then the test harness will look for the long option of `--aep`, `--bep`, `--fep`, and `-mep` for the endpoint of that particular remote agent. 
+
+#### Long Options for Remote Endpoints
+
+- --aep: ACME agent’s remote endpoint URL (e.g., http://remote-acme.com).
+- --bep: BOB agent’s remote endpoint URL.
+- --fep: FABER agent’s remote endpoint URL.
+- --mep: MALLORY agent’s remote endpoint URL.
+
+#### Example Command
+```bash
+LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io \
+TAILS_SERVER_URL_CONFIG=https://tails.vonx.io \
+./manage run \
+  -a remote --aep http://remote-acme.com \
+  -b acapy-main -f acapy-main -m acapy-main \
+  -t @T002-RFC0160
+```
+This example command will test a remote agent in the role if Acme, an issuer/verifier in conjuction with test harness managed acapy agents playing the other roles of Bob, Faber, and Mallory.
+
+Any combination of remote and test harness managed agents is testable, including all remote if one is so inclined.
+
+#### Local Example
+
+To verify and see the remote implementation in the test harness working locally, you will need to run one of the test harness agents outside of the OATH docker network. Then use that agent as a remote agent. 
+
+Build the local agents:
+```bash
+./manage build -a acapy-main
+```
+
+Run a remote agent locally:
+```bash
+docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v /Users/Shel/Projects/BC.gov/aries-agent-test-harness_nodlesh/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=host.docker.internal -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false
+```
+
+Run the tests:
+```bash
+LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -a acapy-main -b remote --bep http://0.0.0.0:9031 -f acapy-main -m acapy-main -t @T002-RFC0160
+```
+
+#### Handling Errors
+
+If you encounter any issues while using the remote option, check the following:
+
+- Endpoint URLs and Ports: Ensure the URLs and ports specified are correct and accessible from your local machine or environment the test harness is running in.
+- Agent Configuration: Make sure the agents on the remote server are properly configured and running.
+- Logs: Check the remote agents log in conjuction with the other agents logs for hints on what could be causing the errors. 
+
+## Conclusion
+
+The remote option in the Test Harness allows you to test verifiable credential interactions with agents running in remote environments. This flexibility essentially allows you to verify that your agent(s) can successfully interop with other agents for the implemented protocols. 
+
+For any extra troubleshooting please consult with the [OWL maintainers on Discord](https://discord.com/channels/1022962884864643214/1214965981470924911).

--- a/REMOTE_AGENT_TESTING.md
+++ b/REMOTE_AGENT_TESTING.md
@@ -53,13 +53,19 @@ Build the local agents:
 
 Run a remote agent locally:
 ```bash
-docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v  $PWD/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=host.docker.internal -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false
+./start-remote-agent-demo.sh
 ```
 
 Run the tests:
 ```bash
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -a acapy-main -b remote --bep http://0.0.0.0:9031 -f acapy-main -m acapy-main -t @T002-RFC0160
 ```
+
+Shutdown the remote agent
+```bash
+./end-remote-agent-demo.sh
+```
+
 
 #### Handling Errors
 

--- a/REMOTE_AGENT_TESTING.md
+++ b/REMOTE_AGENT_TESTING.md
@@ -53,7 +53,7 @@ Build the local agents:
 
 Run a remote agent locally:
 ```bash
-docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v /Users/Shel/Projects/BC.gov/aries-agent-test-harness_nodlesh/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=host.docker.internal -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false
+docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v  <location_of_test_harness>/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=host.docker.internal -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false
 ```
 
 Run the tests:

--- a/REMOTE_AGENT_TESTING.md
+++ b/REMOTE_AGENT_TESTING.md
@@ -53,7 +53,7 @@ Build the local agents:
 
 Run a remote agent locally:
 ```bash
-docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v  <location_of_test_harness>/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=host.docker.internal -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false
+docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v  $PWD/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=host.docker.internal -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false
 ```
 
 Run the tests:

--- a/end-remote-agent-demo.sh
+++ b/end-remote-agent-demo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# set -x
+
+echo Stoping remote agent:
+docker stop fred_agent
+echo Removing remote agent:
+docker rm fred_agent

--- a/end-remote-agent-demo.sh
+++ b/end-remote-agent-demo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # set -x
 
-echo Stoping remote agent:
+echo Stopping remote agent:
 docker stop fred_agent
 echo Removing remote agent:
 docker rm fred_agent

--- a/manage
+++ b/manage
@@ -1500,9 +1500,6 @@ case "${COMMAND}" in
   dockerhost)
       echo ${DOCKERHOST}
     ;;
-  dockerhost_url_templates)
-      dockerhost_url_templates
-    ;;
   *)
       usage
     ;;

--- a/manage
+++ b/manage
@@ -1105,17 +1105,29 @@ runTests() {
   if [[ ${COMMAND} != "dry-run" ]]; then
     echo ""
     echo "Exporting Agent logs."
-    docker logs acme_agent > .logs/acme_agent.log
-    docker logs bob_agent > .logs/bob_agent.log
-    docker logs faber_agent > .logs/faber_agent.log
-    docker logs mallory_agent > .logs/mallory_agent.log
-
-    if [[ "${USE_NGROK}" = "true" ]]; then
-      echo "Exporting ngrok Agent logs."
-      docker logs acme_agent-ngrok > .logs/acme_agent-ngrok.log
-      docker logs bob_agent-ngrok > .logs/bob_agent-ngrok.log
-      docker logs faber_agent-ngrok > .logs/faber_agent-ngrok.log
-      docker logs mallory_agent-ngrok > .logs/mallory_agent-ngrok.log
+    if [[ IS_ACME_REMOTE -eq 0 ]]; then
+      docker logs acme_agent > .logs/acme_agent.log
+      if [[ "${USE_NGROK}" = "true" ]]; then
+        docker logs acme_agent-ngrok > .logs/acme_agent-ngrok.log
+      fi
+    fi
+    if [[ IS_BOB_REMOTE -eq 0 ]]; then
+      docker logs bob_agent > .logs/bob_agent.log
+      if [[ "${USE_NGROK}" = "true" ]]; then
+        docker logs bob_agent-ngrok > .logs/bob_agent-ngrok.log
+      fi
+    fi
+    if [[ IS_FABER_REMOTE -eq 0 ]]; then
+      docker logs faber_agent > .logs/faber_agent.log
+      if [[ "${USE_NGROK}" = "true" ]]; then
+        docker logs faber_agent-ngrok > .logs/faber_agent-ngrok.log
+      fi
+    fi
+    if [[ IS_MALLORY_REMOTE -eq 0 ]]; then
+      docker logs mallory_agent > .logs/mallory_agent.log
+      if [[ "${USE_NGROK}" = "true" ]]; then
+        docker logs mallory_agent-ngrok > .logs/mallory_agent-ngrok.log
+      fi
     fi
   fi
 

--- a/manage
+++ b/manage
@@ -2,7 +2,9 @@
 # set -x
 
 # Set of valid agents - add new agents here
+# added remote as a valid agent to allow for remote agent testing.
 export VALID_AGENTS=$(ls aries-backchannels/*/Dockerfile.* | sed "s/^.*file.//" |  tr "\n" " " | sort -u)
+VALID_AGENTS="${VALID_AGENTS} remote"
 
 export MSYS_NO_PATHCONV=1
 # getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
@@ -33,6 +35,15 @@ TAILS_SERVER_URL_INTERNAL="$(echo ${TAILS_SERVER_URL_INTERNAL} | sed "s/:\/\/loc
 
 REDIS_CLUSTER_URL_HOST="${REDIS_CLUSTER_URL_CONFIG:-http://localhost:6377}"
 
+# Define variables for endpoints and ports
+declare ACME_ENDPOINT=""
+declare ACME_PORT=""
+declare BOB_ENDPOINT=""
+declare BOB_PORT=""
+declare FABER_ENDPOINT=""
+declare FABER_PORT=""
+declare MALLORY_ENDPOINT=""
+declare MALLORY_PORT=""
 
 # Running on Windows?
 if [[ "$OSTYPE" == "msys" ]]; then
@@ -823,20 +834,36 @@ startHarness(){
 
   # Only start agents that are asked for in the ./manage start command
   if [[ "$ACME" != "none" ]]; then
-    export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
-    startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
+    if checkAndSetRemote "ACME"; then
+      echo "ACME is set to remote."
+    else
+      export ACME_AGENT=${ACME_AGENT:-${ACME}-agent-backchannel}
+      startAgent Acme acme_agent "$ACME_AGENT" "9020-9029" 9020 9021 "$AIP_CONFIG" "$ACME"
+    fi
   fi
   if [[ "$BOB" != "none" ]]; then
-    export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
-    startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
+    if checkAndSetRemote "BOB"; then
+      echo "BOB is set to remote."
+    else
+      export BOB_AGENT=${BOB_AGENT:-${BOB}-agent-backchannel}
+      startAgent Bob bob_agent "$BOB_AGENT" "9030-9039" 9030 9031 "$AIP_CONFIG" "$BOB"
+    fi
   fi
   if [[ "$FABER" != "none" ]]; then
-    export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
-    startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
+    if checkAndSetRemote "FABER"; then
+      echo "FABER is set to remote."
+    else
+      export FABER_AGENT=${FABER_AGENT:-${FABER}-agent-backchannel}
+      startAgent Faber faber_agent "$FABER_AGENT" "9040-9049" 9040 9041 "$AIP_CONFIG" "$FABER"
+    fi
   fi
   if [[ "$MALLORY" != "none" ]]; then
-    export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
-    startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
+    if checkAndSetRemote "MALLORY"; then
+      echo "MALLORY is set to remote."
+    else
+      export MALLORY_AGENT=${MALLORY_AGENT:-${MALLORY}-agent-backchannel}
+      startAgent Mallory mallory_agent "$MALLORY_AGENT" "9050-9059" 9050 9051 "$AIP_CONFIG" "$MALLORY"
+    fi
   fi
 
   echo
@@ -863,6 +890,22 @@ startHarness(){
   if [[ "${REPORT}" = "allure" ]]; then
     writeEnvProperties
   fi
+}
+
+# Check if the agent is remote and set the endpoint and port
+checkAndSetRemote() {
+  local agent_name=$1
+  local endpoint_var="${agent_name}_ENDPOINT"
+  local port_var="${agent_name}_PORT"
+
+  if [[ "${!agent_name}" == "remote" ]]; then
+    if [[ -z "${!endpoint_var}" || -z "${!port_var}" ]]; then
+      echo "Error: ${agent_name} is set to remote, but ${endpoint_var} or ${port_var} is not set."
+      exit 1
+    fi
+    return 0
+  fi
+  return 1
 }
 
 deleteAgents() {
@@ -960,6 +1003,41 @@ runRunSet() {
   exit 0
 }
 
+# Function to build the -D options for agents when running the tests
+buildAgentOptions() {
+  local agent_name=$1
+  local endpoint_var="${agent_name}_ENDPOINT"
+  local port_var="${agent_name}_PORT"
+
+  if [[ "${!agent_name}" == "remote" ]]; then
+    if [[ -z "${!endpoint_var}" || -z "${!port_var}" ]]; then
+      echo "Error: ${agent_name} is set to remote, but ${endpoint_var} or ${port_var} is not set."
+      exit 1
+    fi
+    echo "-D ${agent_name}=${!endpoint_var}:${!port_var}"
+  else
+    # Use predefined ports for non-remote agents
+    case ${agent_name} in
+      ACME)
+        echo "-D ${agent_name}=http://0.0.0.0:9020"
+        ;;
+      BOB)
+        echo "-D ${agent_name}=http://0.0.0.0:9030"
+        ;;
+      FABER)
+        echo "-D ${agent_name}=http://0.0.0.0:9040"
+        ;;
+      MALLORY)
+        echo "-D ${agent_name}=http://0.0.0.0:9050"
+        ;;
+      *)
+        echo "Error: Unknown agent ${agent_name}"
+        exit 1
+        ;;
+    esac
+  fi
+}
+
 runTests() {
   runArgs=${@}
 
@@ -977,14 +1055,20 @@ runTests() {
   export BEHAVE_INI_TMP="$(pwd)/behave.ini.tmp"
   cp ${BEHAVE_INI} ${BEHAVE_INI_TMP}
 
+  # Build the agent options
+  ACME_OPTIONS=$(buildAgentOptions "ACME")
+  BOB_OPTIONS=$(buildAgentOptions "BOB")
+  FABER_OPTIONS=$(buildAgentOptions "FABER")
+  MALLORY_OPTIONS=$(buildAgentOptions "MALLORY")
+
   if [[ "${REPORT}" = "allure" && "${COMMAND}" != "dry-run" ]]; then
       echo "Executing tests with Allure Reports."
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" -v "$(pwd)/aries-test-harness/allure/allure-results:/aries-test-harness/allure/allure-results/" $DOCKER_ENV aries-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" -v "$(pwd)/aries-test-harness/allure/allure-results:/aries-test-harness/allure/allure-results/" $DOCKER_ENV aries-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS}
   elif [[ "${COMMAND}" = "dry-run" ]]; then
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini $DOCKER_ENV aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050 |\
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini $DOCKER_ENV aries-test-harness -k ${runArgs} ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS} |\
         grep "Feature:\|Scenario Outline\|\@" | sed "/n(u/d"
   else
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" $DOCKER_ENV aries-test-harness -k ${runArgs} -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -D Faber=http://0.0.0.0:9040 -D Mallory=http://0.0.0.0:9050
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" $DOCKER_ENV aries-test-harness -k ${runArgs} ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS}
   fi
   local docker_result=$?
   rm ${BEHAVE_INI_TMP}
@@ -1068,6 +1152,7 @@ isAgent() {
   for agent in ${VALID_AGENTS}; do
     if [[ "${1}" == "${agent}" ]]; then
         result=true
+        break
     fi
   done
 
@@ -1154,6 +1239,68 @@ if [[ "${COMMAND}" == "run" || "${COMMAND}" == "start" || "${COMMAND}" == "test"
   TAGS=""
   BEHAVE_INI=aries-test-harness/behave.ini
 
+  # Parse long options
+  TEMP_ARGS=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --aep)
+        ACME_ENDPOINT="$2"
+        shift 2
+        ;;
+      --ap)
+        ACME_PORT="$2"
+        shift 2
+        ;;
+      --bep)
+        BOB_ENDPOINT="$2"
+        shift 2
+        ;;
+      --bp)
+        BOB_PORT="$2"
+        shift 2
+        ;;
+      --fep)
+        FABER_ENDPOINT="$2"
+        shift 2
+        ;;
+      --fp)
+        FABER_PORT="$2"
+        shift 2
+        ;;
+      --mep)
+        MALLORY_ENDPOINT="$2"
+        shift 2
+        ;;
+      --mp)
+        MALLORY_PORT="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        echo -e \\n"Invalid script option: $1"\\n
+        usage
+        ;;
+      *)
+        TEMP_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  # Add remaining arguments to TEMP_ARGS
+  while [[ $# -gt 0 ]]; do
+    TEMP_ARGS+=("$1")
+    shift
+  done
+
+  # Rebuild the argument list to exclude long options
+  set -- "${TEMP_ARGS[@]}"
+
+  # Parse short options
+  OPTIND=1  # Reset OPTIND to 1 to reprocess the arguments
   while getopts "hna:b:c:f:m:r:e:d:t:v:i:" FLAG; do
     case $FLAG in
         h ) usage ;;

--- a/manage
+++ b/manage
@@ -1500,6 +1500,9 @@ case "${COMMAND}" in
   dockerhost)
       echo ${DOCKERHOST}
     ;;
+  dockerhost_url_templates)
+      dockerhost_url_templates
+    ;;
   *)
       usage
     ;;

--- a/manage
+++ b/manage
@@ -37,13 +37,13 @@ REDIS_CLUSTER_URL_HOST="${REDIS_CLUSTER_URL_CONFIG:-http://localhost:6377}"
 
 # Define variables for endpoints and ports
 declare ACME_ENDPOINT=""
-declare ACME_PORT=""
 declare BOB_ENDPOINT=""
-declare BOB_PORT=""
 declare FABER_ENDPOINT=""
-declare FABER_PORT=""
 declare MALLORY_ENDPOINT=""
-declare MALLORY_PORT=""
+declare IS_ACME_REMOTE=0
+declare IS_BOB_REMOTE=0
+declare IS_FABER_REMOTE=0
+declare IS_MALLORY_REMOTE=0
 
 # Running on Windows?
 if [[ "$OSTYPE" == "msys" ]]; then
@@ -511,10 +511,16 @@ dockerhost_url_templates() {
 
 pingAgent(){
   name=${1}
-  port=${2}
+  endpoint=${2}
+  port=${3}
 
   # ping agent using a backchannel-exposed api
-  rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null http://localhost:${port}/agent/command/status/)
+  # if port is not provided just use the endpoint
+  if [[ -z ${port} ]]; then
+    rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null ${endpoint}/agent/command/status/)
+  else
+    rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null ${endpoint}:${port}/agent/command/status/)
+  fi
   if (( ${rtnCd} == 200 )); then
     return 0
   else
@@ -867,18 +873,35 @@ startHarness(){
   fi
 
   echo
+
   # Check if agents were successfully started.
   if [[ "$ACME" != "none" ]]; then
-    waitForAgent Acme 9020
+    if [[ IS_ACME_REMOTE -eq 0 ]]; then
+      waitForAgent Acme http://localhost 9020
+    else
+      waitForAgent Acme ${ACME_ENDPOINT}
+    fi
   fi
   if [[ "$BOB" != "none" ]]; then
-    waitForAgent Bob 9030
+    if [[ IS_BOB_REMOTE -eq 0 ]]; then
+      waitForAgent Bob http://localhost 9030
+    else
+      waitForAgent Bob ${BOB_ENDPOINT}
+    fi
   fi
   if [[ "$FABER" != "none" ]]; then
-    waitForAgent Faber 9040
+    if [[ IS_FABER_REMOTE -eq 0 ]]; then
+      waitForAgent Faber http://localhost 9040
+    else
+      waitForAgent Faber ${FABER_ENDPOINT}
+    fi
   fi
   if [[ "$MALLORY" != "none" ]]; then
-    waitForAgent Mallory 9050
+    if [[ IS_MALLORY_REMOTE -eq 0 ]]; then
+      waitForAgent Mallory http://localhost 9050
+    else
+      waitForAgent Mallory ${MALLORY_ENDPOINT}
+    fi
   fi
   echo
 
@@ -897,22 +920,30 @@ checkAndSetRemote() {
   local agent_name=$1
   local endpoint_var="${agent_name}_ENDPOINT"
   local port_var="${agent_name}_PORT"
+  local is_remote_var="IS_${agent_name}_REMOTE"
 
-  if [[ "${!agent_name}" == "remote" ]]; then
-    if [[ -z "${!endpoint_var}" || -z "${!port_var}" ]]; then
-      echo "Error: ${agent_name} is set to remote, but ${endpoint_var} or ${port_var} is not set."
-      exit 1
-    fi
+  if [[ -n "${!endpoint_var}" ]]; then
+    eval $is_remote_var=1
     return 0
+  else
+    return 1
   fi
-  return 1
 }
 
 deleteAgents() {
-    deleteAgent acme_agent
-    deleteAgent bob_agent
-    deleteAgent faber_agent
-    deleteAgent mallory_agent
+    # Check if agent is remote and delete it
+    if [[ IS_ACME_REMOTE -eq 0 ]]; then
+      deleteAgent acme_agent
+    fi
+    if [[ IS_BOB_REMOTE -eq 0 ]]; then
+      deleteAgent bob_agent
+    fi
+    if [[ IS_FABER_REMOTE -eq 0 ]]; then
+      deleteAgent faber_agent
+    fi
+    if [[ IS_MALLORY_REMOTE -eq 0 ]]; then
+      deleteAgent mallory_agent
+    fi
 }
 
 deleteAgent() {
@@ -1006,18 +1037,15 @@ runRunSet() {
 # Function to build the -D options for agents when running the tests
 buildAgentOptions() {
   local agent_name=$1
-  local endpoint_var="${agent_name}_ENDPOINT"
-  local port_var="${agent_name}_PORT"
+  # need an upper case version of the agent name
+  upper_agent_name=$(printf "%s" "$agent_name" | tr '[:lower:]' '[:upper:]')
+  local endpoint_var="${upper_agent_name}_ENDPOINT"
 
-  if [[ "${!agent_name}" == "remote" ]]; then
-    if [[ -z "${!endpoint_var}" || -z "${!port_var}" ]]; then
-      echo "Error: ${agent_name} is set to remote, but ${endpoint_var} or ${port_var} is not set."
-      exit 1
-    fi
-    echo "-D ${agent_name}=${!endpoint_var}:${!port_var}"
+  if [[ -n "${!endpoint_var}" ]]; then
+    echo "-D ${agent_name}=${!endpoint_var}"
   else
     # Use predefined ports for non-remote agents
-    case ${agent_name} in
+    case ${upper_agent_name} in
       ACME)
         echo "-D ${agent_name}=http://0.0.0.0:9020"
         ;;
@@ -1056,10 +1084,10 @@ runTests() {
   cp ${BEHAVE_INI} ${BEHAVE_INI_TMP}
 
   # Build the agent options
-  ACME_OPTIONS=$(buildAgentOptions "ACME")
-  BOB_OPTIONS=$(buildAgentOptions "BOB")
-  FABER_OPTIONS=$(buildAgentOptions "FABER")
-  MALLORY_OPTIONS=$(buildAgentOptions "MALLORY")
+  ACME_OPTIONS=$(buildAgentOptions "Acme")
+  BOB_OPTIONS=$(buildAgentOptions "Bob")
+  FABER_OPTIONS=$(buildAgentOptions "Faber")
+  MALLORY_OPTIONS=$(buildAgentOptions "Mallory")
 
   if [[ "${REPORT}" = "allure" && "${COMMAND}" != "dry-run" ]]; then
       echo "Executing tests with Allure Reports."
@@ -1113,14 +1141,30 @@ stopHarness(){
   fi
 
   echo "Cleanup:"
-  echo "  - Shutting down all the agents ..."
-  docker stop acme_agent bob_agent faber_agent mallory_agent > /dev/null
-  docker rm -v acme_agent bob_agent faber_agent mallory_agent > /dev/null
-
-  stopIfExists acme_agent-ngrok
-  stopIfExists bob_agent-ngrok
-  stopIfExists faber_agent-ngrok
-  stopIfExists mallory_agent-ngrok
+  echo "  - Shutting down all test harness managed agents ..."
+  # Check if each agent is remote and only stop and remove the container if it is not remote
+  if [[ IS_ACME_REMOTE -eq 0 ]]; then
+    docker stop acme_agent > /dev/null
+    docker rm -v acme_agent > /dev/null
+    stopIfExists acme_agent-ngrok
+  fi
+  if [[ IS_BOB_REMOTE -eq 0 ]]; then
+    docker stop bob_agent > /dev/null
+    docker rm -v bob_agent > /dev/null
+    stopIfExists bob_agent-ngrok
+  fi
+  if [[ IS_FABER_REMOTE -eq 0 ]]; then
+    docker stop faber_agent > /dev/null
+    docker rm -v faber_agent > /dev/null
+    stopIfExists faber_agent-ngrok
+  fi
+  if [[ IS_MALLORY_REMOTE -eq 0 ]]; then
+    docker stop mallory_agent > /dev/null
+    docker rm -v mallory_agent > /dev/null
+    stopIfExists mallory_agent-ngrok
+  fi
+  # docker stop acme_agent bob_agent faber_agent mallory_agent > /dev/null
+  # docker rm -v acme_agent bob_agent faber_agent mallory_agent > /dev/null
 
   printf "Done\n"
 
@@ -1239,105 +1283,90 @@ if [[ "${COMMAND}" == "run" || "${COMMAND}" == "start" || "${COMMAND}" == "test"
   TAGS=""
   BEHAVE_INI=aries-test-harness/behave.ini
 
-  # Parse long options
-  TEMP_ARGS=()
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --aep)
-        ACME_ENDPOINT="$2"
-        shift 2
-        ;;
-      --ap)
-        ACME_PORT="$2"
-        shift 2
-        ;;
-      --bep)
-        BOB_ENDPOINT="$2"
-        shift 2
-        ;;
-      --bp)
-        BOB_PORT="$2"
-        shift 2
-        ;;
-      --fep)
-        FABER_ENDPOINT="$2"
-        shift 2
-        ;;
-      --fp)
-        FABER_PORT="$2"
-        shift 2
-        ;;
-      --mep)
-        MALLORY_ENDPOINT="$2"
-        shift 2
-        ;;
-      --mp)
-        MALLORY_PORT="$2"
-        shift 2
-        ;;
-      --)
-        shift
-        break
-        ;;
-      -*)
-        echo -e \\n"Invalid script option: $1"\\n
-        usage
-        ;;
-      *)
-        TEMP_ARGS+=("$1")
-        shift
-        ;;
-    esac
-  done
+# --- Parse options manually ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h)
+      usage
+      shift
+      ;;
+    -a)
+      export ACME="$2"
+      shift 2
+      ;;
+    -b)
+      export BOB="$2"
+      shift 2
+      ;;
+    -f)
+      export FABER="$2"
+      shift 2
+      ;;
+    -m)
+      export MALLORY="$2"
+      shift 2
+      ;;
+    -r)
+      export REPORT="$2"
+      shift 2
+      ;;
+    -e)
+      export REPORT_ERROR_TYPE="$2"
+      shift 2
+      ;;
+    -d)
+      export ACME="$2"
+      export BOB="$2"
+      export FABER="$2"
+      export MALLORY="$2"
+      shift 2
+      ;;
+    -t)
+      export TAGS="${TAGS} --tags=$2"
+      shift 2
+      ;;
+    -v)
+      export AIP_CONFIG="$2"
+      shift 2
+      ;;
+    -i)
+      export BEHAVE_INI="$2"
+      shift 2
+      ;;
+    -n)
+      export USE_NGROK="true"
+      shift
+      ;;
+    --aep)
+      export ACME_ENDPOINT="$2"
+      shift 2
+      ;;
+    --bep)
+      export BOB_ENDPOINT="$2"
+      shift 2
+      ;;
+    --fep)
+      export FABER_ENDPOINT="$2"
+      shift 2
+      ;;
+    --mep)
+      export MALLORY_ENDPOINT="$2"
+      shift 2
+      ;;
+    --) # End of options
+      shift
+      break
+      ;;
+    -*)
+      echo -e "\\nInvalid script option: $1\\n"
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
-  # Add remaining arguments to TEMP_ARGS
-  while [[ $# -gt 0 ]]; do
-    TEMP_ARGS+=("$1")
-    shift
-  done
-
-  # Rebuild the argument list to exclude long options
-  set -- "${TEMP_ARGS[@]}"
-
-  # Parse short options
-  OPTIND=1  # Reset OPTIND to 1 to reprocess the arguments
-  while getopts "hna:b:c:f:m:r:e:d:t:v:i:" FLAG; do
-    case $FLAG in
-        h ) usage ;;
-        : ) usage ;;
-        \? ) #unrecognized option - show help
-        echo -e \\n"Invalid script option: -${OPTARG}"\\n
-        usage
-            ;;
-        r ) export REPORT=${OPTARG}
-            ;;
-        e ) export REPORT_ERROR_TYPE=${OPTARG}
-            ;;
-        a ) export ACME=${OPTARG}
-            ;;
-        b ) export BOB=${OPTARG}
-            ;;
-        f ) export FABER=${OPTARG}
-            ;;
-        m ) export MALLORY=${OPTARG}
-            ;;
-        t ) export TAGS="${TAGS} --tags=${OPTARG}"
-            ;;
-        v ) export AIP_CONFIG=${OPTARG}
-            ;;
-        i ) export BEHAVE_INI=${OPTARG}
-            ;;
-        n ) export USE_NGROK="true"
-            ;;
-        d )
-            export ACME=${OPTARG}
-            export BOB=${OPTARG}
-            export FABER=${OPTARG}
-            export MALLORY=${OPTARG}
-            ;;
-    esac
-  done
-  shift $((OPTIND-1))
 
   if [[ "${COMMAND}" == "run" || "${COMMAND}" == "test" ]]; then
     for agent in ${ACME} ${BOB} ${FABER} ${MALLORY}; do

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Aries Agent Test Harness (AATH) Interop Information
-repo_name: hyperledger/aries-agent-test-harness
-repo_url: https://github.com/hyperledger/aries-agent-test-harness
+site_name: OWL Agent Test Harness (OATH) Interop Information
+repo_name: openwallet-foundation/owl-agent-test-harness
+repo_url: https://github.com/openwallet-foundation/owl-agent-test-harness
 theme:
   name: material
   logo: https://raw.githubusercontent.com/hyperledger/aries-rfcs/main/collateral/Hyperledger_Aries_Logo_White.png
@@ -77,28 +77,29 @@ extra:
   version:
     provider: mike
 nav:
-- Aries Interoperability Information:
+- Interoperability Information:
     - Summary of Latest Results: README.md
-    - Introduction to Aries Interoperability: aries-interop-intro.md
-    - Aries Agent Test Harness Coverage: guide/TEST-COVERAGE.md
+    - Introduction to Interoperability: aries-interop-intro.md
+    - OWL Agent Test Harness Coverage: guide/TEST-COVERAGE.md
 - Latest Results by Agent:
-    - Aries Cloud Agent Python: acapy.md
+    - Cloud Agent Python: acapy.md
     - Credo-TS: credo.md
     - Aries VCX: aries-vcx.md
-- AATH Documentation:
-    - Aries Agent Test Harness: guide/README.md
+- OATH Documentation:
+    - OWL Agent Test Harness: guide/README.md
     - Test Development Guidelines: guide/TEST_DEV_GUIDE.md
-    - Aries Backchannels: guide/aries-backchannels.md
-    - Working with Dev Containers in AATH: guide/AATH_DEV_CONTAINERS.md
-    - Running AATH Locally: guide/RunningLocally.md
+    - Backchannels: guide/aries-backchannels.md
+    - Working with Dev Containers in OATH: guide/AATH_DEV_CONTAINERS.md
+    - Running OATH Locally: guide/RunningLocally.md
     - Debugging Backchannels: guide/Debugging.md
-    - Running AATH Using Dev Containers: guide/AATH_DEV_CONTAINERS.md
+    - Running OATH Using Dev Containers: guide/AATH_DEV_CONTAINERS.md
     - Managing Connection IDs in Tests: guide/ACCESS-CONNECTION-IDS.md
-    - Taking Advantage of Connection Reuse in AATH: guide/CONNECTION-REUSE.md
+    - Taking Advantage of Connection Reuse in OATH: guide/CONNECTION-REUSE.md
     - Configuring Tests with Credential Types and Proofs: guide/CONFIGURE-CRED-TYPES.md
+    - Remote Agent Testing: guide/REMOTE_AGENT_TESTING.md
     - Mobile Agent Testing: guide/MOBILE_AGENT_TESTING.md
     - Retry Failed Test Scenarios: guide/RETRY-FAILED-SCENARIOS.md
-    - Aries Agent Test Harness Advanced Test Reporting: guide/TEST_REPORTING.md
+    - OWL Agent Test Harness Advanced Test Reporting: guide/TEST_REPORTING.md
 - Contributing:
     - Contributing: guide/CONTRIBUTING.md
     - Code of Conduct: guide/CODE_OF_CONDUCT.md

--- a/start-remote-agent-demo.sh
+++ b/start-remote-agent-demo.sh
@@ -3,6 +3,7 @@
 
 . /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))"
 export DOCKERHOST=$(getDockerHost)
+SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 
   # generate acapy plugin config file, writing $DOCKERHOST into URLs
 pushd ${SCRIPT_HOME}/aries-backchannels/acapy/ > /dev/null

--- a/start-remote-agent-demo.sh
+++ b/start-remote-agent-demo.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# set -x
+
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))"
+export DOCKERHOST=$(getDockerHost)
+
+  # generate acapy plugin config file, writing $DOCKERHOST into URLs
+pushd ${SCRIPT_HOME}/aries-backchannels/acapy/ > /dev/null
+
+mkdir -p .build/acapy-main.data
+mkdir -p .build/acapy.data
+
+sed "s/REPLACE_WITH_DOCKERHOST/${DOCKERHOST}/g" plugin-config.template | tee > .build/plugin-config.yml
+
+rm -f .build/acapy-main.data/plugin-config.yml .build/acapy.data/plugin-config.yml
+cp .build/plugin-config.yml .build/acapy-main.data/plugin-config.yml
+mv .build/plugin-config.yml .build/acapy.data/plugin-config.yml
+
+popd > /dev/null
+
+docker run -dt --name "fred_agent" --expose "9030-9039" -p "9030-9039:9030-9039" -v $PWD/aries-backchannels/acapy/.build/acapy-main.data:/data-mount:z --env-file=aries-backchannels/acapy/acapy-main.env -e AGENT_NAME=Fred -e LEDGER_URL=http://test.bcovrin.vonx.io -e TAILS_SERVER_URL=https://tails.vonx.io -e DOCKERHOST=$DOCKERHOST -e CONTAINER_NAME=fred_agent "acapy-main-agent-backchannel" -p "9031" -i false


### PR DESCRIPTION
This PR adds the ability to test with remote agents, that is agents not in or managed by the test harness. For more details see the new REMOTE_AGENT_TESTING.md file in this PR. 

closes #737

To test this PR: 
Build the local agents:
```bash
./manage build -a acapy-main
```

Run a remote agent locally:
```bash
./start-remote-agent-demo.sh
```

Run the tests with a remote agent:
```bash
LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -a acapy-main -b remote --bep http://0.0.0.0:9031 -f acapy-main -m acapy-main -t @T002-RFC0160
```

Shutdown the remote agent
```bash
./end-remote-agent-demo.sh
```