### PR TITLE
Feature/manual bdd test with tags

### DIFF
--- a/.github/workflows/test-harness-acapy-bbs-present-proof.yml
+++ b/.github/workflows/test-harness-acapy-bbs-present-proof.yml
@@ -26,8 +26,8 @@ jobs:
   test-bbs-present-proof:
     runs-on: ubuntu-latest
     env:
-      LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
-      GENESIS_URL: "http://test.bcovrin.vonx.io/genesis"
+      LEDGER_URL_CONFIG: "https://test.bcovrin.vonx.io"
+      GENESIS_URL: "https://test.bcovrin.vonx.io/genesis"
       TAILS_SERVER_URL_CONFIG: "https://tails.vonx.io"
       LOG_LEVEL: "INFO"
     steps:

--- a/.github/workflows/test-harness-acapy-bbs-present-proof.yml
+++ b/.github/workflows/test-harness-acapy-bbs-present-proof.yml
@@ -1,0 +1,48 @@
+# Run only the present-proof v2 BBS+ (BbsBlsSignature2020) + did:key scenarios
+# that were failing with HTTP 500 on verify-presentation. Uses BCovrin test
+# ledger so no local von-network or tails server is needed.
+#
+# Trigger: manually from Actions tab, or on push/PR to any branch (including feature branches).
+name: test-harness-acapy-bbs-present-proof
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/test-harness-acapy-bbs-present-proof.yml'
+      - 'aries-test-harness/features/0454-present-proof-v2.feature'
+      - 'aries-test-harness/features/steps/0454-present-proof-v2-v3.py'
+  pull_request:
+    paths:
+      - '.github/workflows/test-harness-acapy-bbs-present-proof.yml'
+      - 'aries-test-harness/features/0454-present-proof-v2.feature'
+      - 'aries-test-harness/features/steps/0454-present-proof-v2-v3.py'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-bbs-present-proof:
+    runs-on: ubuntu-latest
+    env:
+      LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
+      GENESIS_URL: "http://test.bcovrin.vonx.io/genesis"
+      TAILS_SERVER_URL_CONFIG: "https://tails.vonx.io"
+      LOG_LEVEL: "INFO"
+    steps:
+      - name: Checkout test harness
+        uses: actions/checkout@v4
+        with:
+          path: test-harness
+
+      - name: Run BBS+ present-proof scenarios (BCovrin test ledger)
+        id: run_test
+        uses: ./test-harness/actions/run-test-harness-wo-reports
+        with:
+          BUILD_AGENTS: "-a acapy-main"
+          TEST_AGENTS: "-d acapy-main"
+          TEST_SCOPE: "-t @RFC0454 -t @CredFormat_JSON-LD -t @ProofType_BbsBlsSignature2020 -t @DidMethod_key -t @DIDExchangeConnection"
+          REPORT_PROJECT: acapy-bbs-present-proof
+          REPORTING: ""
+          OTHER_PARAMS: ""

--- a/.github/workflows/test-harness-acapy-bbs-present-proof.yml
+++ b/.github/workflows/test-harness-acapy-bbs-present-proof.yml
@@ -46,3 +46,12 @@ jobs:
           REPORT_PROJECT: acapy-bbs-present-proof
           REPORTING: ""
           OTHER_PARAMS: ""
+
+      - name: Upload agent logs (faber_agent.log, bob_agent.log, etc.)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bbs-present-proof-agent-logs
+          path: test-harness/.logs/
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
Makes the BDD test GitHub Action generic so it can be run manually with any tag set, while keeping the previous default scope for push/PR runs.

## Changes
- **`workflow_dispatch` input:** Adds a `test_tags` input so whoever runs the workflow from the Actions tab can pass a space-separated list of tags (e.g. `@RFC0454 @bbs @wip @aip1`). Supports exclusions with `~@tag`.
- **Tag handling:** A "Build test scope from tags" step converts the input string into the `-t @tag` form expected by the test harness and passes it into the run step.
- **Artifacts:** Agent logs (e.g. `faber_agent.log`, `bob_agent.log`) are still uploaded as a downloadable artifact (`bbs-present-proof-agent-logs`, 14-day retention), including when the run fails.

## How to use
1. Open the **Actions** tab.
2. In the left sidebar, click **Manual BDD test (configurable tags)**.
3. Click **Run workflow** (dropdown on the right).
4. Choose the branch (e.g. `main` or this feature branch).
5. Optionally set **Test tags** (e.g. `@AcceptanceTest ~@wip`).
6. Click the green **Run workflow** button. Download agent logs from **Artifacts** on the run page if needed.
