### PR TITLE
Dump agent stdout and stderr directly to file (don't pipe to console)

### DIFF
--- a/aries-backchannels/acapy/acapy-main.env
+++ b/aries-backchannels/acapy/acapy-main.env
@@ -1,3 +1,6 @@
 
 LOG_LEVEL=DEBUG
 RUST_LOG=warn
+# set PIPE_AGENT_OUTPUT=True to pipe output from agents "live"
+# (default "False" will dump agent stdout and stderr to separate files)
+# PIPE_AGENT_OUTPUT=True

--- a/aries-backchannels/python/utils.py
+++ b/aries-backchannels/python/utils.py
@@ -242,3 +242,14 @@ def pad_base64(value: str) -> str:
         n_missing = 4 - (len(value) % 4)
         value = value + (n_missing * "=")
     return value
+
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif v.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    else:
+        raise argparse.ArgumentTypeError("Boolean value expected.")

--- a/manage
+++ b/manage
@@ -599,7 +599,7 @@ startAgent() {
     # set the docker environment that needs to be passed to the test container
     setDockerEnv
 
-    local container_id=$(docker run -dt --name "${CONTAINER_NAME}" --network aath_network --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${DATA_VOLUME_ARG} ${ENV_FILE_ARG} $DOCKER_ENV "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
+    local container_id=$(docker run -dt --name "${CONTAINER_NAME}" -v ./.logs:/agent_logs --network aath_network --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" ${DATA_VOLUME_ARG} ${ENV_FILE_ARG} $DOCKER_ENV "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false)
 
     sleep 1
     if [[ "${USE_NGROK}" = "true" ]]; then


### PR DESCRIPTION
Opening for feedback.

See issue #896 - there is a potential issue with python deadlocking when subprocess output is read using a PIPE.

This PR changes the default behaviour to dump the agent's output directly to a file (actually 2 files) rather than trying to stream to the console.

(It's theoretically possible to stream the file output to the console, although (a) I couldn't get this to work in the context of the backchannel (although I got it working in a stand-alone script), and (b) the file output comes out in big "chunks" anyways (based on the file's buffer size) so output to the console wouldn't be very usable anyways.)

I left the "output streaming" option in place (the default behaviour is the new file output) - it can be selected using a env var `PIPE_AGENT_OUTPUT=True`.
