### PR TITLE
Tests for acapy/credo with anoncreds format

### DIFF
--- a/.github/workflows/test-harness-acapy-credo-anoncreds.yml
+++ b/.github/workflows/test-harness-acapy-credo-anoncreds.yml
@@ -1,12 +1,12 @@
-name: test-harness-acapy-credo-anoncreds
-# RUNSET_NAME: "ACA-PY to Credo Anoncreds"
-# Scope: Anoncreds
+name: test-harness-acapy-anoncreds-credo
+# RUNSET_NAME: "ACA-PY/AnonCreds to Credo"
+# Scope: AnonCreds
 #
 # Summary
 #
 # This runset uses the current main branch of ACA-Py for all of the agents except Bob (holder),
 # which uses the master branch of Credo TS. The runset covers a small number of credential
-# issue and revocation scenarios for Anoncreds credentials.
+# issue and revocation scenarios for AnonCreds credentials.
 #
 # Current
 #
@@ -43,13 +43,13 @@ jobs:
           BUILD_AGENTS: "-a acapy-main -a credo"
           TEST_AGENTS: "-d acapy-main -b credo"
           TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453,@T001-RFC0454b -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183 -t @Anoncreds"
-          REPORT_PROJECT: acapy-b-credo-anoncreds
+          REPORT_PROJECT: acapy-anoncreds-credo
         env:
           BACKCHANNEL_EXTRA_acapy_main: "{\"wallet-type\":\"askar-anoncreds\"}"
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}
         uses: ./test-harness/actions/run-send-gen-test-results-secure
         with:
-          REPORT_PROJECT: acapy-b-credo-anoncreds
+          REPORT_PROJECT: acapy-anoncreds-credo
           ADMIN_USER: ${{ secrets.AllureAdminUser }}
           ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-acapy-credo-anoncreds.yml
+++ b/.github/workflows/test-harness-acapy-credo-anoncreds.yml
@@ -1,0 +1,55 @@
+name: test-harness-acapy-credo
+# RUNSET_NAME: "ACA-PY to Credo Anoncreds"
+# Scope: Anoncreds
+#
+# Summary
+#
+# This runset uses the current main branch of ACA-Py for all of the agents except Bob (holder),
+# which uses the master branch of Credo TS. The runset covers a small number of credential
+# issue and revocation scenarios for Anoncreds credentials.
+#
+# Current
+#
+# Initial version created.
+#
+# *Status Note Updated: 2025.03.20*
+#
+# End
+on:
+  workflow_dispatch:
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      LEDGER_URL_CONFIG: "http://localhost:9000"
+      TAILS_SERVER_URL_CONFIG: "http://localhost:6543"
+      START_TIMEOUT: 120
+    steps:
+      - name: checkout-test-harness
+        uses: actions/checkout@v4
+        with:
+          path: test-harness
+      - name: run-von-network
+        uses: ./test-harness/actions/run-von-network
+      - name: run-indy-tails-server
+        uses: ./test-harness/actions/run-indy-tails-server
+      - name: run-test-harness-wo-reports
+        id: run_test_harness
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a acapy-main -a credo"
+          TEST_AGENTS: "-d acapy-main -b credo"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453,@T001-RFC0454b -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183 -t @Anoncreds"
+          REPORT_PROJECT: acapy-b-credo-anoncreds
+        env:
+          BACKCHANNEL_EXTRA_acapy_main: "{\"wallet-type\":\"askar-anoncreds\"}"
+      - name: run-send-gen-test-results-secure
+        if: ${{ steps.run_test_harness.conclusion == 'success' }}
+        uses: ./test-harness/actions/run-send-gen-test-results-secure
+        with:
+          REPORT_PROJECT: acapy-b-credo-anoncreds
+          ADMIN_USER: ${{ secrets.AllureAdminUser }}
+          ADMIN_PW: ${{ secrets.AllureAdminPW }}

--- a/.github/workflows/test-harness-acapy-credo-anoncreds.yml
+++ b/.github/workflows/test-harness-acapy-credo-anoncreds.yml
@@ -1,4 +1,4 @@
-name: test-harness-acapy-credo
+name: test-harness-acapy-credo-anoncreds
 # RUNSET_NAME: "ACA-PY to Credo Anoncreds"
 # Scope: Anoncreds
 #

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -20,7 +20,7 @@ from python.agent_backchannel import (RUN_MODE, START_TIMEOUT,
                                       AgentBackchannel, AgentPorts,
                                       BackchannelCommand, default_genesis_txns, get_ledger_url)
 from python.storage import (get_resource, pop_resource, pop_resource_latest,
-                            push_resource)
+                            push_resource, get_data_id_from_exch_id)
 from python.utils import flatten, log_msg, output_reader, prompt_loop
 from typing_extensions import Literal
 
@@ -438,7 +438,6 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         thread_id = message["thread_id"]
 
-        # thread_id = indy::{rev_reg_id}::{cred_rev_id}
         push_resource(thread_id, "revocation-notification-msg", message)
 
     async def handle_issue_credential(self, message: Mapping[str, Any]):
@@ -447,9 +446,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         if "state" in message and message["state"] == "deleted":
             # ignore "deleted" state
             return
-        push_resource(thread_id, "credential-msg", message)
+        push_resource(thread_id, "credential-msg", message, exch_id_name="credential_exchange_id")
         if "revocation_id" in message:  # also push as a revocation message
-            push_resource(thread_id, "revocation-registry-msg", message)
+            push_resource(thread_id, "revocation-registry-msg", message, exch_id_name="credential_exchange_id")
             log_msg("Issue Credential Webhook message contains revocation info")
 
     async def handle_issue_credential_v2_0(self, message: Mapping[str, Any]):
@@ -458,10 +457,32 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         if "state" in message and message["state"] == "deleted":
             # ignore "deleted" state
             return
-        push_resource(thread_id, "credential-msg", message)
+        push_resource(thread_id, "credential-msg", message, exch_id_name="cred_ex_id")
         if "revocation_id" in message:  # also push as a revocation message
-            push_resource(thread_id, "revocation-registry-msg", message)
+            push_resource(thread_id, "revocation-registry-msg", message, exch_id_name="cred_ex_id")
             log_msg("Issue Credential Webhook message contains revocation info")
+
+    async def handle_issue_credential_v2_0_anoncreds(self, message: Mapping[str, Any]):
+        log_msg("Received Issue Credential v2 Anoncreds Webhook message: " + json.dumps(message, indent=4))
+        thread_id = get_data_id_from_exch_id("credential-msg", "cred_ex_id", message["cred_ex_id"])
+        log_msg(f"Thread ID: {thread_id}")
+        # fetch the credential to get the revocation info
+        if "cred_id_stored" in message:
+            record_id = message["cred_id_stored"]
+        else:
+            return
+        agent_operation = f"/credential/{record_id}"
+        (resp_status, resp_text) = await self.admin_GET(agent_operation)
+        log_msg(f"Anoncreds Credential: {resp_status} {resp_text}")
+        if resp_status == 200:
+            resp_json = json.loads(resp_text)
+            if "cred_rev_id" in resp_json:
+                message["revocation_id"] = resp_json["cred_rev_id"]
+            if "rev_reg_id" in resp_json:
+                message["revoc_reg_id"] = resp_json["rev_reg_id"]
+        if "revocation_id" in message:  # push as a revocation message
+            push_resource(thread_id, "revocation-registry-msg", message)
+            log_msg(f"Issue Anoncreds Credential Webhook message contains revocation info: {thread_id} {message}")
 
     async def handle_present_proof_v2_0(self, message: Mapping[str, Any]):
         log_msg("Received a Present Proof v2 Webhook message: " + json.dumps(message, indent=4))
@@ -469,7 +490,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         if "state" in message and message["state"] == "deleted":
             # ignore "deleted" state
             return
-        push_resource(thread_id, "presentation-msg", message)
+        push_resource(thread_id, "presentation-msg", message, exch_id_name="presentation_exchange_id")
 
     async def handle_present_proof(self, message: Mapping[str, Any]):
         log_msg("Received a Present Proof Webhook message: " + json.dumps(message, indent=4))
@@ -477,7 +498,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         if "state" in message and message["state"] == "deleted":
             # ignore "deleted" state
             return
-        push_resource(thread_id, "presentation-msg", message)
+        push_resource(thread_id, "presentation-msg", message, exch_id_name="pres_ex_id")
 
     async def handle_revocation_registry(self, message: Mapping[str, Any]):
         # No thread id in the webhook for revocation registry messages
@@ -1864,10 +1885,12 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             return (resp_status, resp_text)
 
         elif topic == "revocation-registry" and record_id:
+            print(f">>> pop attempt with: {record_id} revocation-registry-msg")
             revocation_msg = pop_resource(record_id, "revocation-registry-msg")
             i = 0
             while revocation_msg is None and i < MAX_TIMEOUT:
                 await asyncio.sleep(1)
+                print(f">>> pop attempt with: {record_id} revocation-registry-msg")
                 revocation_msg = pop_resource(record_id, "revocation-registry-msg")
                 i = i + 1
 
@@ -2349,6 +2372,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             if operation == "revoke":
                 if comparibleVersion > 54:
                     agent_operation = f"/revocation/{operation}"
+                    if data["anoncreds"]:
+                        agent_operation = "/anoncreds" + agent_operation
                     if "cred_ex_id" in data:
                         admin_data = {
                             "cred_ex_id": data["cred_ex_id"],
@@ -2388,6 +2413,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                         data = None
             elif operation == "credential-record":
                 agent_operation = f"/revocation/{operation}"
+                if command.anoncreds:
+                    agent_operation = "/anoncreds" + agent_operation
                 if "cred_ex_id" in data:
                     cred_ex_id = data["cred_ex_id"]
                     agent_operation = f"{agent_operation}?cred_ex_id={cred_ex_id}"

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -1885,12 +1885,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             return (resp_status, resp_text)
 
         elif topic == "revocation-registry" and record_id:
-            print(f">>> pop attempt with: {record_id} revocation-registry-msg")
             revocation_msg = pop_resource(record_id, "revocation-registry-msg")
             i = 0
             while revocation_msg is None and i < MAX_TIMEOUT:
                 await asyncio.sleep(1)
-                print(f">>> pop attempt with: {record_id} revocation-registry-msg")
                 revocation_msg = pop_resource(record_id, "revocation-registry-msg")
                 i = i + 1
 

--- a/aries-test-harness/agent_test_utils.py
+++ b/aries-test-harness/agent_test_utils.py
@@ -8,13 +8,10 @@ def setup_schemas_for_issuance(context, credential_data):
     # Prepare schemas for usage
     for schema in context.schema_dict:
         try:
-            print(">>> schema:", schema)
             credential_data_json_file = open(
                 "features/data/cred_data_" + schema.lower() + ".json"
             )
             credential_data_json = json.load(credential_data_json_file)
-            print(">>> credential_data_json_file:", credential_data_json_file)
-            print(">>> credential_data_json:", credential_data_json)
             context.credential_data_dict[schema] = credential_data_json[
                 credential_data
             ]["attributes"]

--- a/aries-test-harness/agent_test_utils.py
+++ b/aries-test-harness/agent_test_utils.py
@@ -1,6 +1,39 @@
 import datetime
+import json
 import time
 from typing import Optional
+
+
+def setup_schemas_for_issuance(context, credential_data):
+    # Prepare schemas for usage
+    for schema in context.schema_dict:
+        try:
+            print(">>> schema:", schema)
+            credential_data_json_file = open(
+                "features/data/cred_data_" + schema.lower() + ".json"
+            )
+            credential_data_json = json.load(credential_data_json_file)
+            print(">>> credential_data_json_file:", credential_data_json_file)
+            print(">>> credential_data_json:", credential_data_json)
+            context.credential_data_dict[schema] = credential_data_json[
+                credential_data
+            ]["attributes"]
+
+            context.credential_data = context.credential_data_dict[schema]
+            context.schema = context.schema_dict[schema]
+        except FileNotFoundError:
+            print(
+                FileNotFoundError
+                + ": features/data/cred_data_"
+                + schema.lower()
+                + ".json"
+            )
+
+        if "AIP20" in context.tags or "DIDComm-V2" in context.tags:
+            context.filters_dict[schema] = credential_data_json[credential_data][
+                "filters"
+            ]
+            context.filters = context.filters_dict[schema]
 
 
 def create_non_revoke_interval(timeframe):

--- a/aries-test-harness/features/0183-revocation-anoncreds.feature
+++ b/aries-test-harness/features/0183-revocation-anoncreds.feature
@@ -1,0 +1,23 @@
+@revocation @RFC0183 @AIP20
+Feature: RFC 0183 Aries agent credential revocation and revocation notification, anoncreds-specific
+
+   # note that the "indy" format should fail with an "anoncreds" wallet
+   @T001.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_v2_Revoc @MobileTest @RFC0441 @CredFormat_Anoncreds @Anoncreds
+   Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked
+      Given "2" agents
+         | name  | role     |
+         | Bob   | prover   |
+         | Faber | verifier |
+      And "Faber" and "Bob" have an existing connection
+      And "Bob" has an issued credential with formats from <issuer> with <credential_data>
+      When <issuer> revokes the credential
+      And "Faber" sends a <request_for_proof> presentation to "Bob"
+      And "Bob" makes the <presentation> of the proof
+      And "Faber" acknowledges the proof
+      Then "Bob" has the proof verified
+
+      Examples:
+         | issuer | credential_data   | request_for_proof              | presentation                  |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
+
+

--- a/aries-test-harness/features/0183-revocation-anoncreds.feature
+++ b/aries-test-harness/features/0183-revocation-anoncreds.feature
@@ -1,8 +1,11 @@
 @revocation @RFC0183 @AIP20
 Feature: RFC 0183 Aries agent credential revocation and revocation notification, anoncreds-specific
 
-   # note that the "indy" format should fail with an "anoncreds" wallet
-   @T001.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_v2_Revoc @MobileTest @RFC0441 @CredFormat_Anoncreds @Anoncreds
+   Background: create a schema and credential definition in order to issue a credential
+      Given "Acme" has a public did
+      And "Acme" is ready to issue a credential
+
+   @T001.2a-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_v2_Revoc @MobileTest @RFC0441 @CredFormat_Anoncreds @Anoncreds
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked
       Given "2" agents
          | name  | role     |
@@ -11,13 +14,13 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification,
       And "Faber" and "Bob" have an existing connection
       And "Bob" has an issued credential with formats from <issuer> with <credential_data>
       When <issuer> revokes the credential
-      And "Faber" sends a <request_for_proof> presentation to "Bob"
-      And "Bob" makes the <presentation> of the proof
-      And "Faber" acknowledges the proof
-      Then "Bob" has the proof verified
+      When "Faber" sends a <request_for_proof> presentation with formats to "Bob"
+      And "Bob" makes the <presentation> of the proof with formats
+      And "Faber" acknowledges the proof with formats
+      Then "Bob" has the proof with formats verified
 
       Examples:
-         | issuer | credential_data   | request_for_proof              | presentation                  |
-         | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
+         | issuer | credential_data   | request_for_proof                 | presentation                     |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_v2_revoc_address | presentation_DL_v2_revoc_address |
 
 

--- a/aries-test-harness/features/0183-revocation.feature
+++ b/aries-test-harness/features/0183-revocation.feature
@@ -41,25 +41,6 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | issuer | credential_data   | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
-   # note that the "indy" format should fail with an "anoncreds" wallet
-   @T001.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @RFC0441
-   Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked
-      Given "2" agents
-         | name  | role     |
-         | Bob   | prover   |
-         | Faber | verifier |
-      And "Bob" has an issued credential from <issuer> with <credential_data>
-      When <issuer> revokes the credential
-      And "Faber" and "Bob" have an existing connection
-      And "Faber" sends a <request_for_proof> presentation to "Bob"
-      And "Bob" makes the <presentation> of the proof
-      And "Faber" acknowledges the proof
-      Then "Bob" has the proof verified
-
-      Examples:
-         | issuer | credential_data   | request_for_proof              | presentation                  |
-         | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
-
    @T002-HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
    Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with timesstamp
       Given "2" agents

--- a/aries-test-harness/features/0454-present-proof-v2.feature
+++ b/aries-test-harness/features/0454-present-proof-v2.feature
@@ -52,6 +52,32 @@ Feature: RFC 0454 Aries agent present proof v2
          | Acme   | Data_DL_MaxValues | proof_request_DL_address_v2_dif_pe | presentation_DL_address_v2_dif_pe |
 
 
+   @T001-RFC0454b @critical @AcceptanceTest
+   Scenario Outline: Present Proof of specific types and proof is acknowledged with a Drivers License credential type with a DID Exchange Connection
+      Given "2" agents
+         | name  | role     |
+         | Faber | verifier |
+         | Bob   | prover   |
+      And "Faber" and "Bob" have an existing connection
+      And "Bob" has an issued credential with formats from <issuer> with <credential_data>
+      When "Faber" sends a <request_for_proof> presentation with formats to "Bob"
+      And "Bob" makes the <presentation> of the proof with formats
+      And "Faber" acknowledges the proof with formats
+      Then "Bob" has the proof with formats verified
+
+      @AIP20 @CredFormat_Indy @RFC0592 @Schema_DriversLicense_v2
+      Examples:
+         | issuer | credential_data   | request_for_proof               | presentation                   |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_address_v2     | presentation_DL_address_v2     |
+         | Faber  | Data_DL_MaxValues | proof_request_DL_age_over_19_v2 | presentation_DL_age_over_19_v2 |
+
+      @AIP20 @CredFormat_Anoncreds @RFC0592 @Schema_DriversLicense_v2 @Anoncreds
+      Examples:
+         | issuer | credential_data   | request_for_proof               | presentation                   |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_address_v2     | presentation_DL_address_v2     |
+         | Faber  | Data_DL_MaxValues | proof_request_DL_age_over_19_v2 | presentation_DL_age_over_19_v2 |
+
+
    @T002-RFC0454 @RFC0510 @critical @AcceptanceTest @DIDExchangeConnection @CredFormat_JSON-LD @Schema_Citizenship_Context @CredProposalStart
    Scenario Outline: Present Proof of specific types and proof is acknowledged with a Citizenship credential type with a DID Exchange Connection
       Given "2" agents

--- a/aries-test-harness/features/data/anoncreds_schema_driverslicense_v2_revoc.json
+++ b/aries-test-harness/features/data/anoncreds_schema_driverslicense_v2_revoc.json
@@ -1,0 +1,16 @@
+{
+   "schema":{
+      "schema": {
+         "name":"Schema_DriversLicense_v2_Revoc",
+         "version":"1.0.1",
+         "attrNames":[
+            "address",
+            "DL_number",
+            "expiry",
+            "age"
+         ]
+      },
+      "options":{}
+   },
+   "cred_def_support_revocation":true
+}

--- a/aries-test-harness/features/data/cred_data_anoncreds_schema_driverslicense_v2_revoc.json
+++ b/aries-test-harness/features/data/cred_data_anoncreds_schema_driverslicense_v2_revoc.json
@@ -1,0 +1,67 @@
+{
+   "Data_DL_MaxValues":{
+      "cred_name":"Data_DriversLicense_v2_MaxValues",
+      "schema_name":"Schema_DriversLicense_v2_Revoc",
+      "schema_version":"1.0.1",
+      "attributes":[
+         {
+            "name":"address",
+            "value":"947 this street, Kingston Ontario Canada, K9O 3R5"
+         },
+         {
+            "name":"DL_number",
+            "value":"09385029529385"
+         },
+         {
+            "name":"expiry",
+            "value":"10/12/2022"
+         },
+         {
+            "name":"age",
+            "value":"30"
+         }
+      ],
+      "filters": {
+         "indy": {
+            "cred_def_id": "replace_me",
+            "issuer_did": "replace_me",
+            "schema_id": "replace_me",
+            "schema_issuer_did": "replace_me",
+            "schema_name": "Schema_DriversLicense_v2_Revoc",
+            "schema_version": "1.0.1"
+         },
+         "anoncreds":{
+            "cred_def_id": "replace_me"
+         },
+         "json-ld": {
+            "credential": {
+               "@context": [
+                  "https://www.w3.org/2018/credentials/v1", 
+                  "https://w3id.org/security/bbs/v1",
+                  {
+                     "dl": "http://example.com/drivers-license#",
+                     "AATHDriversLicense": "dl:AATHDriversLicense",
+                     "address": "dl:address",
+                     "DL_number": "dl:DL_number",
+                     "expiry": "dl:expiry",
+                     "age": "dl:age"
+                   }
+               ],
+               "type": ["VerifiableCredential", "AATHDriversLicense"],
+               "issuer": "replace_me",
+               "issuanceDate": "2010-01-01T19:73:24Z",
+               "credentialSubject": {
+                  "address": "947 this street, Kingston Ontario Canada, K9O 3R5",
+                  "DL_number": "09385029529385",
+                  "expiry": "10/12/2022",
+                  "age": "30"
+               }
+            },
+            "options": {
+               "proofType": "replace_me"
+            }
+            
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/data/cred_data_schema_driverslicense_v2_revoc.json
+++ b/aries-test-harness/features/data/cred_data_schema_driverslicense_v2_revoc.json
@@ -1,0 +1,67 @@
+{
+   "Data_DL_MaxValues":{
+      "cred_name":"Data_DriversLicense_v2_MaxValues",
+      "schema_name":"Schema_DriversLicense_v2_Revoc",
+      "schema_version":"1.0.1",
+      "attributes":[
+         {
+            "name":"address",
+            "value":"947 this street, Kingston Ontario Canada, K9O 3R5"
+         },
+         {
+            "name":"DL_number",
+            "value":"09385029529385"
+         },
+         {
+            "name":"expiry",
+            "value":"10/12/2022"
+         },
+         {
+            "name":"age",
+            "value":"30"
+         }
+      ],
+      "filters": {
+         "indy": {
+            "cred_def_id": "replace_me",
+            "issuer_did": "replace_me",
+            "schema_id": "replace_me",
+            "schema_issuer_did": "replace_me",
+            "schema_name": "Schema_DriversLicense_v2_Revoc",
+            "schema_version": "1.0.1"
+         },
+         "anoncreds":{
+            "cred_def_id": "replace_me"
+         },
+         "json-ld": {
+            "credential": {
+               "@context": [
+                  "https://www.w3.org/2018/credentials/v1", 
+                  "https://w3id.org/security/bbs/v1",
+                  {
+                     "dl": "http://example.com/drivers-license#",
+                     "AATHDriversLicense": "dl:AATHDriversLicense",
+                     "address": "dl:address",
+                     "DL_number": "dl:DL_number",
+                     "expiry": "dl:expiry",
+                     "age": "dl:age"
+                   }
+               ],
+               "type": ["VerifiableCredential", "AATHDriversLicense"],
+               "issuer": "replace_me",
+               "issuanceDate": "2010-01-01T19:73:24Z",
+               "credentialSubject": {
+                  "address": "947 this street, Kingston Ontario Canada, K9O 3R5",
+                  "DL_number": "09385029529385",
+                  "expiry": "10/12/2022",
+                  "age": "30"
+               }
+            },
+            "options": {
+               "proofType": "replace_me"
+            }
+            
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/data/presentation_DL_v2_revoc_address.json
+++ b/aries-test-harness/features/data/presentation_DL_v2_revoc_address.json
@@ -1,0 +1,12 @@
+{
+   "presentation": {
+      "comment": "This is a comment for the send presentation.",
+      "requested_attributes": {
+         "address_attrs": {
+            "cred_type_name": "Schema_DriversLicense_v2_Revoc",
+            "revealed": true,
+            "cred_id": "replace_me"
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/data/proof_request_DL_v2_revoc_address.json
+++ b/aries-test-harness/features/data/proof_request_DL_v2_revoc_address.json
@@ -1,0 +1,16 @@
+{
+   "presentation_request": {
+      "requested_attributes": {
+         "address_attrs": {
+            "name": "address",
+            "restrictions": [
+               {
+                  "schema_name": "Schema_DriversLicense_v2_Revoc",
+                  "schema_version": "1.0.1"
+               }
+            ]
+         }
+      },
+      "version": "0.1.0"
+   }
+}

--- a/aries-test-harness/features/data/schema_driverslicense_v2_revoc.json
+++ b/aries-test-harness/features/data/schema_driverslicense_v2_revoc.json
@@ -1,0 +1,13 @@
+{
+   "schema":{
+      "schema_name":"Schema_DriversLicense_v2_Revoc",
+      "schema_version":"1.0.1",
+      "attributes":[
+         "address",
+         "DL_number",
+         "expiry",
+         "age"
+      ]
+   },
+   "cred_def_support_revocation":true
+}

--- a/aries-test-harness/features/steps/0011-0183-revocation.py
+++ b/aries-test-harness/features/steps/0011-0183-revocation.py
@@ -31,11 +31,13 @@ from agent_test_utils import create_non_revoke_interval
 def step_impl(context, issuer: str):
 
     issuer_url = context.config.userdata.get(issuer)
+    cred_format = context.rev_cred_format
 
     credential_revocation = {
         "cred_rev_id": context.cred_rev_id,
         "rev_registry_id": context.rev_reg_id,
         "publish_immediately": True,
+        "anoncreds": cred_format == "anoncreds",
     }
 
     # always do this regardless
@@ -55,10 +57,14 @@ def step_impl(context, issuer: str):
     # Check the Holder wallet for the credential
     # Should be a 200 since the revoke doesn't remove the cred from the holders wallet.
     # What else to check?
+    if cred_format == "anoncreds":
+        credential_id = context.credential_id_dict[context.schema["schema"]["name"]][-1]
+    else:
+        credential_id = context.credential_id_dict[context.schema["schema_name"]][-1]
     (resp_status, resp_text) = agent_backchannel_GET(
         context.config.userdata.get(context.holder_name) + "/agent/command/",
         "credential",
-        id=context.credential_id_dict[context.schema["schema_name"]][-1],
+        id=credential_id,
     )
     assert resp_status == 200, f"resp_status {resp_status} is not 200; {resp_text}"
 

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -20,6 +20,15 @@ SCHEMA_TEMPLATE = {
     "attributes": ["attr_1", "attr_2", "attr_3"],
 }
 
+SCHEMA_TEMPLATE_ANONCREDS = {
+    "schema": {
+        "name": "test_schema.",
+        "version": "1.0.0",
+        "attrNames": ["attr_1", "attr_2", "attr_3"],
+    },
+    "options":{}
+}
+
 CRED_DEF_TEMPLATE = {
     "support_revocation": False,
     "schema_id": "",
@@ -59,8 +68,12 @@ def step_impl(context, issuer):
 
     # check for a schema already loaded in the context. If it is not, load the template
     if not context.schema:
-        context.schema = SCHEMA_TEMPLATE.copy()
-        context.schema["schema_name"] = context.schema["schema_name"] + issuer
+        if context.anoncreds:
+            context.schema = SCHEMA_TEMPLATE_ANONCREDS.copy()
+            context.schema["schema_name"] = get_schema_name(context) + issuer
+        else:
+            context.schema = SCHEMA_TEMPLATE.copy()
+            context.schema["schema_name"] = get_schema_name(context) + issuer
 
     context.issuer_did = issuer_did["did"]
     context.issuer_did_dict[get_schema_name(context)] = issuer_did["did"]

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -2,41 +2,16 @@ import json
 from time import sleep
 
 from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST
-from agent_test_utils import format_cred_proposal_by_aip_version, get_schema_name
+from agent_test_utils import (
+    setup_schemas_for_issuance,
+    format_cred_proposal_by_aip_version,
+    get_schema_name)
 from behave import given, then, when
 
 CRED_FORMAT_INDY = "indy"
 CRED_FORMAT_JSON_LD = "json-ld"
 CRED_FORMAT_ANONCREDS = "anoncreds"
 
-
-def setup_schemas_for_issuance(context, credential_data):
-    # Prepare schemas for usage
-    for schema in context.schema_dict:
-        try:
-            credential_data_json_file = open(
-                "features/data/cred_data_" + schema.lower() + ".json"
-            )
-            credential_data_json = json.load(credential_data_json_file)
-            context.credential_data_dict[schema] = credential_data_json[
-                credential_data
-            ]["attributes"]
-
-            context.credential_data = context.credential_data_dict[schema]
-            context.schema = context.schema_dict[schema]
-        except FileNotFoundError:
-            print(
-                FileNotFoundError
-                + ": features/data/cred_data_"
-                + schema.lower()
-                + ".json"
-            )
-
-        if "AIP20" in context.tags or "DIDComm-V2" in context.tags:
-            context.filters_dict[schema] = credential_data_json[credential_data][
-                "filters"
-            ]
-            context.filters = context.filters_dict[schema]
 
 @given('"{issuer}" is ready to issue a "{cred_format}" credential')
 def step_impl(context, issuer: str, cred_format: str = CRED_FORMAT_INDY):
@@ -159,6 +134,8 @@ def step_impl(context, issuer, cred_format):
     # if context does not have the credential thread id then the proposal was not the starting point for the protocol.
     else:
         cred_data = context.credential_data
+        print(">>> cred_data:", cred_data)
+        print(">>> filters:", context.filters)
 
         # We only want to send data for the cred format being used
         assert (

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -134,8 +134,6 @@ def step_impl(context, issuer, cred_format):
     # if context does not have the credential thread id then the proposal was not the starting point for the protocol.
     else:
         cred_data = context.credential_data
-        print(">>> cred_data:", cred_data)
-        print(">>> filters:", context.filters)
 
         # We only want to send data for the cred format being used
         assert (

--- a/aries-test-harness/features/steps/0453-issue-credential-v2.py
+++ b/aries-test-harness/features/steps/0453-issue-credential-v2.py
@@ -271,6 +271,7 @@ def step_impl(context, holder, cred_format):
         )
         assert resp_status == 200, f"resp_status {resp_status} is not 200; {resp_text}"
         resp_json = json.loads(resp_text)
+        print(">>> resp_json:", resp_json)
         context.cred_rev_id = resp_json["revocation_id"]
         context.rev_reg_id = resp_json["revoc_reg_id"]
 

--- a/aries-test-harness/features/steps/0454-present-proof-v2-v3.py
+++ b/aries-test-harness/features/steps/0454-present-proof-v2-v3.py
@@ -54,23 +54,6 @@ def step_impl(context, prover, issuer, credential_data):
     # assign the credential data to the context for use in the credential offer or proposal.
     if credential_data != None:
         setup_schemas_for_issuance(context, credential_data)
-        #for schema in context.schema_dict:
-        #    try:
-        #        credential_data_json_file = open(
-        #            "features/data/cred_data_" + schema.lower() + ".json"
-        #        )
-        #        credential_data_json = json.load(credential_data_json_file)
-        #        context.credential_data_dict[schema] = credential_data_json[
-        #            credential_data
-        #        ]["attributes"]
-
-        #    except FileNotFoundError:
-        #        print(
-        #            FileNotFoundError
-        #            + ": features/data/cred_data_"
-        #            + schema.lower()
-        #            + ".json"
-        #        )
 
     # Check if a connection between the players has already been established in this test.
     should_create_connection = (

--- a/aries-test-harness/features/steps/0454-present-proof-v2-v3.py
+++ b/aries-test-harness/features/steps/0454-present-proof-v2-v3.py
@@ -3,10 +3,12 @@ from behave import *
 import json
 from agent_backchannel_client import agent_backchannel_POST, expected_agent_state
 from agent_test_utils import (
+    setup_schemas_for_issuance,
     get_relative_timestamp_to_epoch,
     amend_presentation_definition_with_runtime_data,
 )
 from distutils.util import strtobool
+
 
 def prepare_proof_request(context: Any, request_for_proof: str) -> Dict[str, Any]:
     try:
@@ -51,23 +53,24 @@ def prepare_proof_request(context: Any, request_for_proof: str) -> Dict[str, Any
 def step_impl(context, prover, issuer, credential_data):
     # assign the credential data to the context for use in the credential offer or proposal.
     if credential_data != None:
-        for schema in context.schema_dict:
-            try:
-                credential_data_json_file = open(
-                    "features/data/cred_data_" + schema.lower() + ".json"
-                )
-                credential_data_json = json.load(credential_data_json_file)
-                context.credential_data_dict[schema] = credential_data_json[
-                    credential_data
-                ]["attributes"]
+        setup_schemas_for_issuance(context, credential_data)
+        #for schema in context.schema_dict:
+        #    try:
+        #        credential_data_json_file = open(
+        #            "features/data/cred_data_" + schema.lower() + ".json"
+        #        )
+        #        credential_data_json = json.load(credential_data_json_file)
+        #        context.credential_data_dict[schema] = credential_data_json[
+        #            credential_data
+        #        ]["attributes"]
 
-            except FileNotFoundError:
-                print(
-                    FileNotFoundError
-                    + ": features/data/cred_data_"
-                    + schema.lower()
-                    + ".json"
-                )
+        #    except FileNotFoundError:
+        #        print(
+        #            FileNotFoundError
+        #            + ": features/data/cred_data_"
+        #            + schema.lower()
+        #            + ".json"
+        #        )
 
     # Check if a connection between the players has already been established in this test.
     should_create_connection = (


### PR DESCRIPTION
This runs a few tests to issue anoncreds format credentials from aca-py to credo.

For acapy/acapy these tests all work (`-d acapy-main`) but with credo they all fail (`-d acapy-main -b credo`).  I'm not smart enough to know why :-S

To run these test with acapy/credo run the following (this combines all the tag filters from the existing credo test runs, with additional tags to run the new tests):

```
BACKCHANNEL_EXTRA_acapy_main="{\"wallet-type\":\"askar-anoncreds\"}" ./manage run -d acapy-main -b credo -t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453,@T001-RFC0454b -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183 -t @Anoncreds
```
