### PR TITLE
Credo Backchannel AIP 2 Support

### DIFF
--- a/.devcontainer/Credo-ts-container/devcontainer.json
+++ b/.devcontainer/Credo-ts-container/devcontainer.json
@@ -25,11 +25,11 @@
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [9020],
+	"forwardPorts": [9020, 9021],
 
 	"runArgs": [
 		"--network=aath_network",
-		"--name=acme_agent_dev"
+		"--name=credo_agent_dev"
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
@@ -51,6 +51,11 @@
 		apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 && \
 		add-apt-repository -y \"deb http://security.ubuntu.com/ubuntu bionic-security main\" && \
 		apt-get install -y --allow-unauthenticated libindy",
+
+    // Add environment variables
+    "containerEnv": {
+        "RUN_MODE": "docker"
+    },
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.github/workflows/test-harness-acapy-credo.yml
+++ b/.github/workflows/test-harness-acapy-credo.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a credo"
           TEST_AGENTS: "-d acapy-main -b credo"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453,@RFC0023 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
           REPORT_PROJECT: acapy-b-credo
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}

--- a/.github/workflows/test-harness-acapy-credo.yml
+++ b/.github/workflows/test-harness-acapy-credo.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a credo"
           TEST_AGENTS: "-d acapy-main -b credo"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453,@RFC0023 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453,@RFC0023 -t ~@wip -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
           REPORT_PROJECT: acapy-b-credo
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}

--- a/.github/workflows/test-harness-credo-acapy.yml
+++ b/.github/workflows/test-harness-credo-acapy.yml
@@ -8,13 +8,11 @@ name: test-harness-credo-acapy
 # This runset uses the current master branch of Credo TS for all of the agents except Bob (holder),
 # which uses the main branch of ACA-Py. The runset covers all of the AIP 1.0 tests
 # except those that are known **not** to work with the Credo TS
-# The runset excludes implicit invitations since Credo does not support this. 
-#   See https://github.com/openwallet-foundation/credo-ts/issues/992
 #
 # Current
 #
 # All AIP10 tests are currently running.
-# OOB & DID Exchange Tests are running, except for the implicit invitations. 
+# OOB & DID Exchange Tests are running. 
 #
 # *Status Note Updated: 2024.10.29*
 #
@@ -45,7 +43,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a credo -a acapy-main"
           TEST_AGENTS: "-d credo -b acapy-main"
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453,@RFC0023 -t ~@T005-RFC0023 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453,@RFC0023 -t ~@Transport_NoHttpOutbound -t ~@QualifiedDIDs"
           REPORT_PROJECT: credo-b-acapy
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}

--- a/.github/workflows/test-harness-credo-acapy.yml
+++ b/.github/workflows/test-harness-credo-acapy.yml
@@ -8,12 +8,15 @@ name: test-harness-credo-acapy
 # This runset uses the current master branch of Credo TS for all of the agents except Bob (holder),
 # which uses the main branch of ACA-Py. The runset covers all of the AIP 1.0 tests
 # except those that are known **not** to work with the Credo TS
+# The runset excludes implicit invitations since Credo does not support this. 
+#   See https://github.com/openwallet-foundation/credo-ts/issues/992
 #
 # Current
 #
 # All AIP10 tests are currently running.
+# OOB & DID Exchange Tests are running, except for the implicit invitations. 
 #
-# *Status Note Updated: 2024.09.06*
+# *Status Note Updated: 2024.10.29*
 #
 # End
 on:
@@ -42,7 +45,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a credo -a acapy-main"
           TEST_AGENTS: "-d credo -b acapy-main"
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211,@T001-RFC0453,@RFC0023 -t ~@T005-RFC0023 -t ~@Transport_NoHttpOutbound -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
           REPORT_PROJECT: credo-b-acapy
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}

--- a/.github/workflows/test-harness-credo.yml
+++ b/.github/workflows/test-harness-credo.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a credo"
           TEST_AGENTS: "-d credo"
-          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211 -t ~@DIDExchangeConnection -t ~@QualifiedDIDs"
+          TEST_SCOPE: "-t @AcceptanceTest -t ~@wip -t @AIP10,@RFC0211 -t ~@QualifiedDIDs"
           REPORT_PROJECT: credo
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}

--- a/aries-backchannels/credo-ts/.vscode/launch.json
+++ b/aries-backchannels/credo-ts/.vscode/launch.json
@@ -20,7 +20,7 @@
             "env": {
                 "LEDGER_URL": "http://test.bcovrin.vonx.io",
                 "TAILS_SERVER_URL": "http://tails.bcovrin.vonx.io",
-                "DOCKERHOST": "acme_agent_dev"
+                "DOCKERHOST": "credo_agent_dev"
             },
             "args": [
                 "ts-node",

--- a/aries-backchannels/credo-ts/server/src/controllers/AgentStatusController.ts
+++ b/aries-backchannels/credo-ts/server/src/controllers/AgentStatusController.ts
@@ -36,13 +36,16 @@ export class AgentStatusController extends BaseController {
 
   @Post('/agent/start')
   async restartAgent(@BodyParams('data') data: StartAgentData) {
+    this.agent.config.logger.debug('stopping agent')
     await this.testHarnessConfig.stopAgent()
 
+    this.agent.config.logger.debug('restarting agent')
     await this.testHarnessConfig.startAgent({
       inboundTransports: data.parameters.inbound_transports ?? ['http'],
       outboundTransports: data.parameters.outbound_transports ?? ['http'],
     })
 
+    this.agent.config.logger.debug('agent startup')
     await this.testHarnessConfig.agentStartup()
   }
 }

--- a/aries-backchannels/credo-ts/server/src/controllers/DIDExchangeController.ts
+++ b/aries-backchannels/credo-ts/server/src/controllers/DIDExchangeController.ts
@@ -1,0 +1,62 @@
+import { Controller, Get, PathParams, Post, BodyParams } from '@tsed/common'
+import { NotFound } from '@tsed/exceptions'
+import {
+  OutOfBandRecord,
+  OutOfBandInvitation,
+  ConnectionInvitationMessage,
+  ConnectionRecord,
+  JsonTransformer,
+  AgentConfig,
+  OutOfBandEventTypes,
+  OutOfBandStateChangedEvent,
+  OutOfBandState,
+  CredoError,
+  DidExchangeState,
+} from '@credo-ts/core'
+
+import { filter, firstValueFrom, ReplaySubject, tap, timeout } from 'rxjs'
+import { BaseController } from '../BaseController'
+import { TestHarnessConfig } from '../TestHarnessConfig'
+import { ConnectionUtils } from '../utils/ConnectionUtils'
+
+@Controller('/agent/command/did-exchange')
+export class DIDExchangeController extends BaseController {
+  private subject = new ReplaySubject<OutOfBandStateChangedEvent>()
+
+  public constructor(testHarnessConfig: TestHarnessConfig) {
+    super(testHarnessConfig)
+  }
+
+  onStartup = () => {
+    this.subject = new ReplaySubject<OutOfBandStateChangedEvent>()
+    // Catch all events in replay subject for later use
+    this.agent.events
+      .observable<OutOfBandStateChangedEvent>(OutOfBandEventTypes.OutOfBandStateChanged)
+      .subscribe(this.subject)
+  }
+
+  @Get('/:id')
+  async getConnectionById(@PathParams('id') id: string) {
+    const connection = await ConnectionUtils.getConnectionByConnectionIdOrOutOfBandId(this.agent, id)
+
+    if (!connection) throw new NotFound(`Connection with id ${id} not found`)
+
+    return connection
+  }
+
+  // Implementing this method just to satisfy AATH. This will not call credo and just set the state that was set in the previous step of receive invitation.
+  @Post('/send-request')
+  async sendRequest(@BodyParams('id') id: string) {
+    const connection = await ConnectionUtils.getConnectionByConnectionIdOrOutOfBandId(this.agent, id)
+    
+    if (!connection) {
+      throw new CredoError('Connection not found')
+    }
+
+    //connection.state = DidExchangeState.RequestSent
+
+    return connection
+  }
+
+
+}

--- a/aries-backchannels/credo-ts/server/src/controllers/DidController.ts
+++ b/aries-backchannels/credo-ts/server/src/controllers/DidController.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@tsed/common'
 import { BaseController } from '../BaseController'
 import { TestHarnessConfig } from '../TestHarnessConfig'
+import { CredoError } from '@credo-ts/core'
 
 @Controller('/agent/command/did')
 export class DidController extends BaseController {
@@ -10,7 +11,18 @@ export class DidController extends BaseController {
 
   @Get()
   async getPublicDid() {
+    //const publicDidInfoRecord = await this.agent.genericRecords.findById('_INFO')
     const publicDidInfoRecord = await this.agent.genericRecords.findById('PUBLIC_DID_INFO')
-    return publicDidInfoRecord ? publicDidInfoRecord.content.didInfo : {}
+
+    if (!publicDidInfoRecord) {
+      throw new CredoError('Public DID Info Record not found')
+    }
+
+    //return publicDidInfoRecord ? publicDidInfoRecord.content.didInfo : {}
+    //return (publicDidInfoRecord.content as { 'did-info': { did: string } })['did-info'].did
+    const content = publicDidInfoRecord.content as { didInfo: { did: string } }
+    const did = 'did:indy:bcovrin:test:' + content.didInfo.did
+    //return content.didInfo.did
+    return did
   }
 }

--- a/aries-backchannels/credo-ts/server/src/controllers/OutOfBandController.ts
+++ b/aries-backchannels/credo-ts/server/src/controllers/OutOfBandController.ts
@@ -104,7 +104,7 @@ export class OutOfBandController extends BaseController {
 
     const { outOfBandRecord, connectionRecord } = await this.agent.oob.receiveInvitation(oobInvitation, {
       routing,
-      autoAcceptConnection: false,
+      autoAcceptConnection: true, //was false
       autoAcceptInvitation: true,
     })
 

--- a/aries-backchannels/credo-ts/server/src/controllers/OutOfBandController.ts
+++ b/aries-backchannels/credo-ts/server/src/controllers/OutOfBandController.ts
@@ -111,9 +111,9 @@ export class OutOfBandController extends BaseController {
     this.agent.config.logger.debug('OutOfBandController.receiveInvitation: outOfBandRecord: ', outOfBandRecord)
     this.agent.config.logger.debug('OutOfBandController.receiveInvitation: connectionRecord: ', connectionRecord)
 
-    if (!outOfBandRecord) {
-      throw new CredoError('Processing invitation did not result in a out of band record')
-    }
+    // if (!outOfBandRecord) {
+    //   throw new CredoError('Processing invitation did not result in a out of band record')
+    // }
 
     if (!connectionRecord) {
       throw new CredoError('Processing invitation did not result in a connection record')
@@ -128,9 +128,18 @@ export class OutOfBandController extends BaseController {
       connectionRecord.state = DidExchangeState.InvitationReceived
     }
 
+    // Add the two records to the response and move the state from the connectionRecord to the root of connectionRecords.
+    const connectionRecords = {
+      ...(connectionRecord && { connectionRecord }),
+      ...(outOfBandRecord && { outOfBandRecord }),
+      ...(connectionRecord && { state: connectionRecord.state }),
+      ...(connectionRecord && { connection_id: connectionRecord.outOfBandId })
+    }
+
     //return this.mapConnection(connectionRecord)
-    return connectionRecord
+    //return connectionRecord
     //return outOfBandRecord
+    return connectionRecords
   }
 
   // Implementing this method just to satisfy AATH. This will not call credo and just set the state that was set in the previous step of receive invitation.

--- a/aries-backchannels/credo-ts/server/src/controllers/OutOfBandController.ts
+++ b/aries-backchannels/credo-ts/server/src/controllers/OutOfBandController.ts
@@ -102,6 +102,10 @@ export class OutOfBandController extends BaseController {
     //   }
     // }
 
+    // Remove all undefined values from invitationOptions
+    Object.keys(invitationOptions).forEach(key => (invitationOptions as any)[key] === undefined && delete (invitationOptions as any)[key]);
+    
+
     const outOfBandRecord = await this.agent.oob.createInvitation(invitationOptions)
 
     const config = this.agent.dependencyManager.resolve(AgentConfig)

--- a/aries-test-harness/Dockerfile.dev-harness
+++ b/aries-test-harness/Dockerfile.dev-harness
@@ -1,4 +1,4 @@
-FROM python:3.7-buster
+FROM python:3.9-buster
 
 RUN \
     echo "==> Install stuff not in the requirements..."   && \

--- a/aries-test-harness/Dockerfile.harness
+++ b/aries-test-harness/Dockerfile.harness
@@ -1,4 +1,4 @@
-FROM python:3.7-buster
+FROM python:3.9-buster
 COPY ./requirements.txt /aries-test-harness/
 WORKDIR /aries-test-harness
 RUN pip install -r requirements.txt

--- a/aries-test-harness/features/0211-coordinate-mediation.feature
+++ b/aries-test-harness/features/0211-coordinate-mediation.feature
@@ -73,7 +73,8 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
       | connection |
       | 0160       |
 
-  @T004-RFC0211 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @normal @AcceptanceTest
+
+  @T004-RFC0211 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @normal @AcceptanceTest @allure.issue:https://github.com/openwallet-foundation/credo-ts/issues/2042 @allure.issue:https://github.com/openwallet-foundation/credo-ts/issues/2041
   Scenario Outline: Two agents creating a connection using a mediator without having inbound transports
     Given we have "2" agents
       | name  | role      |
@@ -109,6 +110,7 @@ Feature: RFC 0211 Aries Agent Mediator Coordination
     Examples: Acme and Faber creating a 0160 connection using Bob as a mediator without having inbound transports
       | acme-inbound-transports | acme-outbound-transports | bob-inbound-transports | bob-outbound-transports | faber-inbound-transports | faber-outbound-transports |
       | []                      | ["ws", "http"]           | ["ws", "http"]         | ["ws", "http"]          | []                       | ["ws", "http"]            |
+
 
   # Not all agents support being started without inbound transports. So this tests uses mediation, but with inbound transports
   @T005-RFC0211 @UsesCustomParameters @RFC0025 @Transport_Http @Transport_Ws @critical @AcceptanceTest

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -262,9 +262,15 @@ def step_impl(context, requester):
             ]
         # Credo returns id instead of connection_id on out of band connections.
         elif "id" in resp_json:
+            # context.connection_id_dict[requester][context.responder_name] = resp_json[
+            #     "id"
+            # ]
             context.connection_id_dict[requester][context.responder_name] = resp_json[
-                "id"
+                "outOfBandId"
             ]
+            # context.connection_id_dict[requester][context.responder_name] = resp_json[
+            #     "threadId"
+            # ]
 
 @when('"{requester}" sends the request to "{responder}" with {requester_peer_did_method}')
 @when('"{requester}" sends the request to "{responder}"')

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -260,6 +260,11 @@ def step_impl(context, requester):
             context.connection_id_dict[requester][context.responder_name] = resp_json[
                 "connection_id"
             ]
+        # Credo returns id instead of connection_id on out of band connections.
+        elif "id" in resp_json:
+            context.connection_id_dict[requester][context.responder_name] = resp_json[
+                "id"
+            ]
 
 @when('"{requester}" sends the request to "{responder}" with {requester_peer_did_method}')
 @when('"{requester}" sends the request to "{responder}"')

--- a/aries-test-harness/features/steps/0160-connection.py
+++ b/aries-test-harness/features/steps/0160-connection.py
@@ -83,10 +83,18 @@ def step_impl(context, n):
             context.mediator_url = context.config.userdata.get(row["name"])
             context.mediator_name = row["name"]
             assert context.mediator_url is not None and 0 < len(context.mediator_url)
+        elif row["role"] == "recipient":
+            context.recipient_url = context.config.userdata.get(row["name"])
+            context.recipient_name = row["name"]
+            assert context.recipient_url is not None and 0 < len(context.recipient_url)
+        elif row["role"] == "sender":
+            context.sender_url = context.config.userdata.get(row["name"])
+            context.sender_name = row["name"]
+            assert context.sender_url is not None and 0 < len(context.sender_url)
         else:
             role = row["role"]
             print(
-                f"Data table in step contains an unrecognized role '{role}', must be inviter, invitee, inviteinterceptor, issuer, holder, verifier, prover, requester, responder, mediator, and recipient"
+                f"Data table in step contains an unrecognized role '{role}', must be inviter, invitee, inviteinterceptor, issuer, holder, verifier, prover, requester, responder, mediator, recipient, and sender"
             )
 
     # Iterate over the context.table again and if start_parameters exist for one or more agents, call the start agent step definition.


### PR DESCRIPTION
This PR attempts to fix credo tests pipeline failures. It adds support for OOB and DID Exchange and therefore support other suites of tests that use DID Exchange Connections. 

Indirectly this PR will close the following issues. 
https://github.com/hyperledger/aries-agent-test-harness/issues/696
https://github.com/hyperledger/aries-agent-test-harness/issues/559

