### PR TITLE
Support for backchannel swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We'd love to have help in building out a full Aries interoperability lab.
 - [Using AATH Agents as Services](#using-aath-agents-as-services)
   - [Use Cases](#use-cases)
     - [Debugging within AATH](#debugging-within-aath)
+    - [Accessing Backchannels via Swagger](#accessing-backchannels-via-swagger)
     - [Aries Mobile Test Harness](#aries-mobile-test-harness)
 - [Extra Backchannel-Specific Parameters](#extra-backchannel-specific-parameters)
 - [Custom Configurations for Agents](#custom-configurations-for-agents)
@@ -159,6 +160,26 @@ When running test code in a debugger, you may not always want or need all the ag
 ```bash
 ./manage start -a acapy-main -b acapy-main
 ```
+
+#### Accessing Backchannels via Swagger
+
+You can run a Swagger UI to expose your backchannel's API, for manual testing or maybe just to take a look at the API to understand it better.
+
+If you start up all the agents:
+
+```bash
+./manage start -d acapy-main
+```
+
+... then you can start up a Swagger UI as follows (run this from the same directory):
+
+```bash
+docker pull swaggerapi/swagger-ui
+docker run -p 8081:8080 -e SWAGGER_JSON=/mnt/openapi-spec.yml -v ${PWD}/docs/assets:/mnt swaggerapi/swagger-ui
+```
+
+Now open your browser with `http://localhost:8081` - you can pick which of the 4 agents you want to connect to.
+
 
 #### Aries Mobile Test Harness
 

--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -11,6 +11,8 @@ from aiohttp import ClientSession, web
 from aiohttp.typedefs import Handler
 from typing_extensions import Literal, TypedDict
 
+import aiohttp_cors
+
 from .utils import log_msg
 
 LOGGER = logging.getLogger(__name__)
@@ -212,6 +214,18 @@ class AgentBackchannel:
                 web.get("/agent/response/{topic}/{id}", self._get_response_backchannel),
             ]
         )
+
+        # add CORS support so we can run a swagger UI in a separate docker container
+        cors = aiohttp_cors.setup(self.app, defaults={
+           "*": aiohttp_cors.ResourceOptions(
+                allow_credentials=True,
+                expose_headers="*",
+                allow_headers="*"
+            )
+        })
+
+        for route in list(self.app.router.routes()):
+            cors.add(route)
 
         runner = web.AppRunner(self.app)
         await runner.setup()

--- a/aries-backchannels/python/requirements.txt
+++ b/aries-backchannels/python/requirements.txt
@@ -8,3 +8,4 @@ aiohttp>=3.8.1
 ConfigArgParse
 typing_extensions
 base58
+aiohttp_cors

--- a/docs/assets/openapi-spec.yml
+++ b/docs/assets/openapi-spec.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 servers:
   - description: Agent Backchannel
-    url: http://localhost:{port}
+    url: http://{hostname}:{port}
     variables:
       port:
         description: >
@@ -16,6 +16,15 @@ servers:
           - "9040"
           - "9050"
         default: "9020"
+      hostname:
+        description: >
+          The host running the API implementation
+            * localhost
+            * host.docker.internal
+        enum:
+            - "localhost"
+            - "host.docker.internal"
+        default: "localhost"
 info:
   description: |
     This page documents the backchannel API the test harness uses to communicate with agents under tests.


### PR DESCRIPTION
Run a swagger UI in a separate docker container to access backchannel API's.
