### PR TITLE
Create public did with endpoint and remove seeded did creation

### DIFF
--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -3,8 +3,8 @@ import logging
 import os
 import random
 import traceback
-import debugpy
 from dataclasses import dataclass
+from secrets import token_hex
 from typing import Any, Optional, Tuple
 
 from aiohttp import ClientSession, web
@@ -106,7 +106,7 @@ class AgentBackchannel:
         self.params = params
         self.extra_args = extra_args
         rand_name = str(random.randint(100_000, 999_999))
-        self.seed = ("my_seed_000000000000000000000000" + rand_name)[-32:]
+        self.seed = token_hex(16)
 
         # Set the backchannel on each request so it can be used by the route methods
         @web.middleware

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -185,6 +185,12 @@ def step_impl(context, responder: str):
 @when('"{responder}" sends an explicit invitation with a public DID to "{requester}"')
 def step_impl(context, responder: str, requester: str):
     responder_url = context.config.userdata.get(responder)
+    
+    # Create or get public did
+    (resp_status, resp_text) = agent_backchannel_GET(
+        responder_url + "/agent/command/", "did"
+    )
+    assert resp_status == 200, f"resp_status {resp_status} is not 200; {resp_text}"
 
     data = {"use_public_did": True}
 


### PR DESCRIPTION
This fixes the failed tests for creating a connection with a public did by creating the did:sov with acapy instead of with the seed startup parameter.

The acapy agent will no longer register a did on the ledger before starting the agent and tests. It also no longer uses the insecure seed method at all in the test suite.