### PR TITLE
Repair manage script arguments

### DIFF
--- a/manage
+++ b/manage
@@ -1114,12 +1114,12 @@ runTests() {
 
   if [[ "${REPORT}" = "allure" && "${COMMAND}" != "dry-run" ]]; then
       echo "Executing tests with Allure Reports."
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" -v "$(pwd)/aries-test-harness/allure/allure-results:/aries-test-harness/allure/allure-results/" $DOCKER_ENV aries-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS}
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" -v "$(pwd)/aries-test-harness/allure/allure-results:/aries-test-harness/allure/allure-results/" $DOCKER_ENV aries-test-harness ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS}
   elif [[ "${COMMAND}" = "dry-run" ]]; then
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini $DOCKER_ENV aries-test-harness -k ${runArgs} ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS} |\
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini $DOCKER_ENV aries-test-harness ${runArgs} ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS} |\
         grep "Feature:\|Scenario Outline\|\@" | sed "/n(u/d"
   else
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" $DOCKER_ENV aries-test-harness -k ${runArgs} ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS}
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-test-harness/behave.ini -v "$(pwd)/.logs:/aries-test-harness/logs" $DOCKER_ENV aries-test-harness ${runArgs} ${ACME_OPTIONS} ${BOB_OPTIONS} ${FABER_OPTIONS} ${MALLORY_OPTIONS}
   fi
   local docker_result=$?
   rm ${BEHAVE_INI_TMP}


### PR DESCRIPTION
I was looking at the test runs from the acapy repo and noticed that around a month ago they weren't running as long as they should be. The test weren't actually being run because of a `-k` argument not recognized in behave tests. I have no idea why this started happening as it just occurred randomly without any code being merged to either project ?

This `-k` argument shouldn't be here though. the arguments passed in should have the appropriate tags arguments. I think it was added for some legacy interaction with pytest but I'm really not sure.