### PR TITLE
OATH Gardening

### DIFF
--- a/.github/workflows/test-harness-acapy.yml
+++ b/.github/workflows/test-harness-acapy.yml
@@ -44,7 +44,7 @@ jobs:
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound"
           REPORT_PROJECT: acapy
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run-test-harness-wo-reports.outcome == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy 

--- a/.github/workflows/test-harness-credo.yml
+++ b/.github/workflows/test-harness-credo.yml
@@ -43,7 +43,7 @@ jobs:
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211 -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
           REPORT_PROJECT: credo
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run-test-harness-wo-reports.outcome == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: credo

--- a/aries-backchannels/acapy/Dockerfile.acapy
+++ b/aries-backchannels/acapy/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \
@@ -15,7 +15,7 @@ RUN chmod +x ./jq
 
 COPY python/requirements.txt python/
 COPY acapy/requirements-latest.txt acapy/
-RUN pip install -r acapy/requirements-latest.txt && pip install -r python/requirements.txt
+RUN pip install -r acapy/requirements-latest.txt -r python/requirements.txt
 
 # Copy the necessary files from the AATH Backchannel sub-folders
 COPY python python

--- a/aries-backchannels/acapy/requirements-latest.txt
+++ b/aries-backchannels/acapy/requirements-latest.txt
@@ -1,1 +1,1 @@
-aries-cloudagent[indy, bbs, askar]
+acapy-agent[indy, bbs, askar]

--- a/manage
+++ b/manage
@@ -13,7 +13,7 @@ export DOCKERHOST=$(getDockerHost)
 
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-aath}"
-export AGENT_TIMEOUT=30
+export AGENT_TIMEOUT=60
 export LEDGER_TIMEOUT=60
 # these can be overridden via env vars
 export LEDGER_URL_CONFIG="${LEDGER_URL_CONFIG}"
@@ -517,9 +517,9 @@ pingAgent(){
   # ping agent using a backchannel-exposed api
   # if port is not provided just use the endpoint
   if [[ -z ${port} ]]; then
-    rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null ${endpoint}/agent/command/status/)
+    rtnCd=$(curl -s --max-time 10 --write-out '%{http_code}' --output /dev/null ${endpoint}/agent/command/status/)
   else
-    rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null ${endpoint}:${port}/agent/command/status/)
+    rtnCd=$(curl -s --max-time 10 --write-out '%{http_code}' --output /dev/null ${endpoint}:${port}/agent/command/status/)
   fi
   if (( ${rtnCd} == 200 )); then
     return 0
@@ -1484,13 +1484,15 @@ case "${COMMAND}" in
     ;;
 
   run)
+      trap 'stopHarness auto' EXIT
+
       startHarness
       if [ $? -eq 1 ]; then
         echo "Failed to communicate with one or more agents. Please see agent logs to diagnose the problem. Skipping tests."
+        exit 1
       else
         runTests ${TAGS} ${@}
       fi
-      stopHarness auto
     ;;
   runset)
       runRunSet ${@}


### PR DESCRIPTION
This PR is a set of small fixes/enhancements to OATH that I have noticed over the last few weeks. 

- [x] Don't push to Allure reports in pipeline if an agent issue happens and tests don't run.
- [x] Update acapy docker build from aries, and move container to python 3.12.
- [X] Extend wait for agent status to 60 seconds and if agent container shutdown don't let curl hang waiting for a response.