### PR TITLE
All workflow edits to skip reporting

### DIFF
--- a/.github/workflows/test-harness-acapy-aip10.yml
+++ b/.github/workflows/test-harness-acapy-aip10.yml
@@ -36,6 +36,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a acapy-main"
@@ -43,7 +44,7 @@ jobs:
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0211 -t ~@wip -t ~@T004-RFC0211 -t ~@Transport_NoHttpOutbound"
           REPORT_PROJECT: acapy-aip10  
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-aip10 

--- a/.github/workflows/test-harness-acapy-aip20.yml
+++ b/.github/workflows/test-harness-acapy-aip20.yml
@@ -36,6 +36,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a acapy-main"
@@ -43,7 +44,7 @@ jobs:
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP20 -t ~@wip -t ~@T004-RFC0211 -t ~@Transport_NoHttpOutbound -t ~@DidMethod_orb"
           REPORT_PROJECT: acapy-aip20
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-aip20

--- a/.github/workflows/test-harness-acapy-ariesvcx.yml
+++ b/.github/workflows/test-harness-acapy-ariesvcx.yml
@@ -38,6 +38,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a aries-vcx -a acapy-main"
@@ -45,7 +46,7 @@ jobs:
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@RFC0793 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws"
           REPORT_PROJECT: acapy-b-aries-vcx
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-aries-vcx

--- a/.github/workflows/test-harness-acapy-credo.yml
+++ b/.github/workflows/test-harness-acapy-credo.yml
@@ -39,6 +39,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a acapy-main -a credo"
@@ -46,7 +47,7 @@ jobs:
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
           REPORT_PROJECT: acapy-b-credo
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: acapy-b-credo

--- a/.github/workflows/test-harness-ariesvcx-acapy.yml
+++ b/.github/workflows/test-harness-ariesvcx-acapy.yml
@@ -42,6 +42,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a aries-vcx -a acapy-main"
@@ -49,7 +50,7 @@ jobs:
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@RFC0793 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws"
           REPORT_PROJECT: aries-vcx-b-acapy
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: aries-vcx-b-acapy

--- a/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
+++ b/.github/workflows/test-harness-ariesvcx-ariesvcx.yml
@@ -38,6 +38,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a aries-vcx"
@@ -45,7 +46,7 @@ jobs:
           TEST_SCOPE: "-t @RFC0036,@RFC0037,@RFC0160,@RFC0023,@RFC0793 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws"
           REPORT_PROJECT: aries-vcx
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: aries-vcx

--- a/.github/workflows/test-harness-ariesvcx-credo.yml
+++ b/.github/workflows/test-harness-ariesvcx-credo.yml
@@ -32,6 +32,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a aries-vcx -a credo"
@@ -44,6 +45,7 @@ jobs:
           name: agent-logs
           path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: aries-vcx-b-credo

--- a/.github/workflows/test-harness-credo-acapy.yml
+++ b/.github/workflows/test-harness-credo-acapy.yml
@@ -37,6 +37,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a credo -a acapy-main"
@@ -44,7 +45,7 @@ jobs:
           TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
           REPORT_PROJECT: credo-b-acapy
       - name: run-send-gen-test-results-secure
-        if: ${{ always() }}
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: credo-b-acapy

--- a/.github/workflows/test-harness-credo-ariesvcx.yml
+++ b/.github/workflows/test-harness-credo-ariesvcx.yml
@@ -32,6 +32,7 @@ jobs:
       - name: run-indy-tails-server
         uses: ./test-harness/actions/run-indy-tails-server
       - name: run-test-harness-wo-reports
+        id: run_test_harness
         uses: ./test-harness/actions/run-test-harness-wo-reports
         with:
           BUILD_AGENTS: "-a aries-vcx -a credo"
@@ -44,6 +45,7 @@ jobs:
           name: agent-logs
           path: ./test-harness/.logs/
       - name: run-send-gen-test-results-secure
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: credo-b-aries-vcx


### PR DESCRIPTION
This PR adds working reporting logic to all workflows in the interop test pipeline. Reports will now only be sent to Allure if the tests actually run. If they don't run because of failure to communicate to one or more of the agents, no reports will be sent. This will solve the issue of blank reports in Allure. 