### PR TITLE
Small repairs

### DIFF
--- a/.github/workflows/test-harness-acapy-credo.yml
+++ b/.github/workflows/test-harness-acapy-credo.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a acapy-main -a credo"
           TEST_AGENTS: "-d acapy-main -b credo"
-          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183"
+          TEST_SCOPE: "-t @AcceptanceTest -t @AIP10,@RFC0441,@RFC0211,@T001-RFC0453 -t ~@wip -t ~@DIDExchangeConnection -t ~@T004-RFC0211 -t ~@QualifiedDIDs -t ~@T001-RFC0183 -t ~@Anoncreds"
           REPORT_PROJECT: acapy-b-credo
       - name: run-send-gen-test-results-secure
         if: ${{ steps.run_test_harness.conclusion == 'success' }}

--- a/aries-test-harness/features/0183-revocation.feature
+++ b/aries-test-harness/features/0183-revocation.feature
@@ -42,7 +42,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
    # note that the "indy" format should fail with an "anoncreds" wallet
-   @T001.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @RFC0441
+   @T001.2-HIPE0011 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @MobileTest @Indy @RFC0441
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove with a prover that doesn't care if it was revoked
       Given "2" agents
          | name  | role     |
@@ -61,7 +61,7 @@ Feature: RFC 0183 Aries agent credential revocation and revocation notification
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
    @T002-HIPE0011 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @RFC0441
-   Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with timesstamp
+   Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with timestamp
       Given "2" agents
          | name  | role     |
          | Bob   | prover   |


### PR DESCRIPTION
A couple small repairs. 

One test is failing consistently for acapy --> credo because it's testing anoncreds without an anoncreds wallet.
Another was failing for acapy-anoncreds because it was using legacy issue-credential v1 which isn't compatible with acapy anoncreds.