### PR TITLE
Update repository references for the indy-sdk.

### DIFF
--- a/.devcontainer/ACA-Py-container/devcontainer.json
+++ b/.devcontainer/ACA-Py-container/devcontainer.json
@@ -20,7 +20,7 @@
 	],
 
 	"workspaceFolder": "/aries-backchannels/acapy",
-	
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"docker-from-docker": "latest"
@@ -39,8 +39,8 @@
 
 	"updateContentCommand": "apt-get update && \
 		apt-get install -y git gnupg2 software-properties-common curl && \
-		apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 && \
-		add-apt-repository 'deb https://repo.sovrin.org/sdk/deb bionic stable' && \
+		apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  && \
+		add-apt-repository 'deb https://hyperledger.jfrog.io/artifactory/indy bionic stable' && \
 		apt-get update && \
 		apt-get install -y libindy libnullpay",
 

--- a/.devcontainer/AFJ-container/devcontainer.json
+++ b/.devcontainer/AFJ-container/devcontainer.json
@@ -14,7 +14,7 @@
 	"workspaceMount": "source=${localWorkspaceFolder}/aries-backchannels/javascript,target=/aries-backchannels/javascript,type=bind",
 
 	"workspaceFolder": "/aries-backchannels/javascript",
-	
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"docker-from-docker": "latest"
@@ -32,8 +32,8 @@
 		npm install && \
 		apt-get update -y && \
 		apt-get install -y software-properties-common apt-transport-https curl build-essential && \
-		apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 && \
-		add-apt-repository -y \"deb https://repo.sovrin.org/sdk/deb bionic stable\" && \
+		apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  && \
+		add-apt-repository -y \"deb https://hyperledger.jfrog.io/artifactory/indy bionic stable\" && \
 		apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 && \
 		add-apt-repository -y \"deb http://security.ubuntu.com/ubuntu bionic-security main\" && \
 		apt-get install -y --allow-unauthenticated libindy",

--- a/.devcontainer/Credo-ts-container/devcontainer.json
+++ b/.devcontainer/Credo-ts-container/devcontainer.json
@@ -14,7 +14,7 @@
 	"workspaceMount": "source=${localWorkspaceFolder}/aries-backchannels/credo-ts,target=/aries-backchannels/credo-ts,type=bind",
 
 	"workspaceFolder": "/aries-backchannels/credo-ts",
-	
+
 	"mounts": [
 		{ "source": "${localWorkspaceFolder}/aries-backchannels/data", "target": "/aries-backchannels/data", "type": "bind" }
 	],
@@ -46,8 +46,8 @@
 		npm install && \
 		apt-get update -y && \
 		apt-get install -y software-properties-common apt-transport-https curl build-essential && \
-		apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 && \
-		add-apt-repository -y \"deb https://repo.sovrin.org/sdk/deb bionic stable\" && \
+		apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  && \
+		add-apt-repository -y \"deb https://hyperledger.jfrog.io/artifactory/indy bionic stable\" && \
 		apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 && \
 		add-apt-repository -y \"deb http://security.ubuntu.com/ubuntu bionic-security main\" && \
 		apt-get install -y --allow-unauthenticated libindy",

--- a/aries-backchannels/acapy/Dockerfile.acapy
+++ b/aries-backchannels/acapy/Dockerfile.acapy
@@ -2,8 +2,8 @@ FROM python:3.12-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \
-   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
-   && add-apt-repository 'deb https://repo.sovrin.org/sdk/deb bionic stable' \
+   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  \
+   && add-apt-repository 'deb https://hyperledger.jfrog.io/artifactory/indy bionic stable' \
    && apt-get update \
    && apt-get install -y libindy libnullpay
 

--- a/aries-backchannels/acapy/Dockerfile.acapy-main
+++ b/aries-backchannels/acapy/Dockerfile.acapy-main
@@ -2,8 +2,8 @@ FROM python:3.12-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \
-   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
-   && add-apt-repository 'deb https://repo.sovrin.org/sdk/deb bionic stable' \
+   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  \
+   && add-apt-repository 'deb https://hyperledger.jfrog.io/artifactory/indy bionic stable' \
    && apt-get update \
    && apt-get install -y libindy libnullpay
 

--- a/aries-backchannels/acapy/Dockerfile.acapy-redis
+++ b/aries-backchannels/acapy/Dockerfile.acapy-redis
@@ -2,8 +2,8 @@ FROM python:3.7-slim-bullseye
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \
-   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
-   && add-apt-repository 'deb https://repo.sovrin.org/sdk/deb bionic stable' \
+   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  \
+   && add-apt-repository 'deb https://hyperledger.jfrog.io/artifactory/indy bionic stable' \
    && apt-get update \
    && apt-get install -y libindy libnullpay
 

--- a/aries-backchannels/credo-ts/Dockerfile.credo
+++ b/aries-backchannels/credo-ts/Dockerfile.credo
@@ -7,11 +7,11 @@ RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     curl \
     # Only needed to build indy-sdk
-    build-essential 
+    build-essential
 
 # libindy
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61
+RUN add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy bionic stable"
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
@@ -26,9 +26,9 @@ RUN npm install -g yarn
 # RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
 #     nodejs
     #libindy \
-    
 
-# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install
 #RUN apt-get install -y --no-install-recommends yarn
 
 RUN apt-get upgrade -y libstdc++6

--- a/aries-backchannels/credo-ts/Dockerfile.credo-branch
+++ b/aries-backchannels/credo-ts/Dockerfile.credo-branch
@@ -8,11 +8,11 @@ RUN apt-get update -y && apt-get install -y \
     curl \
     git \
     # Only needed to build indy-sdk
-    build-essential 
+    build-essential
 
 # libindy
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61
+RUN add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy bionic stable"
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
@@ -26,7 +26,7 @@ RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
     libindy \
     nodejs
 
-# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install
 RUN apt-get install -y --no-install-recommends yarn
 
 FROM base as final

--- a/aries-backchannels/credo-ts/Dockerfile.dev-credo
+++ b/aries-backchannels/credo-ts/Dockerfile.dev-credo
@@ -7,11 +7,11 @@ RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     curl \
     # Only needed to build indy-sdk
-    build-essential 
+    build-essential
 
 # libindy
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61
+RUN add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy bionic stable"
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
@@ -25,7 +25,7 @@ RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
     libindy \
     nodejs
 
-# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install
 RUN apt-get install -y --no-install-recommends yarn
 
 FROM base as final

--- a/aries-backchannels/javascript/Dockerfile.dev-javascript
+++ b/aries-backchannels/javascript/Dockerfile.dev-javascript
@@ -7,11 +7,11 @@ RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     curl \
     # Only needed to build indy-sdk
-    build-essential 
+    build-essential
 
 # libindy
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61
+RUN add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy bionic stable"
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
@@ -25,7 +25,7 @@ RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
     libindy \
     nodejs
 
-# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install
 RUN apt-get install -y --no-install-recommends yarn
 
 FROM base as final

--- a/aries-backchannels/javascript/Dockerfile.javascript
+++ b/aries-backchannels/javascript/Dockerfile.javascript
@@ -7,11 +7,11 @@ RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     curl \
     # Only needed to build indy-sdk
-    build-essential 
+    build-essential
 
 # libindy
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61
+RUN add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy bionic stable"
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
@@ -25,7 +25,7 @@ RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
     libindy \
     nodejs
 
-# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install
 RUN apt-get install -y --no-install-recommends yarn
 
 FROM base as final

--- a/aries-backchannels/javascript/Dockerfile.javascript-branch
+++ b/aries-backchannels/javascript/Dockerfile.javascript-branch
@@ -8,11 +8,11 @@ RUN apt-get update -y && apt-get install -y \
     curl \
     git \
     # Only needed to build indy-sdk
-    build-essential 
+    build-essential
 
 # libindy
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61
+RUN add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy bionic stable"
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
@@ -26,7 +26,7 @@ RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
     libindy \
     nodejs
 
-# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install
 RUN apt-get install -y --no-install-recommends yarn
 
 FROM base as final

--- a/aries-backchannels/mobile/Dockerfile.mobile
+++ b/aries-backchannels/mobile/Dockerfile.mobile
@@ -5,7 +5,7 @@ WORKDIR /aries-backchannels
 
 RUN apt-get update \
    && apt-get install -y git gnupg2 software-properties-common curl \
-   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
+   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61  \
    && apt-get update \
    && apt-get install -y software-properties-common \
    && apt-get update


### PR DESCRIPTION
- The indy-sdk packages have been migrated to the Hyperledger repository.  The Sovrin repositories have been deprecated.
  - New location: https://hyperledger.jfrog.io/ui/native/indy/pool/bionic/
  - Previous location: https://repo.sovrin.org/sdk/deb/pool/bionic/
    - Only the `master` and `stable` channels were migrated over.