### PR TITLE
Remove universal resolver / Use subprocess.run

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -291,8 +291,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             # if the env var is set for tails server then use that.
             result.append(("--emit-new-didcomm-mime-type"))
 
-        result.append(("--universal-resolver"))
-
         # result.append(("--plugin", "redis_events.v1_0.redis_queue.events"))
         result.append(("--plugin-config", "/data-mount/plugin-config.yml"))
         
@@ -1811,7 +1809,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
     def _process(
         self, args: List[str], env: Dict[str, str], loop: asyncio.AbstractEventLoop
     ):
-        proc = subprocess.Popen(args, env=env, encoding="utf-8", preexec_fn=os.setsid)
+        proc = subprocess.run(args, env=env, encoding="utf-8")
         stdout = loop.run_in_executor(
             None,
             output_reader,


### PR DESCRIPTION
This changes to subprocess.run instead of subprocess.Popen allowing log info to be captured on a crash/shutdown. I'm not really sure why Popen was chosen here as the backchannel is only a single process. I haven't seen any side effects.

I removed the universal resolver. There is a universal resolver pinned to a version and started up. However the universal resolver wasn't configured to it and was falling back to the default which is the dev.uniresolver. Hence the issue coming up here.

I believe the uniresolver is only used for the `did:orb` method. I don't know a lot about this and don't think it needs to be tested so I chose to remove it instead of trying to configure it properly in docker. I think it also needs a valid ssl certificate.

Tests will still fail because the connection plugin isn't load yet. I will update https://github.com/openwallet-foundation/owl-agent-test-harness/pull/901 after to try and get everything passing.