### PR TITLE
Update manage to stop on agent failure

### DIFF
--- a/manage
+++ b/manage
@@ -881,12 +881,18 @@ startHarness(){
     else
       waitForAgent Acme ${ACME_ENDPOINT}
     fi
+    if [ $? -eq 1 ]; then
+      return 1
+    fi
   fi
   if [[ "$BOB" != "none" ]]; then
     if [[ IS_BOB_REMOTE -eq 0 ]]; then
       waitForAgent Bob http://localhost 9030
     else
       waitForAgent Bob ${BOB_ENDPOINT}
+    fi
+    if [ $? -eq 1 ]; then
+      return 1
     fi
   fi
   if [[ "$FABER" != "none" ]]; then
@@ -895,12 +901,18 @@ startHarness(){
     else
       waitForAgent Faber ${FABER_ENDPOINT}
     fi
+    if [ $? -eq 1 ]; then
+      return 1
+    fi
   fi
   if [[ "$MALLORY" != "none" ]]; then
     if [[ IS_MALLORY_REMOTE -eq 0 ]]; then
       waitForAgent Mallory http://localhost 9050
     else
       waitForAgent Mallory ${MALLORY_ENDPOINT}
+    fi
+    if [ $? -eq 1 ]; then
+      return 1
     fi
   fi
   echo
@@ -1473,9 +1485,11 @@ case "${COMMAND}" in
 
   run)
       startHarness
-      echo ""
-      runTests ${TAGS} ${@}
-      echo ""
+      if [ $? -eq 1 ]; then
+        echo "Failed to communicate with one or more agents. Please see agent logs to diagnose the problem. Skipping tests."
+      else
+        runTests ${TAGS} ${@}
+      fi
       stopHarness auto
     ;;
   runset)


### PR DESCRIPTION
When running a set of tests, and the start routine fails to communicate to one of the designated agents, the execution of the tests would continue. Of course this would cause some or all of the tests to fail. This PR changes that logic and when the test harness does not get a successful startup of an agent, will let the user know there was an issue, skip the running of the tests, and stop any running test harness services. This should end the interop results getting complete failures in the reports when it was just an agent startup issue. 