### PR TITLE
Pin behave to version 1.2.6

### DIFF
--- a/aries-test-harness/behave.ini
+++ b/aries-test-harness/behave.ini
@@ -7,6 +7,7 @@
 format=json.pretty
 no_skipped=true
 #logging_level = INFO
+tag_expression_protocol = v1
 
 [behave.userdata]
 # these should be set dynamically, when running under Docker

--- a/aries-test-harness/requirements.txt
+++ b/aries-test-harness/requirements.txt
@@ -1,2 +1,2 @@
-behave
+behave==1.2.6
 allure-behave==2.13.3


### PR DESCRIPTION
I think this should fix the allure problem. Not having behave pinned upgraded it in the docker build to version 1.3.x which apparently has breaking changes related to how the script is parsing the tags.

I tried to allow it to upgrade for a while but the manage script is extremely complicated and I could get the format correct. It's supposed to change to these other tag expressions, but there was also an issue with the argument format.