### PR TITLE
Return starting process with Popen

### DIFF
--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -1809,7 +1809,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
     def _process(
         self, args: List[str], env: Dict[str, str], loop: asyncio.AbstractEventLoop
     ):
-        proc = subprocess.run(args, env=env, encoding="utf-8")
+        proc = subprocess.Popen(args, env=env, encoding="utf-8", preexec_fn=os.setsid)
         stdout = loop.run_in_executor(
             None,
             output_reader,


### PR DESCRIPTION
So using .run instead of .Popen does have unintended consequences. It was working for me for a while and does help get the logger output but then the backchannel communication stopped work. Same problem in github actions.

I'd need to do a lot deeper dive into whats going on here but this should get them running again.

We can make sure extra processes are killed and re-run with .run to get the logs if we need to in the future.

Possibly https://github.com/openwallet-foundation/owl-agent-test-harness/pull/900 does have some merit. Seems like processes aren't being handled that well.